### PR TITLE
Stop Get-Process from adding exceptions to $Error when checking if pageant / ssh-agent aren't running

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -249,7 +249,7 @@ function Get-SshAgent() {
     } else {
         $agentPid = $Env:SSH_AGENT_PID
         if ($agentPid) {
-            $sshAgentProcess = Get-Process | Where-Object { $_.Id -eq $agentPid -and $_.Name -eq 'ssh-agent' } | Select -ExpandProperty Id
+            $sshAgentProcess = Get-Process | Where-Object { $_.Id -eq $agentPid -and $_.Name -eq 'ssh-agent' }
             if ($null -ne $sshAgentProcess) {
                 return $agentPid
             } else {


### PR DESCRIPTION
Updating the Get-Process call in GitUtils.ps1 so exceptions aren't added to the global $Error array

This occurs when pageant or ssh-agent aren't running, and therefore there is no process / pid to retrieve. However this is a valid scenario so shouldn't be added to the global $Error array.

Also being more explicit with the check of the returned value from Get-Process
