### PR TITLE
Changes the default profile example to set prompt globally instead of locally

### DIFF
--- a/profile.example.ps1
+++ b/profile.example.ps1
@@ -9,7 +9,7 @@ Import-Module .\posh-git
 
 
 # Set up a simple prompt, adding the git prompt parts inside git repos
-function prompt {
+function global:prompt {
     $realLASTEXITCODE = $LASTEXITCODE
 
     # Reset color, which can be messed up by Enable-GitColors


### PR DESCRIPTION
Problem:
The default example profile in posh-git provides a prompt function, as it does this in the current scope if you call this in a function the prompt on the shell is not modified.
I was attempting to create a function that would allow me to install posh-git only if I wanted to use it in a shell instead of in all shells when I hit this.

Proposed Solution:
Modify the prompt in the example to modify global:prompt instead of simply prompt - this means that it will work even if it is called in a lower scope.

I realise that this could just be modified by people that needed in the file they base on the example, but think it might be helpful to modify it here?
