### PR TITLE
Adds support for shorthand force-push syntax

### DIFF
--- a/GitTabExpansion.ps1
+++ b/GitTabExpansion.ps1
@@ -223,6 +223,11 @@ function GitTabExpansion($lastBlock) {
         "^push.* (?<remote>\S+) (?<ref>[^\s\:]*\:)(?<branch>\S*)$" {
             gitRemoteBranches $matches['remote'] $matches['ref'] $matches['branch']
         }
+        
+        # Handles git push remote +<branch>  (force push)
+        "^push.* (?<remote>\S+) (?<ref>\+)(?<branch>\S*)$" {
+            gitRemoteBranches $matches['remote'] $matches['ref'] $matches['branch']
+        }
 
         # Handles git push remote <branch>
         # Handles git pull remote <branch>


### PR DESCRIPTION
Git supports a short-hand syntax for force-pushing a branch to a remote by including the "+" modifier before the branch name. However when doing so, Posh-git was no longer able to auto-complete the branch name as it did not understand this syntax.  This PR adds that support.

Closes #173
