### PR TITLE
Reset Get-LocalOrParentPath() checkin name

### DIFF
--- a/Utils.ps1
+++ b/Utils.ps1
@@ -18,7 +18,7 @@ Set-Alias ?? Invoke-NullCoalescing -Force
 function Get-LocalOrParentPath($path) {
     $checkIn = Get-Item -Force .
     while ($checkIn -ne $NULL) {
-        $pathToTest = Join-Path $checkIn $path
+        $pathToTest = Join-Path $checkIn.fullname $path
         if (Test-Path -LiteralPath $pathToTest) {
             return $pathToTest
         } else {


### PR DESCRIPTION
commit 72fde6f made $pathToTest use Join-Path and in the process dropped the
fullname from $checkin. On my system, this had the negative of introducing a
PS to my prompt when outside of a git repository. Restoring $checkIn.fullname
leaves the path on the prompt an expected c:\path> instead of c:\pathPS>
