### PR TITLE
colors more friendly for colorblind users and still good for others

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -19,7 +19,7 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     BranchBackgroundColor       = $Host.UI.RawUI.BackgroundColor
     BranchAheadForegroundColor  = [ConsoleColor]::Green
     BranchAheadBackgroundColor  = $Host.UI.RawUI.BackgroundColor
-    BranchBehindForegroundColor = [ConsoleColor]::Red
+    BranchBehindForegroundColor = [ConsoleColor]::Blue
     BranchBehindBackgroundColor = $Host.UI.RawUI.BackgroundColor
     BranchBehindAndAheadForegroundColor = [ConsoleColor]::Yellow
     BranchBehindAndAheadBackgroundColor = $Host.UI.RawUI.BackgroundColor
@@ -31,11 +31,11 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     IndexForegroundColor      = [ConsoleColor]::DarkGreen
     IndexBackgroundColor      = $Host.UI.RawUI.BackgroundColor
 
-    WorkingForegroundColor    = [ConsoleColor]::DarkRed
+    WorkingForegroundColor    = [ConsoleColor]::Red
     WorkingBackgroundColor    = $Host.UI.RawUI.BackgroundColor
 
     UntrackedText             = ' !'
-    UntrackedForegroundColor  = [ConsoleColor]::DarkRed
+    UntrackedForegroundColor  = [ConsoleColor]::Red
     UntrackedBackgroundColor  = $Host.UI.RawUI.BackgroundColor
 
     ShowStatusWhenZero        = $true


### PR DESCRIPTION
Changed BranchBehindForegroundColor = [ConsoleColor]::Blue and DarkRed to Red to make colors more friendly for colorblind users.

Especially helpful when combined with:

$Host.UI.RawUI.ForegroundColor = [ConsoleColor]::Gray
$Host.UI.RawUI.BackgroundColor = [ConsoleColor]::Black

![image](https://f.cloud.github.com/assets/553630/1873320/79ae4ee2-78b7-11e3-8058-374174b61b5e.png)
