### PR TITLE
What do you think about expanding on all aliases of Git?

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -166,3 +166,9 @@ function Enable-GitColors {
     $env:TERM = 'cygwin'
     $env:LESS = 'FRSX'
 }
+
+function Get-GitAliasPattern {
+   $aliases = @('git') + (Get-Alias | where {$_.definition -eq 'git' } | select -Exp Name) -join '|' 
+   "(" + $aliases + ")"
+}
+

--- a/posh-git.psm1
+++ b/posh-git.psm1
@@ -14,5 +14,6 @@ Export-ModuleMember -Function @(
         'Enable-GitColors', 
         'Get-GitDirectory',
         'GitTabExpansion',
+        'Get-GitAliasPattern',
         'tgit')
 

--- a/profile.example.ps1
+++ b/profile.example.ps1
@@ -30,11 +30,9 @@ if(!(Test-Path Function:\$teBackup)) {
 # Set up tab expansion and include git expansion
 function TabExpansion($line, $lastWord) {
     $lastBlock = [regex]::Split($line, '[|;]')[-1]
-    $aliases = alias | where {$_.definition -eq 'git' } | foreach {"|" + $_.name}
-    $gitCmd = "(git$aliases)" 
     switch -regex ($lastBlock) {
         # Execute git tab completion for all git-related commands
-        "$gitCmd (.*)" { GitTabExpansion $lastBlock }
+        "$(Get-GitAliasPattern) (.*)" { GitTabExpansion $lastBlock }
         # Fall back on existing tab expansion
         default { & $teBackup $line $lastWord }
     }


### PR DESCRIPTION
In addition to expanding only on the command git, expand on any alias
of git. For example

New-Alias g git
g co<Tab>

New-Alias got git
got co<Tab>

It does require a change to the profile. Maybe it would be better if
the decision to use the git tab expansion or the default one happened
in the posh-git stuff so there would be less need to mess with the
profile all together.
