### PR TITLE
Implement tab completion for tags.

### DIFF
--- a/GitTabExpansion.ps1
+++ b/GitTabExpansion.ps1
@@ -74,6 +74,12 @@ function script:gitBranches($filter, $includeHEAD = $false) {
         foreach { $prefix + $_ }
 }
 
+function script:gitTags($filter) {
+    git tag |
+        where { $_ -like "$filter*" } |
+        foreach { $_ }
+}
+
 function script:gitFeatures($filter, $command){
 	$featurePrefix = git config --local --get "gitflow.prefix.$command"
     $branches = @(git branch --no-color | foreach { if($_ -match "^\*?\s*$featurePrefix(?<ref>.*)") { $matches['ref'] } }) 
@@ -281,6 +287,7 @@ function GitTabExpansion($lastBlock) {
         # Handles git <cmd> <ref>
         "^(?:checkout|cherry|cherry-pick|diff|difftool|log|merge|rebase|reflog\s+show|reset|revert|show).* (?<ref>\S*)$" {
             gitBranches $matches['ref'] $true
+            gitTags $matches['ref']
         }
     }
 }

--- a/GitTabExpansion.ps1
+++ b/GitTabExpansion.ps1
@@ -76,8 +76,7 @@ function script:gitBranches($filter, $includeHEAD = $false) {
 
 function script:gitTags($filter) {
     git tag |
-        where { $_ -like "$filter*" } |
-        foreach { $_ }
+		where { $_ -like "$filter*" }
 }
 
 function script:gitFeatures($filter, $command){

--- a/GitTabExpansion.ps1
+++ b/GitTabExpansion.ps1
@@ -76,7 +76,7 @@ function script:gitBranches($filter, $includeHEAD = $false) {
 
 function script:gitTags($filter) {
     git tag |
-		where { $_ -like "$filter*" }
+        where { $_ -like "$filter*" }
 }
 
 function script:gitFeatures($filter, $command){


### PR DESCRIPTION
Here's my initial attempt at implementing tab completion for tags (Issue #108).  It doesn't yet recognize trying to complete using "tags/" like described in the issue, but cycles through a combined list of branches and tags similar to how this is handled in the bash prompt implementation.