### PR TITLE
Fixing a bug where the Git Status is written multiple times

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -156,7 +156,9 @@ if(!(Test-Path Variable:Global:VcsPromptStatuses)) {
 function Global:Write-VcsStatus { $Global:VcsPromptStatuses | foreach { & $_ } }
 
 # Add scriptblock that will execute for Write-VcsStatus
-$Global:VcsPromptStatuses += {
+$PoshGitVcsPrompt = {
     $Global:GitStatus = Get-GitStatus
     Write-GitStatus $GitStatus
 }
+$Global:VcsPromptStatuses += $PoshGitVcsPrompt
+$ExecutionContext.SessionState.Module.OnRemove = { $Global:VcsPromptStatuses = $Global:VcsPromptStatuses | ? { $_ -ne $PoshGitVcsPrompt} }


### PR DESCRIPTION
The bug occurs when you Remove-Module posh-git and Import-Module posh-git

As the variable VcsPromptStatuses already exists in the global scope from a previous import additional Write-VcsStatus calls are added to the variable.

The change removes the variable when the module is unloaded (which is good practice anyway) while still allowing the variable to exist in the global scope to enable the same extensibility hook

I've also placed the variable name used into another variable as it is being reused a few times so if it needs to change it only needs to be changed in one place - it may also be a candidate to be refactored into a module exported variable rather than a global