### PR TITLE
Fixing tab expansion for PowerTab. There is no longer git.cmd in msysgit...

### DIFF
--- a/GitTabExpansion.ps1
+++ b/GitTabExpansion.ps1
@@ -215,7 +215,7 @@ function GitTabExpansion($lastBlock) {
 
 if (Get-Command "Register-TabExpansion" -errorAction SilentlyContinue)
 {
-    Register-TabExpansion "git.cmd" -Type Command {
+    Register-TabExpansion "git.exe" -Type Command {
         param($Context, [ref]$TabExpansionHasOutput, [ref]$QuoteSpaces)  # 1:
 
         $line = $Context.Line


### PR DESCRIPTION
Fix for tab completion when PowerTab is installed. Since msys git 1.7.10 (or something) there is no git.cmd file. There is only git.exe as  default git command.
