### PR TITLE
Update path to TortoiseProc to reflect rename.

### DIFF
--- a/TortoiseGit.ps1
+++ b/TortoiseGit.ps1
@@ -1,7 +1,16 @@
 # TortoiseGit 
 
+function private:Get-TortoiseGitPath {
+  if ((Test-Path "C:\Program Files\TortoiseGit\bin\TortoiseGitProc.exe") -eq $true) {
+    # TortoiseGit 1.8.0 renamed TortoiseProc to TortoiseGitProc.
+    return "C:\Program Files\TortoiseGit\bin\TortoiseGitProc.exe"
+  }
+
+  return "C:\Program Files\TortoiseGit\bin\TortoiseProc.exe"
+}
+
 $Global:TortoiseGitSettings = new-object PSObject -Property @{
-  TortoiseGitPath = "C:\Program Files\TortoiseGit\bin\TortoiseProc.exe"
+  TortoiseGitPath = (Get-TortoiseGitPath)
 }
 
 function tgit {


### PR DESCRIPTION
TortoiseGit 1.8.0 renamed TortoiseProc to TortoiseGitProc, which caused a bug in posh-git where calling tgit would throw an exception (could not find TortoiseProc.exe).

This commit fixes that bug, by testing whether TortoiseGitProc exists and using that if it does.  If it does not exist, then the default TortoiseProc is used instead.
