### PR TITLE
Restore missing DefaultForegroundColor

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -2,6 +2,8 @@
 # http://www.markembling.info/view/my-ideal-powershell-prompt-with-git-integration
 
 $global:GitPromptSettings = New-Object PSObject -Property @{
+    DefaultForegroundColor                      = $Host.UI.RawUI.ForegroundColor
+
     BeforeText                                  = ' ['
     BeforeForegroundColor                       = [ConsoleColor]::Yellow
     BeforeBackgroundColor                       = $Host.UI.RawUI.BackgroundColor


### PR DESCRIPTION
Removed in #202.

This may only impact me, but I'm getting an error in the GitHub for Windows shell because my local settings is missing this now-obsolete property. Maybe we can remove it eventually, but for now it's safer to leave it in.

```
Exception setting "ForegroundColor": "Cannot convert null to type "System.ConsoleColor" due to enumeration values that
are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are
"Black, DarkBlue, DarkGreen, DarkCyan, DarkRed, DarkMagenta, DarkYellow, Gray, DarkGray, Blue, Green, Cyan, Red,
Magenta, Yellow, White"."
At C:\Users\Keith\AppData\Local\GitHub\PoshGit_869d4c5159797755bc04749db47b166136e59132\profile.example.ps1:16 char:5
+     $Host.UI.RawUI.ForegroundColor = $GitPromptSettings.DefaultForegroundColor
```