### PR TITLE
Disabled stash count calculation when EnableStashStatus is $false. 

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -120,7 +120,10 @@ function Get-GitStatus($gitDir = (Get-GitDirectory)) {
         if($settings.EnableFileStatus -and !$(InDisabledRepository)) {
             dbg 'Getting status' $sw
             $status = git -c color.status=false status --short --branch 2>$null
-            $stashCount = $null | git stash list 2>$null | measure-object | select -expand Count
+            if($settings.EnableStashStatus) {
+                dbg 'Getting stash count' $sw
+                $stashCount = $null | git stash list 2>$null | measure-object | select -expand Count
+            }
         } else {
             $status = @()
         }


### PR DESCRIPTION
The stash count calculation was taking several seconds. I updated Get-GitStatus to skip the calculation if the EnableStashStatus setting is $false.