### PR TITLE
Differentiate Untracked/Identical Branch in Prompt

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -30,6 +30,7 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     LocalStagedStatusForegroundColor            = [ConsoleColor]::Cyan
     LocalStagedStatusBackgroundColor            = $Host.UI.RawUI.BackgroundColor
 
+    BranchUntrackedSymbol                       = $null
     BranchForegroundColor                       = [ConsoleColor]::Cyan
     BranchBackgroundColor                       = $Host.UI.RawUI.BackgroundColor
 
@@ -117,7 +118,9 @@ function Write-GitStatus($status) {
         $branchStatusBackgroundColor = $s.BranchBackgroundColor
         $branchStatusForegroundColor = $s.BranchForegroundColor
 
-        if ($status.BehindBy -eq 0 -and $status.AheadBy -eq 0) {
+        if (!$status.Upstream) {
+            $branchStatusSymbol          = $s.BranchUntrackedSymbol
+        } elseif ($status.BehindBy -eq 0 -and $status.AheadBy -eq 0) {
             # We are aligned with remote
             $branchStatusSymbol          = $s.BranchIdenticalStatusToSymbol
             $branchStatusBackgroundColor = $s.BranchIdenticalStatusToBackgroundColor

--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -31,11 +31,11 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     LocalStagedStatusBackgroundColor            = $Host.UI.RawUI.BackgroundColor
     
     BranchIdenticalStatusToSymbol               = [char]0x2261 # Three horizontal lines
-    BranchIdenticalStatusToForegroundColor      = [ConsoleColor]::Green
+    BranchIdenticalStatusToForegroundColor      = [ConsoleColor]::Cyan
     BranchIdenticalStatusToBackgroundColor      = $Host.UI.RawUI.BackgroundColor
     
     BranchAheadStatusSymbol                     = [char]0x2191 # Up arrow
-    BranchAheadStatusForegroundColor            = [ConsoleColor]::Cyan
+    BranchAheadStatusForegroundColor            = [ConsoleColor]::Green
     BranchAheadStatusBackgroundColor            = $Host.UI.RawUI.BackgroundColor
     
     BranchBehindStatusSymbol                    = [char]0x2193 # Down arrow

--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -29,7 +29,10 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     LocalStagedStatusSymbol                     = '~'
     LocalStagedStatusForegroundColor            = [ConsoleColor]::Cyan
     LocalStagedStatusBackgroundColor            = $Host.UI.RawUI.BackgroundColor
-    
+
+    BranchForegroundColor                       = [ConsoleColor]::Cyan
+    BranchBackgroundColor                       = $Host.UI.RawUI.BackgroundColor
+
     BranchIdenticalStatusToSymbol               = [char]0x2261 # Three horizontal lines
     BranchIdenticalStatusToForegroundColor      = [ConsoleColor]::Cyan
     BranchIdenticalStatusToBackgroundColor      = $Host.UI.RawUI.BackgroundColor
@@ -110,6 +113,10 @@ function Write-GitStatus($status) {
     if ($status -and $s) {
         Write-Prompt $s.BeforeText -BackgroundColor $s.BeforeBackgroundColor -ForegroundColor $s.BeforeForegroundColor
 
+        $branchStatusSymbol          = $null
+        $branchStatusBackgroundColor = $s.BranchBackgroundColor
+        $branchStatusForegroundColor = $s.BranchForegroundColor
+
         if ($status.BehindBy -eq 0 -and $status.AheadBy -eq 0) {
             # We are aligned with remote
             $branchStatusSymbol          = $s.BranchIdenticalStatusToSymbol
@@ -133,13 +140,13 @@ function Write-GitStatus($status) {
         } else {
             # This condition should not be possible but defaulting the variables to be safe
             $branchStatusSymbol          = "?"
-            $branchStatusBackgroundColor = $Host.UI.RawUI.BackgroundColor
-            $branchStatusForegroundColor = $Host.UI.RawUI.ForegroundColor
         }
 
         Write-Prompt (Format-BranchName($status.Branch)) -BackgroundColor $branchStatusBackgroundColor -ForegroundColor $branchStatusForegroundColor
         
-        Write-Prompt  (" {0}" -f $branchStatusSymbol) -BackgroundColor $branchStatusBackgroundColor -ForegroundColor $branchStatusForegroundColor
+        if ($branchStatusSymbol) {
+            Write-Prompt  (" {0}" -f $branchStatusSymbol) -BackgroundColor $branchStatusBackgroundColor -ForegroundColor $branchStatusForegroundColor
+        }
 
         if($s.EnableFileStatus -and $status.HasIndex) {
             Write-Prompt $s.BeforeIndexText -BackgroundColor $s.BeforeIndexBackgroundColor -ForegroundColor $s.BeforeIndexForegroundColor

--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -180,6 +180,7 @@ function Get-GitStatus($gitDir = (Get-GitDirectory)) {
             Branch          = $branch
             AheadBy         = $aheadBy
             BehindBy        = $behindBy
+            Upstream        = $upstream
             HasIndex        = [bool]$index
             Index           = $index
             HasWorking      = [bool]$working


### PR DESCRIPTION
Fixes #212 with follow-up from #202:

* Swaps back to previous branch colors: Ahead = Green; Untracked/Identical = Cyan
* Restores previous behavior of initializing with `BranchForegroundColor`/`BranchBackgroundColor` and then overriding as appropriate.
* Hides branch status symbol if it's not set (drops an extra space)
* Adds `$GitPromptSettings.BranchUntrackedSymbol` if a symbol is desired there (default = nothing)

![image](https://cloud.githubusercontent.com/assets/133987/9506872/27e86ea2-4c10-11e5-850f-326d2c8680af.png)

/cc @mattdeckard @paulmarsy