### PR TITLE
Mark Enable-GitColors obsolete

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -207,7 +207,7 @@ function InDisabledRepository {
 }
 
 function Enable-GitColors {
-    $env:TERM = 'cygwin'
+    Write-Warning 'Enable-GitColors is Obsolete and will be removed in a future version of posh-git.'
 }
 
 function Get-AliasPattern($exe) {

--- a/profile.example.ps1
+++ b/profile.example.ps1
@@ -12,9 +12,6 @@ Import-Module .\posh-git
 function global:prompt {
     $realLASTEXITCODE = $LASTEXITCODE
 
-    # Reset color, which can be messed up by Enable-GitColors
-    $Host.UI.RawUI.ForegroundColor = $GitPromptSettings.DefaultForegroundColor
-
     Write-Host($pwd.ProviderPath) -nonewline
 
     Write-VcsStatus

--- a/profile.example.ps1
+++ b/profile.example.ps1
@@ -23,8 +23,6 @@ function global:prompt {
     return "> "
 }
 
-Enable-GitColors
-
 Pop-Location
 
 Start-SshAgent -Quiet


### PR DESCRIPTION
Fixes #178. I haven't seen any adverse behavior from not setting `TERM`.