### PR TITLE
Updated comments to include requirement for PowerShell2

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,8 @@ posh-git
 
 A set of PowerShell scripts which provide Git/PowerShell integration
 
+### Requirements: PowerShell2
+
 ### Prompt for Git repositories
    The prompt within Git repositories can show the current branch and the state of files (additions, modifications, deletions) within.
    


### PR DESCRIPTION
I'm just doing the quick any dirty approach of updating the ReadMe to include requirements of powershell 2. My client only has PS1 on their systems. I initially got "Import-Module" not recognized when I tried to reload my profile. Hopefully this will save someone a few minutes by realizing they need PowerShell2. 
