### PR TITLE
Removing code to add a single ssh key if none are provided.

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -281,8 +281,7 @@ function Add-SshKey() {
     if (!$sshAdd) { Write-Warning 'Could not find ssh-add'; return }
 
     if ($args.Count -eq 0) {
-        $sshPath = Get-SshPath
-        if ($sshPath) { & $sshAdd $sshPath }
+        & $sshAdd
     } else {
         foreach ($value in $args) {
             & $sshAdd $value


### PR DESCRIPTION
ssh-add, if run without parameters, will add all the keys found in ~/.ssh. There
is no need to use a default file when calling it.

I happen to be using id_dsa and id_rsa keys and this call was creating work for me.
