### PR TITLE
Cope with multiple Pageant installs (one-line change)

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -301,7 +301,7 @@ function Get-SshPath($File = 'id_rsa')
 # Add a key to the SSH agent
 function Add-SshKey() {
     if ($env:GIT_SSH -imatch 'plink') {
-        $pageant = Get-Command pageant -Erroraction SilentlyContinue | Select -ExpandProperty Name
+        $pageant = Get-Command pageant -Erroraction SilentlyContinue | Select -First 1 -ExpandProperty Name
         if (!$pageant) { Write-Warning 'Could not find Pageant'; return }
 
         if ($args.Count -eq 0) {


### PR DESCRIPTION
If Pageant is installed multiple times (e.g. inside both TortoiseGit and TortoiseHg) then just pick the first one.

I actually fixed this on my installation as follows:
$pageant = Get-Command pageant -Erroraction SilentlyContinue | Select -ExpandProperty Name | head -1
but I think this pull request is the PowerShell way of doing the same thing.
