### PR TITLE
Integrate with powertab if it's available.

### DIFF
--- a/GitTabExpansion.ps1
+++ b/GitTabExpansion.ps1
@@ -212,6 +212,19 @@ function GitTabExpansion($lastBlock) {
     }
 }
 
+if (Get-Command "Register-TabExpansion" -errorAction SilentlyContinue)
+{
+    Register-TabExpansion "git.cmd" -Type Command {
+        param($Context, [ref]$TabExpansionHasOutput, [ref]$QuoteSpaces)  # 1:
+
+        $line = $Context.Line
+        $lastBlock = [regex]::Split($line, '[|;]')[-1].TrimStart()
+        $TabExpansionHasOutput.Value = $true
+        GitTabExpansion $lastBlock
+    }
+    return
+}
+
 if (Test-Path Function:\TabExpansion) {
     Rename-Item Function:\TabExpansion TabExpansionBackup
 }


### PR DESCRIPTION
Hi. You mention here that you'd be interested in a patch to integrate with PowerTab: https://github.com/dahlbyk/posh-git/issues/31

This patch integrates with PowerTab, although you need to load PowerTab first. It falls back to the normal behaviour if PowerTab isn't present. I haven't included the "tgit" command because I don't have Tortoise Git installed and I'm not sure of the full command name. PowerTab seems to be quite picky and requires you to register on the full name of the command you want to provide completion for - the registration code must specify "git.cmd", not just "git", and I'm not sure whether tgit is provided by a "tgit.cmd", "tgit.exe" or something else. (It might be possible to extract the full name at startup using Get-Command, but I haven't investigated this.)
