### PR TITLE
Issue running Install.ps1 due to version check functionality

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -11,7 +11,7 @@ if(!(Get-Command git -ErrorAction SilentlyContinue)) {
 }
 
 $installDir = Split-Path $MyInvocation.MyCommand.Path -Parent
-if(!($installDir\CheckVersion.ps1)) {
+if(!(. (Join-Path $installDir "CheckVersion.ps1"))) {
     return
 }
 


### PR DESCRIPTION
I just found this project today and decided to give it a try. First off, thanks for putting this together and sharing it!

Unfortunately, the install.ps1 script throws an "Unexpected token '\CheckVersion.ps1' in expression or statement." error on line #14. I don't know much about PowerShell, but I made a small adjustment to that line and it's now working as expected.
