### PR TITLE
Avoid polluting $error on module load

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -144,7 +144,7 @@ function Write-GitStatus($status) {
     }
 }
 
-if((Get-Variable -Scope Global -Name VcsPromptStatuses -ErrorAction SilentlyContinue) -eq $null) {
+if(!(Test-Path -Path variable:Global:VcsPromptStatuses)) {
     $Global:VcsPromptStatuses = @()
 }
 function Global:Write-VcsStatus { $Global:VcsPromptStatuses | foreach { & $_ } }

--- a/GitTabExpansion.ps1
+++ b/GitTabExpansion.ps1
@@ -31,7 +31,7 @@ function script:gitCmdOperations($commands, $command, $filter) {
 
 $script:someCommands = @('add','am','annotate','archive','bisect','blame','branch','bundle','checkout','cherry','cherry-pick','citool','clean','clone','commit','config','describe','diff','difftool','fetch','format-patch','gc','grep','gui','help','init','instaweb','log','merge','mergetool','mv','notes','prune','pull','push','rebase','reflog','remote','rerere','reset','revert','rm','shortlog','show','stash','status','submodule','svn','tag','whatchanged')
 try {
-  if ((git flow 2> $null) -ne $null) {
+  if ((git help -a 2>&1 | Select-String flow) -ne $null) {
       $script:someCommands += 'flow'
   }
 }
@@ -280,7 +280,7 @@ function GitTabExpansion($lastBlock) {
     }
 }
 
-$PowerTab_RegisterTabExpansion = Get-Command Register-TabExpansion -Module powertab -ErrorAction SilentlyContinue
+$PowerTab_RegisterTabExpansion = if (Get-Module -Name powertab) { Get-Command Register-TabExpansion -Module powertab -ErrorAction SilentlyContinue }
 if ($PowerTab_RegisterTabExpansion)
 {
     & $PowerTab_RegisterTabExpansion "git.exe" -Type Command {


### PR DESCRIPTION
I made some small tweaks so I don't see errors from loading posh-git in $error.

These changes are only tested against PowerShell V4, but I think they should work fine in V3 and V2.
