### PR TITLE
Stop error message when id_rsa is missing

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -244,7 +244,7 @@ function Start-SshAgent([switch]$Quiet) {
 function Get-SshFile()
 {
     if ($Env:HOME) {
-        Join-Path (Resolve-Path $Env:HOME) ".ssh\id_rsa"
+        Resolve-Path (Join-Path (Resolve-Path $Env:HOME) ".ssh\id_rsa") -ErrorAction SilentlyContinue 2> $null
     }
     else {
         Resolve-Path ~/.ssh/id_rsa -ErrorAction SilentlyContinue 2> $null


### PR DESCRIPTION
Since we set the $Env:HOME when we launch our Git Shell, we hit 
this new code path which joins that path with the .ssh\id_rsa file.
Problem is, that file doesn't exist so we get ssh-add taking a long 
time and reporting an error.

This code path should do the same thing as the old one and return 
null if the file doesn't exist.
