### PR TITLE
Added configurable support for prompt cursor on newline

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -45,6 +45,7 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     RepositoriesInWhichToDisableFileStatus = @( ) # Array of repository paths
 
     Debug                     = $false
+    PromptNewLine             = $false
 }
 
 $WriteHost = Get-Command Write-Host -Type Cmdlet

--- a/profile.example.ps1
+++ b/profile.example.ps1
@@ -20,7 +20,11 @@ function prompt {
     Write-VcsStatus
 
     $LASTEXITCODE = $realLASTEXITCODE
-    return "> "
+    if($GitPromptSettings.PromptNewLine) {
+        return [System.Environment]::newline + "> "
+    } else {
+        return "> "
+    }
 }
 
 Enable-GitColors


### PR DESCRIPTION
When <b>PromptNewLine</b> flag is set to true on the <b>GitPrompt.ps1</b> file you'll have the cursor on the line below the status prompt.

default:

<pre>C:\Users\PeterLöwenbräuGriffin\code\posh-git [master]></pre>


enabled:

<pre>C:\Users\PeterLöwenbräuGriffin\code\posh-git [master +0 ~1 -0]
></pre>


The default is set to false so if users want to enable it they'll have to go change it themselves.

<i>If this is pulled then maybe a next step might be to enable it at install time?</i>
