### PR TITLE
Fix errors with Set-PSDebug -Strict

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -82,7 +82,11 @@ function Get-GitStatus($gitDir = (Get-GitDirectory)) {
     $enabled = (-not $settings) -or $settings.EnablePromptStatus
     if ($enabled -and $gitDir)
     {
-        if($settings.Debug) { $sw = [Diagnostics.Stopwatch]::StartNew(); Write-Host '' }
+        if($settings.Debug) {
+            $sw = [Diagnostics.Stopwatch]::StartNew(); Write-Host ''
+        } else {
+            $sw = $null
+        }
         $branch = $null
         $aheadBy = 0
         $behindBy = 0


### PR DESCRIPTION
`Set-PSDebug -Strict` will complain if any variable is used before it is initialized. This was happening with the `$sw` variable.

The practical effect of this bug was that the nice posh-git prompt would disappear if `Set-PSDebug -Strict` was ever called in a PowerShell session.
