### PR TITLE
Improve pageant process handling

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -303,7 +303,7 @@ function Start-SshAgent([switch]$Quiet) {
         $pageant = Get-Command pageant -TotalCount 1 -Erroraction SilentlyContinue
         $pageant = if ($pageant) {$pageant} else {Guess-Pageant}
         if (!$pageant) { Write-Warning "Could not find Pageant."; return }
-        & $pageant
+         Start-Process -NoNewWindow $pageant
     } else {
         $sshAgent = Get-Command ssh-agent -TotalCount 1 -ErrorAction SilentlyContinue
         $sshAgent = if ($sshAgent) {$sshAgent} else {Guess-Ssh('ssh-agent')}

--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -244,7 +244,7 @@ function Set-TempEnv($key, $value) {
 # is a running agent.
 function Get-SshAgent() {
     if ($env:GIT_SSH -imatch 'plink') {
-        $pageantPid = Get-Process | Where-Object { $_.Name -eq 'pageant' } | Select -ExpandProperty Id
+        $pageantPid = Get-Process | Where-Object { $_.Name -eq 'pageant' } | Select -ExpandProperty Id -First 1
         if ($null -ne $pageantPid) { return $pageantPid }
     } else {
         $agentPid = $Env:SSH_AGENT_PID

--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -303,7 +303,7 @@ function Start-SshAgent([switch]$Quiet) {
         $pageant = Get-Command pageant -TotalCount 1 -Erroraction SilentlyContinue
         $pageant = if ($pageant) {$pageant} else {Guess-Pageant}
         if (!$pageant) { Write-Warning "Could not find Pageant."; return }
-         Start-Process -NoNewWindow $pageant
+        Start-Process -NoNewWindow $pageant
     } else {
         $sshAgent = Get-Command ssh-agent -TotalCount 1 -ErrorAction SilentlyContinue
         $sshAgent = if ($sshAgent) {$sshAgent} else {Guess-Ssh('ssh-agent')}


### PR DESCRIPTION
Don't wait indefinitely for pageant (given that it's a service-like process that adds a tray icon and waits for input), and don't error when there are already 2 pageant processes.

**Hanging bug**
This is the old behaviour I observed (that I believe f28bb54 removes): 
Start state:
* I am on Windows 10 with pageant 0.63 running. GitUtils runs as part of my powershell profile.
* I start powershell.exe and run `$env:GIT_SSH = "plink"`
* I kill any pageant.exe that is running

Repro:
* I run  `Start-Process powershell.exe` which creates a new powershell window,  starts pageant, then hangs forever (waiting for it to return).
* I close the hanging powershell window, pageant stays running
* I run  `Start-Process powershell.exe` in my original powershell window which starts fine since pageant is already running

**Multiple-pageant bug**
When using GitExtensions on my machine I end up with two pageant processes (one is created by ShimGen), 99021d4 fixes the powershell error thrown in Start-SshAgent due to having an array returned. Stop-SshAgent also uses this, so should work with multiple pageant processes, but you need to call Stop-SshAgent once for each running SshAgent process which could be better, but is an improvement over doing nothing and erroring.