### PR TITLE
Added "Administrator: " prefix to window title

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -138,11 +138,20 @@ function Write-GitStatus($status) {
             }
             $repoName = Split-Path -Leaf (Split-Path $status.GitDir)
             $prefix = if ($s.EnableWindowTitle -is [string]) { $s.EnableWindowTitle } else { '' }
-            $Host.UI.RawUI.WindowTitle = "$prefix$repoName [$($status.Branch)]"
+            $adminHeader = Get-AdminTitleHeader
+            $Host.UI.RawUI.WindowTitle = "$adminHeader$prefix$repoName [$($status.Branch)]"
         }
     } elseif ( $Global:PreviousWindowTitle ) {
         $Host.UI.RawUI.WindowTitle = $Global:PreviousWindowTitle
     }
+}
+
+function Get-AdminTitleHeader
+{
+    $currentUser = [Security.Principal.WindowsPrincipal]([Security.Principal.WindowsIdentity]::GetCurrent())
+    $isAdminProcess = $currentUser.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+    if ($isAdminProcess) { return 'Administrator: ' }
 }
 
 if(!(Test-Path Variable:Global:VcsPromptStatuses)) {

--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -52,6 +52,11 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     Debug                     = $false
 }
 
+$currentUser = [Security.Principal.WindowsPrincipal]([Security.Principal.WindowsIdentity]::GetCurrent())
+$isAdminProcess = $currentUser.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+$adminHeader = if ($isAdminProcess) { 'Administrator: ' } else { '' }
+
 $WindowTitleSupported = $true
 if (Get-Module NuGet) {
     $WindowTitleSupported = $false
@@ -138,20 +143,11 @@ function Write-GitStatus($status) {
             }
             $repoName = Split-Path -Leaf (Split-Path $status.GitDir)
             $prefix = if ($s.EnableWindowTitle -is [string]) { $s.EnableWindowTitle } else { '' }
-            $adminHeader = Get-AdminTitleHeader
-            $Host.UI.RawUI.WindowTitle = "$adminHeader$prefix$repoName [$($status.Branch)]"
+            $Host.UI.RawUI.WindowTitle = "$script:adminHeader$prefix$repoName [$($status.Branch)]"
         }
     } elseif ( $Global:PreviousWindowTitle ) {
         $Host.UI.RawUI.WindowTitle = $Global:PreviousWindowTitle
     }
-}
-
-function Get-AdminTitleHeader
-{
-    $currentUser = [Security.Principal.WindowsPrincipal]([Security.Principal.WindowsIdentity]::GetCurrent())
-    $isAdminProcess = $currentUser.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-
-    if ($isAdminProcess) { return 'Administrator: ' }
 }
 
 if(!(Test-Path Variable:Global:VcsPromptStatuses)) {


### PR DESCRIPTION
Posh-Git was not including this prefix when it set the title, and I keep forgetting which window was launched with "Run As Administrator" and which was not.