### PR TITLE
fix ssh-agent start up

### DIFF
--- a/profile.example.ps1
+++ b/profile.example.ps1
@@ -27,4 +27,4 @@ Enable-GitColors
 
 Pop-Location
 
-Start-SshAgent -Quiet
+Start-Ssh-Agent -Quiet


### PR DESCRIPTION
When using Git with the cmd wrappers, Start-SshAgent is spelled Start-Ssh-Agent.
