### PR TITLE
Support custom key file names with ssl connections

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -313,7 +313,13 @@ function Start-SshAgent([switch]$Quiet) {
             }
         }
     }
-    Add-SshKey
+    $keyfiles = Get-ChildItem -Path "$home/.ssh/*" -Exclude *.*, known_hosts
+    $keyfilepaths = @()
+    foreach($f in $keyfiles)
+    {
+        $keyfilepaths = $keyfilepaths + $f.FullName -replace "c:", "/c" -replace "\\", "/" 
+    }
+    Add-SshKey($keyfilepaths)
 }
 
 function Get-SshPath($File = 'id_rsa')


### PR DESCRIPTION
Start-SshAgent finds all keyfiles (standard and cusomt named) and passes their paths to Add-SshKey.