### PR TITLE
Added tags file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 VERSION
 obj
+tags


### PR DESCRIPTION
There seems to be a hook in git for Windows 1.95 that generates a tags file by default. I added the tags file to .gitignore.