### PR TITLE
sqlps's provider causes posh-git to throw errors

### DIFF
--- a/Utils.ps1
+++ b/Utils.ps1
@@ -17,6 +17,9 @@ Set-Alias ?? Invoke-NullCoalescing -Force
 
 function Get-LocalOrParentPath($path) {
     $checkIn = Get-Item -Force .
+    if ($checkIn.PSProvider.Name -ne 'FileSystem') {
+        return $null
+    }
     while ($checkIn -ne $NULL) {
         $pathToTest = [System.IO.Path]::Combine($checkIn.fullname, $path)
         if (Test-Path -LiteralPath $pathToTest) {


### PR DESCRIPTION
When doing something like importing the SQL Server 2012 powershell extensions, you will get errors from Posh-git if you're in that SQLSERVER provider. This doesn't affect most providers because most of them return quietly when something goes wrong. But SQLSERVER provider in particular does a WMI query any time you `cd` in to something.

The error is similar to:
![image](https://cloud.githubusercontent.com/assets/936215/4328117/2ae86536-3f81-11e4-8962-c2850fa20ba9.png)

There's a couple of places this can be fixed, but I felt like the best place was in Get-LocalOrParentPath and having it check that the $checkIn object is on a provider named 'FileSystem'. I'm happy to fix this, but I wasn't sure if that's really the best place to fix the issue. Also testing a string vs. string may be brittle to locales and I got lucky - I'm honestly unsure; however, a cursory check of e.g. German showed it was still called 'FileSystem'.

Locally I have already fixed it by modifying it as mentioned and all is happy.
