### PR TITLE
Implement describe style setting and functionality.

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -45,6 +45,7 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     EnablePromptStatus        = !$Global:GitMissing
     EnableFileStatus          = $true
     RepositoriesInWhichToDisableFileStatus = @( ) # Array of repository paths
+    DescribeStyle             = ''
 
     EnableWindowTitle         = 'posh~git ~ '
 

--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -48,7 +48,15 @@ function Get-GitBranch($gitDir = $(Get-GitDirectory), [Diagnostics.Stopwatch]$sw
             $b = Invoke-NullCoalescing `
                 { dbg 'Trying symbolic-ref' $sw; git symbolic-ref HEAD 2>$null } `
                 { '({0})' -f (Invoke-NullCoalescing `
-                    { dbg 'Trying describe' $sw; git describe --exact-match HEAD 2>$null } `
+                    {
+                        dbg 'Trying describe' $sw
+                        switch ($Global:GitPromptSettings.DescribeStyle) {
+                            'contains' { git describe --contains HEAD 2>$null }
+                            'branch' { git describe --contains --all HEAD 2>$null }
+                            'describe' { git describe HEAD 2>$null }
+                            default { git describe --tags --exact-match HEAD 2>$null }
+                        }
+                    } `
                     {
                         dbg 'Falling back on parsing HEAD' $sw
                         $ref = $null


### PR DESCRIPTION
This replicates/ports the functionality for configuring how commits checked out as a detached HEAD are represented in the prompt that is available by setting GIT_PS1_DESCRIBE_STYLE for the bash version of the git prompt (https://github.com/git/git/blob/master/contrib/completion/git-prompt.sh). This change adds a property called DescribeStyle to GitPromptSettings which takes the same arguments described in the comments for the bash script:
- **contains** - relative to newer annotated tag (v1.6.3.2~35)
- **branch** - relative to newer tag or branch (master~4)
- **describe** - relative to older annotated tag (v1.6.3.1-13-gdd42c2f)
- **default** - exactly matching tag
