### PR TITLE
add tab expansion for git cherry

### DIFF
--- a/GitTabExpansion.ps1
+++ b/GitTabExpansion.ps1
@@ -258,7 +258,7 @@ function GitTabExpansion($lastBlock) {
         }
 
         # Handles git <cmd> <ref>
-        "^(?:checkout|cherry-pick|diff|difftool|log|merge|rebase|reflog\s+show|reset|revert|show).* (?<ref>\S*)$" {
+        "^(?:checkout|cherry|cherry-pick|diff|difftool|log|merge|rebase|reflog\s+show|reset|revert|show).* (?<ref>\S*)$" {
             gitBranches $matches['ref'] $true
         }
     }


### PR DESCRIPTION
git cherry takes branches (or SHAs) as parameters.  This change merely enables branch name tab completion for the git cherry command.
