### PR TITLE
Fix for an exception when used in the Nuget package manager console

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -78,7 +78,7 @@ function Write-GitStatus($status) {
         }
         
         if($s.EnableFileStatus -and $status.HasIndex) {
-            write-host $s.BeforeIndexText -NoNewLine -BackgroundColor $s.BeforeIndexBackgroundColor -ForegroundColor $s.BeforeIndexForegroundColor
+            Write-Prompt $s.BeforeIndexText -NoNewLine -BackgroundColor $s.BeforeIndexBackgroundColor -ForegroundColor $s.BeforeIndexForegroundColor
             
             if($s.ShowStatusWhenZero -or $status.Index.Added) {
               Write-Prompt " +$($status.Index.Added.Count)" -NoNewline -BackgroundColor $s.IndexBackgroundColor -ForegroundColor $s.IndexForegroundColor


### PR DESCRIPTION
I ran into this exception when trying to use posh-git in the Nuget package manager console in VS.
