### PR TITLE
Remove merged branches

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -50,6 +50,8 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     EnableWindowTitle         = 'posh~git ~ '
 
     Debug                     = $false
+
+    MergedBranchesToKeep       = @("master", "develop")
 }
 
 $WindowTitleSupported = $true

--- a/GitRemoveMergedBranches.ps1
+++ b/GitRemoveMergedBranches.ps1
@@ -1,0 +1,86 @@
+function IsNotCurrentOrIgnoredLocal-GitBranch($branch)
+{
+    $ignored = "master", "develop"
+    !$branch.StartsWith("*") -and !$ignored.Contains($branch)
+}
+
+function TrimRemote-GitBranch($branch)
+{
+    $branch -replace "^(.*?)/(.*)$", "`$2"
+}
+
+function IsNotCurrentOrIgnoredRemote-GitBranch($branch)
+{
+    $ignored = "master", "develop"
+    if ($branch.Contains("/HEAD ->"))
+    {
+        return $false
+    }
+
+    $branchName = TrimRemote-GitBranch $branch
+    return !$ignored.Contains($branchName)
+}
+
+function Get-MergedLocalGitBranches
+{
+    $branches = git branch --merged
+    $trimmed = $branches | foreach {$_.Trim()}
+    return $trimmed | where {IsNotCurrentOrIgnoredLocal-GitBranch $_}
+}
+
+function Get-MergedRemoteBranches
+{
+    $branches = git branch -r --merged
+    $trimmed = $branches | foreach {$_.Trim()}
+    $filtered = $trimmed | where {IsNotCurrentOrIgnoredRemote-GitBranch $_}
+    return $filtered | foreach {TrimRemote-GitBranch $_}
+}
+
+function Remove-MergedLocalGitBranches
+{
+    $branches = Get-MergedLocalGitBranches
+    if ($branches.Length -eq 0)
+    {
+        Write-Host "No local merged branches"
+        return
+    }
+
+    Write-Host "Start deleting local merged branches"
+    Write-Host
+    
+    foreach ($item in $branches)
+    {
+        Write-Host "Deleting branch $item..."
+        git branch -d $trimmed
+        Write-Host
+    }
+    Write-Host "Finish deleting local merged branches"
+}
+
+function Remove-MergedRemoteGitBranches
+{
+    $branches = Get-MergedRemoteBranches
+    if ($branches.Length -eq 0)
+    {
+        Write-Host "No remote merged branches"
+        return
+    }
+
+    Write-Host "Start deleting remote merged branches"
+    Write-Host
+    
+    foreach ($item in $branches)
+    {
+        Write-Host "Deleting branch $item..."
+        git push origin :$branch
+        Write-Host
+    }
+    Write-Host "Finish deleting remote merged branches"
+}
+
+function Remove-MergedGitBranches
+{
+    Remove-MergedLocalGitBranches
+    Write-Host
+    Remove-MergedRemoteGitBranches
+}

--- a/GitRemoveMergedBranches.ps1
+++ b/GitRemoveMergedBranches.ps1
@@ -15,7 +15,7 @@ function Get-MergedLocalGitBranches($ignore)
 {
     $branches = git branch --merged
     $trimmed = $branches | foreach {$_.Trim()}
-    return $trimmed | where {(IsNotCurrentLocal-GitBranch $_) -and !$ignore.Contains($_)}
+    return $trimmed | where {IsNotCurrentLocal-GitBranch $_}
 }
 
 function Get-MergedRemoteBranches($ignore)
