### PR TITLE
Adding svn prefix to branch name if svn clone

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -46,6 +46,8 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     EnableFileStatus          = $true
     RepositoriesInWhichToDisableFileStatus = @( ) # Array of repository paths
 
+    SvnPrefix                 = 'svn '
+
     Debug                     = $false
 }
 
@@ -61,6 +63,10 @@ function Write-GitStatus($status) {
     $s = $global:GitPromptSettings
     if ($status -and $s) {
         $currentBranch = $status.Branch
+        
+        if ($status.IsSvn) {
+            $currentBranch = $s.SvnPrefix + $currentBranch
+        }
         
         Write-Prompt $s.BeforeText -NoNewline -BackgroundColor $s.BeforeBackgroundColor -ForegroundColor $s.BeforeForegroundColor
         if ($status.BehindBy -gt 0 -and $status.AheadBy -gt 0) {

--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -88,6 +88,7 @@ function Get-GitStatus($gitDir = (Get-GitDirectory)) {
             $sw = $null
         }
         $branch = $null
+        $isSvn = $false
         $aheadBy = 0
         $behindBy = 0
         $indexAdded = @()
@@ -143,6 +144,8 @@ function Get-GitStatus($gitDir = (Get-GitDirectory)) {
             }
         }
 
+        $isSvn = (Test-Path $gitDir\svn) 
+        
         if(!$branch) { $branch = Get-GitBranch $gitDir $sw }
         dbg 'Building status object' $sw
         $indexPaths = $indexAdded + $indexModified + $indexDeleted + $indexUnmerged
@@ -168,6 +171,7 @@ function Get-GitStatus($gitDir = (Get-GitDirectory)) {
             HasWorking      = [bool]$working
             Working         = $working
             HasUntracked    = [bool]$filesAdded
+            IsSvn           = $isSvn
         }
 
         dbg 'Finished' $sw


### PR DESCRIPTION
Hard check for .git\svn propogates the existance of that directory to Write-GitStatus using IsSvn.

I can imagine this evolving to support git-tf/git-tfs with a folder/prefix map.  If you'd rather go all in on that pattern, let me know.
