### PR TITLE
Added a colorization for when a branch is both behind and ahead of the remote

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -19,9 +19,11 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     BranchBackgroundColor       = $Host.UI.RawUI.BackgroundColor
     BranchAheadForegroundColor  = [ConsoleColor]::Green
     BranchAheadBackgroundColor  = $Host.UI.RawUI.BackgroundColor
-    BranchBehindForegroundColor  = [ConsoleColor]::Red
-    BranchBehindBackgroundColor  = $Host.UI.RawUI.BackgroundColor
-    
+    BranchBehindForegroundColor = [ConsoleColor]::Red
+    BranchBehindBackgroundColor = $Host.UI.RawUI.BackgroundColor    
+    BranchBehindAndAheadForegroundColor = [ConsoleColor]::Yellow
+    BranchBehindAndAheadBackgroundColor = $Host.UI.RawUI.BackgroundColor
+
     BeforeIndexText           = ""
     BeforeIndexForegroundColor= [ConsoleColor]::DarkGreen
     BeforeIndexBackgroundColor= $Host.UI.RawUI.BackgroundColor
@@ -61,7 +63,11 @@ function Write-GitStatus($status) {
         $currentBranch = $status.Branch
         
         Write-Prompt $s.BeforeText -NoNewline -BackgroundColor $s.BeforeBackgroundColor -ForegroundColor $s.BeforeForegroundColor
-        if ($status.BehindBy -gt 0) {
+        if ($status.BehindBy -gt 0 -and $status.AheadBy -gt 0) {
+            # We are behind and ahead of remote
+            Write-Prompt $currentBranch -NoNewline -BackgroundColor $s.BranchBehindAndAheadBackgroundColor -ForegroundColor $s.BranchBehindAndAheadForegroundColor
+        }
+        elseif ($status.BehindBy -gt 0) {
             # We are behind remote
             Write-Prompt $currentBranch -NoNewline -BackgroundColor $s.BranchBehindBackgroundColor -ForegroundColor $s.BranchBehindForegroundColor
         } elseif ($status.AheadBy -gt 0) {


### PR DESCRIPTION
I added a color option (yellow) so that you can tell when you have commited changes but are also behind the remote.
