### PR TITLE
Made Start-SshAgent faster

### DIFF
--- a/posh-git.psm1
+++ b/posh-git.psm1
@@ -13,6 +13,9 @@ Pop-Location
 if (!$Env:HOME) { $Env:HOME = "$Env:HOMEDRIVE$Env:HOMEPATH" }
 if (!$Env:HOME) { $Env:HOME = "$Env:USERPROFILE" }
 
+Load-TempEnv 'SSH_AGENT_PID'
+Load-TempEnv 'SSH_AUTH_SOCK'
+
 Export-ModuleMember `
     -Alias @(
         '??') `


### PR DESCRIPTION
Don't store the SSH_AGENT_PID and SSH_AUTH_SOCK in [EnvironmentVariableTarget]::User) anymore. Moved to %TEMP%.ssh

[EnvironmentVariableTarget]::User) user is painfully slow, because it notify other processes of the changed value, don't think that this is needed.
May cause a side effect i didn't thought of. Discussion?
