### PR TITLE
set path prompt maximum size=30

### DIFF
--- a/profile.example.ps1
+++ b/profile.example.ps1
@@ -14,7 +14,12 @@ function prompt {
 
     # Reset color, which can be messed up by Enable-GitColors
     $Host.UI.RawUI.ForegroundColor = $GitPromptSettings.DefaultForegroundColor
-
+	$maxpromptsize=30
+	$promptpath=$pwd.path
+	if ($promptpath.length -ge $maxpromptsize)
+	{
+		$pwd = "..." + $promptpath.substring($promptpath.length - $maxpromptsize + 4)
+	}
     Write-Host($pwd) -nonewline
 
     Write-VcsStatus


### PR DESCRIPTION
when you dive deep into a repo the prompt can get infinitely larger by default.  this puts a cap of 30 chars on the prompt to retain readability and avoid posh wraparound.
