### PR TITLE
Allow to use UTF8 characters on a branch name

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -119,7 +119,10 @@ function Get-GitStatus($gitDir = (Get-GitDirectory)) {
 
         if($settings.EnableFileStatus -and !$(InDisabledRepository)) {
             dbg 'Getting status' $sw
+            $currentEncoding = [Console]::OutputEncoding
+            [Console]::OutputEncoding = [Text.Encoding]::UTF8
             $status = git -c color.status=false status --short --branch 2>$null
+            [Console]::OutputEncoding = $currentEncoding
             if($settings.EnableStashStatus) {
                 dbg 'Getting stash count' $sw
                 $stashCount = $null | git stash list 2>$null | measure-object | select -expand Count


### PR DESCRIPTION
If you use mutil-byte characters on a branch name, some of  git commands (such as `git status --branch`) return it in UTF8.
Default code page is not 65001 (UTF8) in every system locale, so `[Console]::OutputEncoding` should be set to UTF8 before executing some of git commands.