@@ -26,7 +26,7 @@ function Get-MergedRemoteBranches($ignore)
     return $trimmed `
         | where {!$_.Contains("/HEAD ->")} `
         | TrimRemote-GitBranch `
-        | where {($_ -ne $current) -and !$ignore.Contains($_)}
+        | where {$_ -ne $current}
 }
 
 function Remove-MergedLocalGitBranches
@@ -35,10 +35,10 @@ function Remove-MergedLocalGitBranches
     Param(
         [Parameter()]
         [string[]]
-        $Ignore = @("master", "develop")
+        $Ignore = $Global:GitPromptSettings.MergedBranchesToKeep
     )
 
-    $branches = Get-MergedLocalGitBranches $Ignore
+    $branches = Get-MergedLocalGitBranches | where {$_ -notin $Ignore}
     if ($branches.Length -eq 0)
     {
         Write-Host "No local merged branches"
@@ -66,10 +66,10 @@ function Remove-MergedRemoteGitBranches
     Param(
         [Parameter()]
         [string[]]
-        $Ignore = @("master", "develop")
+        $Ignore = $Global:GitPromptSettings.MergedBranchesToKeep
     )
 
-    $branches = Get-MergedRemoteBranches $Ignore
+    $branches = Get-MergedRemoteBranches | where {$_ -notin $Ignore}
     if ($branches.Length -eq 0)
     {
         Write-Host "No remote merged branches"
@@ -97,7 +97,7 @@ function Remove-MergedGitBranches()
     Param(
         [Parameter()]
         [string[]]
-        $Ignore = @("master", "develop")
+        $Ignore = $Global:GitPromptSettings.MergedBranchesToKeep
     )
 
     Remove-MergedLocalGitBranches @PSBoundParameters

--- a/GitRemoveMergedBranches.ps1
+++ b/GitRemoveMergedBranches.ps1
@@ -3,9 +3,12 @@ function IsNotCurrentLocal-GitBranch($branch)
     !$branch.StartsWith("*")
 }
 
-function TrimRemote-GitBranch($branch)
+function TrimRemote-GitBranch()
 {
-    $branch -replace "^(.*?)/(.*)$", "`$2"
+    PROCESS
+    {
+        $_ -replace "^(.*?)/(.*)$", "`$2"
+    }
 }
 
 function Get-MergedLocalGitBranches($ignore)
@@ -22,7 +25,7 @@ function Get-MergedRemoteBranches($ignore)
     $trimmed = $branches | foreach {$_.Trim()}
     return $trimmed `
         | where {!$_.Contains("/HEAD ->")} `
-        | foreach {TrimRemote-GitBranch $_} `
+        | TrimRemote-GitBranch `
         | where {($_ -ne $current) -and !$ignore.Contains($_)}
 }
 

--- a/GitRemoveMergedBranches.ps1
+++ b/GitRemoveMergedBranches.ps1
@@ -11,14 +11,14 @@ function TrimRemote-GitBranch()
     }
 }
 
-function Get-MergedLocalGitBranches($ignore)
+function Get-MergedLocalGitBranches()
 {
     $branches = git branch --merged
     $trimmed = $branches | foreach {$_.Trim()}
     return $trimmed | where {IsNotCurrentLocal-GitBranch $_}
 }
 
