### PR TITLE
Fixes cases when the "Home" directory has spaces in it.

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -220,5 +220,6 @@ function Start-SshAgent([switch]$Quiet) {
     $sshAdd = Get-Command ssh-add -TotalCount 1 -ErrorAction SilentlyContinue
     if (!$sshAdd) { Write-Warning 'Could not find ssh-add'; return }
 
-    & $sshAdd
+    $sshPath = resolve-path ~/.ssh/id_rsa
+    & $sshAdd $sshPath
 }


### PR DESCRIPTION
Thank Bradley T. Landis for this patch. He submitted this patch via a [comment on my blog](http://haacked.com/archive/2011/12/19/get-git-for-windows.aspx#86228). I tried it out and it seems to work great.
