### PR TITLE
Support for %HOME% added if declared

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -240,13 +240,24 @@ function Start-SshAgent([switch]$Quiet) {
     Add-SshKey
 }
 
+#get the default ssh keyfile
+function Get-SshFile()
+{
+    if ($Env:HOME) {
+        Join-Path (Resolve-Path $Env:HOME) ".ssh\id_rsa"
+    }
+    else {
+        Resolve-Path ~/.ssh/id_rsa -ErrorAction SilentlyContinue 2> $null    
+    }
+}
+
 # Add a key to the SSH agent
 function Add-SshKey() {
     $sshAdd = Get-Command ssh-add -TotalCount 1 -ErrorAction SilentlyContinue
     if (!$sshAdd) { Write-Warning 'Could not find ssh-add'; return }
 
     if ($args.Count -eq 0) {
-        $sshPath = Resolve-Path ~/.ssh/id_rsa -ErrorAction SilentlyContinue 2> $null
+        $sshPath = Get-SshFile
         if ($sshPath) { & $sshAdd $sshPath }
     } else {
         foreach ($value in $args) {


### PR DESCRIPTION
OpenSSH and Git uses the folder defined in the HOME Environment Variable, if declared, instead of ~. Now also Poshgit support these.

See http://www.google.de/#hl=de&tbo=d&sclient=psy-ab&q=git+home+environment+variable&oq=git+home+&gs_l=serp.1.2.0l4.2145.4026.0.6454.6.5.0.1.1.1.499.1124.2j1j0j1j1.5.0...0.0...1c.1.KAWfBJOlIN8&pbx=1&bav=on.2,or.r_gc.r_pw.r_qf.&fp=56a43b64ebecf8e3&biw=1600&bih=805