-function Get-MergedRemoteBranches($ignore)
+function Get-MergedRemoteBranches()
 {
     $current = Get-GitBranch
     $branches = git branch -r --merged
@@ -32,13 +32,10 @@ function Get-MergedRemoteBranches($ignore)
 function Remove-MergedLocalGitBranches
 {
     [CmdletBinding(SupportsShouldProcess = $true)]
-    Param(
-        [Parameter()]
-        [string[]]
-        $Ignore = $Global:GitPromptSettings.MergedBranchesToKeep
-    )
+    Param()
 
-    $branches = Get-MergedLocalGitBranches | where {$_ -notin $Ignore}
+    $branches = Get-MergedLocalGitBranches `
+        | where {$_ -notin $Global:GitPromptSettings.MergedBranchesToKeep}
     if ($branches.Length -eq 0)
     {
         Write-Host "No local merged branches"
@@ -58,13 +55,10 @@ function Remove-MergedLocalGitBranches
 function Remove-MergedRemoteGitBranches
 {
     [CmdletBinding(SupportsShouldProcess = $true)]
-    Param(
-        [Parameter()]
-        [string[]]
-        $Ignore = $Global:GitPromptSettings.MergedBranchesToKeep
-    )
+    Param()
 
-    $branches = Get-MergedRemoteBranches | where {$_ -notin $Ignore}
+    $branches = Get-MergedRemoteBranches `
+        | where {$_ -notin $Global:GitPromptSettings.MergedBranchesToKeep}
     if ($branches.Length -eq 0)
     {
         Write-Host "No remote merged branches"
@@ -84,11 +78,7 @@ function Remove-MergedRemoteGitBranches
 function Remove-MergedGitBranches()
 {
     [CmdletBinding(SupportsShouldProcess = $true)]
-    Param(
-        [Parameter()]
-        [string[]]
-        $Ignore = $Global:GitPromptSettings.MergedBranchesToKeep
-    )
+    Param()
 
     Remove-MergedLocalGitBranches @PSBoundParameters
     Remove-MergedRemoteGitBranches @PSBoundParameters

--- a/GitRemoveMergedBranches.ps1
+++ b/GitRemoveMergedBranches.ps1
@@ -28,7 +28,7 @@ function Get-MergedRemoteBranches($ignore)
 
 function Remove-MergedLocalGitBranches
 {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     Param(
         [Parameter()]
         [string[]]
@@ -47,8 +47,11 @@ function Remove-MergedLocalGitBranches
     
     foreach ($item in $branches)
     {
-        Write-Host "Deleting branch $item..."
-        git branch -d $trimmed
+        if ($PSCmdlet.ShouldProcess($item, "delete branch"))
+        {
+            Write-Host "Deleting branch $item..."
+            git branch -d $item
+        }
         Write-Host
     }
     Write-Host "Finish deleting local merged branches"
@@ -56,7 +59,7 @@ function Remove-MergedLocalGitBranches
 
 function Remove-MergedRemoteGitBranches
 {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     Param(
         [Parameter()]
         [string[]]
@@ -75,8 +78,11 @@ function Remove-MergedRemoteGitBranches
     
     foreach ($item in $branches)
     {
-        Write-Host "Deleting branch $item..."
-        git push origin :$branch
+        if ($PSCmdlet.ShouldProcess($item, "delete remote branch"))
+        {
+            Write-Host "Deleting branch $item..."
+            git push origin :$item
+        }
         Write-Host
     }
     Write-Host "Finish deleting remote merged branches"
@@ -84,14 +90,14 @@ function Remove-MergedRemoteGitBranches
 
 function Remove-MergedGitBranches()
 {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     Param(
         [Parameter()]
         [string[]]
         $Ignore = @("master", "develop")
     )
 
-    Remove-MergedLocalGitBranches -Ignore $Ignore
+    Remove-MergedLocalGitBranches @PSBoundParameters
     Write-Host
-    Remove-MergedRemoteGitBranches -Ignore $Ignore
+    Remove-MergedRemoteGitBranches @PSBoundParameters
 }

--- a/GitRemoveMergedBranches.ps1
+++ b/GitRemoveMergedBranches.ps1
@@ -78,8 +78,28 @@ function Remove-MergedRemoteGitBranches
 function Remove-MergedGitBranches()
 {
     [CmdletBinding(SupportsShouldProcess = $true)]
-    Param()
+    Param(
+        [Switch]
+        $Remote,
 
-    Remove-MergedLocalGitBranches @PSBoundParameters
-    Remove-MergedRemoteGitBranches @PSBoundParameters
+        [Switch]
+        $All
+    )
+
+    $PSBoundParameters.Remove('Remote') | Out-Null
+    $PSBoundParameters.Remove('All') | Out-Null
+
+    if ($All)
+    {
+        Remove-MergedRemoteGitBranches @PSBoundParameters
+        Remove-MergedLocalGitBranches @PSBoundParameters
+    }
+    elseif ($Remote)
+    {
+        Remove-MergedRemoteGitBranches @PSBoundParameters
+    }
+    else
+    {
+        Remove-MergedLocalGitBranches @PSBoundParameters
+    }
 }

--- a/GitRemoveMergedBranches.ps1
+++ b/GitRemoveMergedBranches.ps1
@@ -45,9 +45,6 @@ function Remove-MergedLocalGitBranches
         return
     }
 
-    Write-Host "Start deleting local merged branches"
-    Write-Host
-    
     foreach ($item in $branches)
     {
         if ($PSCmdlet.ShouldProcess($item, "delete branch"))
@@ -55,9 +52,7 @@ function Remove-MergedLocalGitBranches
             Write-Host "Deleting branch $item..."
             git branch -d $item
         }
-        Write-Host
     }
-    Write-Host "Finish deleting local merged branches"
 }
 
 function Remove-MergedRemoteGitBranches
@@ -76,19 +71,14 @@ function Remove-MergedRemoteGitBranches
         return
     }
 
-    Write-Host "Start deleting remote merged branches"
-    Write-Host
-    
     foreach ($item in $branches)
     {
         if ($PSCmdlet.ShouldProcess($item, "delete remote branch"))
         {
-            Write-Host "Deleting branch $item..."
+            Write-Host "Deleting remote branch $item..."
             git push origin :$item
         }
-        Write-Host
     }
-    Write-Host "Finish deleting remote merged branches"
 }
 
 function Remove-MergedGitBranches()
@@ -101,6 +91,5 @@ function Remove-MergedGitBranches()
     )
 
     Remove-MergedLocalGitBranches @PSBoundParameters
-    Write-Host
     Remove-MergedRemoteGitBranches @PSBoundParameters
 }

--- a/GitRemoveMergedBranches.ps1
+++ b/GitRemoveMergedBranches.ps1
@@ -68,23 +68,19 @@ function Remove-MergedGitBranches() {
     [CmdletBinding(SupportsShouldProcess = $true)]
     Param(
         [Switch]
-        $Remote,
-
-        [Switch]
-        $All,
+        $Local,
 
         [string[]]
-        $RemoteName = 'origin'
+        $Remote
     )
 
-    if ($All) {
-        Remove-MergedRemoteGitBranches $RemoteName
+    if (!$PSBoundParameters.ContainsKey('Local') -and !$PSBoundParameters.ContainsKey('Remote')) {
+        $Local = $true;
+    }
+    if ($Local) {
         Remove-MergedLocalGitBranches
     }
-    elseif ($Remote) {
-        Remove-MergedRemoteGitBranches $RemoteName
-    }
-    else {
-        Remove-MergedLocalGitBranches
+    if ($Remote.Length -gt 0) {
+        Remove-MergedRemoteGitBranches $Remote
     }
 }

--- a/GitRemoveMergedBranches.ps1
+++ b/GitRemoveMergedBranches.ps1
@@ -1,31 +1,25 @@
-function IsNotCurrentLocal-GitBranch($branch)
-{
+function IsNotCurrentLocal-GitBranch($branch) {
     !$branch.StartsWith("*")
 }
 
-function Select-RemoteBranch($remoteName)
-{
+function Select-RemoteBranch($remoteName) {
     PROCESS
     {
-        if ($_ -match "^(.*?)/(.*)$")
-        {
-            if ($Matches[1] -eq $remoteName)
-            {
+        if ($_ -match "^(.*?)/(.*)$") {
+            if ($Matches[1] -eq $remoteName) {
                 write $Matches[2]
             }
         }
     }
 }
 
-function Get-MergedLocalGitBranches()
-{
+function Get-MergedLocalGitBranches() {
     $branches = git branch --merged
     $trimmed = $branches | foreach {$_.Trim()}
     return $trimmed | where {IsNotCurrentLocal-GitBranch $_}
 }
 
-function Get-MergedRemoteBranches($remoteName)
-{
+function Get-MergedRemoteBranches($remoteName) {
     $current = Get-GitBranch
     $branches = git branch -r --merged
     $trimmed = $branches | foreach {$_.Trim()}
@@ -35,51 +29,42 @@ function Get-MergedRemoteBranches($remoteName)
         | where {$_ -ne $current}
 }
 
-function Remove-MergedLocalGitBranches
-{
+function Remove-MergedLocalGitBranches {
     [CmdletBinding(SupportsShouldProcess = $true)]
     Param()
 
     $branches = Get-MergedLocalGitBranches `
         | where {$_ -notin $Global:GitPromptSettings.MergedBranchesToKeep}
-    if ($branches.Length -eq 0)
-    {
+    if ($branches.Length -eq 0) {
         Write-Host "No local merged branches"
         return
     }
 
-    foreach ($item in $branches)
-    {
-        if ($PSCmdlet.ShouldProcess($item, "delete branch"))
-        {
+    foreach ($item in $branches) {
+        if ($PSCmdlet.ShouldProcess($item, "delete branch")) {
             Write-Host "Deleting branch $item..."
             git branch -d $item
         }
     }
 }
 
-function Remove-MergedRemoteGitBranches($remoteName)
-{
+function Remove-MergedRemoteGitBranches($remoteName) {
     $branches = Get-MergedRemoteBranches $remoteName `
         | where {$_ -notin $Global:GitPromptSettings.MergedBranchesToKeep}
-    if ($branches.Length -eq 0)
-    {
+    if ($branches.Length -eq 0) {
         Write-Host "No remote merged branches"
         return
     }
 
-    foreach ($item in $branches)
-    {
-        if ($PSCmdlet.ShouldProcess($item, "delete remote branch"))
-        {
+    foreach ($item in $branches) {
+        if ($PSCmdlet.ShouldProcess($item, "delete remote branch")) {
             Write-Host "Deleting remote branch $item..."
             git push $RemoteName :$item
         }
     }
 }
 
-function Remove-MergedGitBranches()
-{
+function Remove-MergedGitBranches() {
     [CmdletBinding(SupportsShouldProcess = $true)]
     Param(
         [Switch]
@@ -92,17 +77,14 @@ function Remove-MergedGitBranches()
         $RemoteName = 'origin'
     )
 
-    if ($All)
-    {
+    if ($All) {
         Remove-MergedRemoteGitBranches $RemoteName
         Remove-MergedLocalGitBranches
     }
-    elseif ($Remote)
-    {
+    elseif ($Remote) {
         Remove-MergedRemoteGitBranches $RemoteName
     }
-    else
-    {
+    else {
         Remove-MergedLocalGitBranches
     }
 }

--- a/GitRemoveMergedBranches.ps1
+++ b/GitRemoveMergedBranches.ps1
@@ -35,9 +35,6 @@ function Get-MergedRemoteBranches($remoteName) {
 }
 
 function Remove-MergedLocalGitBranches {
-    [CmdletBinding(SupportsShouldProcess = $true)]
-    Param()
-
     $branches = Get-MergedLocalGitBranches `
         | where {$_ -notin $Global:GitPromptSettings.MergedBranchesToKeep}
     if ($branches.Length -eq 0) {
@@ -47,7 +44,6 @@ function Remove-MergedLocalGitBranches {
 
     foreach ($item in $branches) {
         if ($PSCmdlet.ShouldProcess($item, "delete branch")) {
-            Write-Host "Deleting branch $item..."
             git branch -d $item
         }
     }
@@ -63,7 +59,6 @@ function Remove-MergedRemoteGitBranches($remoteName) {
 
     foreach ($item in $branches) {
         if ($PSCmdlet.ShouldProcess($item.FullName, "delete remote branch")) {
-            Write-Host "Deleting remote branch $($item.FullName)..."
             git push $item.RemoteName :$($item.BranchName)
         }
     }

--- a/posh-git.psm1
+++ b/posh-git.psm1
@@ -36,8 +36,6 @@ Export-ModuleMember `
         'Get-SshPath',
         'Update-AllBranches',
         'tgit',
-        'Remove-MergedLocalGitBranches',
-        'Remove-MergedRemoteGitBranches',
         'Remove-MergedGitBranches')
 
 

--- a/posh-git.psm1
+++ b/posh-git.psm1
@@ -7,6 +7,7 @@ Push-Location $psScriptRoot
 . .\GitUtils.ps1
 . .\GitPrompt.ps1
 . .\GitTabExpansion.ps1
+. .\GitRemoveMergedBranches.ps1
 . .\TortoiseGit.ps1
 Pop-Location
 
@@ -34,6 +35,9 @@ Export-ModuleMember `
         'Add-SshKey',
         'Get-SshPath',
         'Update-AllBranches',
-        'tgit')
+        'tgit',
+        'Remove-MergedLocalGitBranches',
+        'Remove-MergedRemoteGitBranches',
+        'Remove-MergedGitBranches')
 
 


### PR DESCRIPTION
Add the cmdlets for removing merged branches:
-  Remove-MergedLocalGitBranches -- removes local merged branches.
-  Remove-MergedRemoteGitBranches -- removes remote merged branches.
-  Remove-MergedGitBranches -- removes both local and remote merged branches.

Implementation placed in the separate file GitRemoveMergedBranches.ps1 although most of other exported cmdlets sit in GitUtils.ps1.  Hope it's not a code style rule to place everything inside GitUtils.ps1.

This is how these cmdlets work.

**Remove-MergedLocalGitBranches**
1.  Call `git branch --merged`.
2.  For each line trim whitespaces from both sides.
3.  Filter out line starting with "*" -- it is the current branch.
4.  Filter out ignored branches -- master and develop by default.
5.  If no branch remains then print message and return.
6.  For each remaining branch call `git branch -d $item`.

**Remove-MergedRemoteGitBranches**

Works same as Remove-MergedLocalGitBranches except three things:
1.  List of merged branches is retrieved by `git branch -r --merged`.
2.  Slightly more complex parsing and filtration.  We need to filter out the line with "/HEAD ->" and cut off `<remote-name>/` part from a beginning of each line.
3.  Removes branch with `git push origin :$item`.

**Remove-MergedGitBranches**
This one simply calls previous two cmdlets.

All three cmdlets support -WhatIf and -Confirm ([link1](http://blogs.technet.com/b/heyscriptingguy/archive/2012/10/02/build-your-own-powershell-cmdlet-part-4-of-9.aspx), [link2](http://becomelotr.wordpress.com/2013/05/01/supports-should-process-oh-really/)).  Also, they all support -Ignore parameter for overriding list of ignored branches.

I haven't tested it enough yet to my shame but I think it is a good idea to create PR to receive feedback as soon as possible.

fixes #79 
