### PR TITLE
Limit length of long branch name

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -50,6 +50,10 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     EnableWindowTitle         = 'posh~git ~ '
 
     Debug                     = $false
+
+    EnableBranchNameLimit     = $true
+    BranchNameLimit           = 20
+    TruncatedBranchSuffix     = "..."
 }
 
 $WindowTitleSupported = $true
@@ -63,6 +67,17 @@ function Write-Prompt($Object, $ForegroundColor, $BackgroundColor = -1) {
     } else {
         Write-Host $Object -NoNewLine -ForegroundColor $ForegroundColor -BackgroundColor $BackgroundColor
     }
+}
+
+function Format-BranchName($branchName){
+    $s = $global:GitPromptSettings
+
+    if($s.EnableBranchNameLimit -eq $true)
+    {
+        $branchName = "{0}{1}" -f $branchName.Substring(0,$s.BranchNameLimit), $s.TruncatedBranchSuffix
+    }
+
+    return $branchName
 }
 
 function Write-GitStatus($status) {
@@ -86,7 +101,7 @@ function Write-GitStatus($status) {
             $branchForegroundColor = $s.BranchAheadForegroundColor
         }
 
-        Write-Prompt $status.Branch -BackgroundColor $branchBackgroundColor -ForegroundColor $branchForegroundColor
+        Write-Prompt (Format-BranchName($status.Branch)) -BackgroundColor $branchBackgroundColor -ForegroundColor $branchForegroundColor
 
         if($s.EnableFileStatus -and $status.HasIndex) {
             Write-Prompt $s.BeforeIndexText -BackgroundColor $s.BeforeIndexBackgroundColor -ForegroundColor $s.BeforeIndexForegroundColor

--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -51,9 +51,8 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
 
     Debug                     = $false
 
-    EnableBranchNameLimit     = $true
-    BranchNameLimit           = 20
-    TruncatedBranchSuffix     = "..."
+    BranchNameLimit           = 0
+    TruncatedBranchSuffix     = '...'
 }
 
 $WindowTitleSupported = $true
@@ -72,7 +71,7 @@ function Write-Prompt($Object, $ForegroundColor, $BackgroundColor = -1) {
 function Format-BranchName($branchName){
     $s = $global:GitPromptSettings
 
-    if($s.EnableBranchNameLimit -eq $true)
+    if($s.BranchNameLimit -gt 0 -and $branchName.Length -gt $s.BranchNameLimit)
     {
         $branchName = "{0}{1}" -f $branchName.Substring(0,$s.BranchNameLimit), $s.TruncatedBranchSuffix
     }

--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -52,7 +52,7 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     Debug                     = $false
 
     BranchNameLimit           = 0
-    TruncatedBranchSuffix     = '…'
+    TruncatedBranchSuffix     = '...'
 }
 
 $WindowTitleSupported = $true

--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -3,7 +3,7 @@
 
 $global:GitPromptSettings = New-Object PSObject -Property @{
     DefaultForegroundColor    = $Host.UI.RawUI.ForegroundColor
-
+    
     BeforeText                = ' ['
     BeforeForegroundColor     = [ConsoleColor]::Yellow
     BeforeBackgroundColor     = $Host.UI.RawUI.BackgroundColor
@@ -52,7 +52,7 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     Debug                     = $false
 
     BranchNameLimit           = 0
-    TruncatedBranchSuffix     = '...'
+    TruncatedBranchSuffix     = '…'
 }
 
 $WindowTitleSupported = $true


### PR DESCRIPTION
I wished to limit the length of the branch name (in the prompt) for branches with very long (verbose) names.  I arbitrarily chose the default to be 20 characters because it seemed to show enough of the branch name when using a Git-Flow like convention, with a JIRA id:  "feature/ABC-123-name...".