### PR TITLE
Fix tag name showing instead of branch name

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -44,6 +44,7 @@ function Get-GitBranch($gitDir = $(Get-GitDirectory), [Diagnostics.Stopwatch]$sw
 
             $b = '({0})' -f (
                 Coalesce-Args `
+                    { dbg 'Trying symbolic-ref' $sw; git symbolic-ref HEAD 2>$null } `
                     { dbg 'Trying describe' $sw; git describe --exact-match HEAD 2>$null } `
                     {
                         dbg 'Falling back on parsing HEAD' $sw


### PR DESCRIPTION
Bring back call to symbolic-ref so that branch names are preferred over tags
- git describe can pull a tag name instead of branch name
- symbolic-ref fails for tag names (so git describe is used instead)
- this code branch is only hit when EnableFileStatus is false or the branch name isn't found in 'git status'
