### PR TITLE
Display git tag name in the prompt

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -50,9 +50,10 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     BranchBehindAndAheadStatusForegroundColor   = [ConsoleColor]::Yellow
     BranchBehindAndAheadStatusBackgroundColor   = $Host.UI.RawUI.BackgroundColor
     
-    TagForegroundColor                        = [ConsoleColor]::DarkGray
-    TagForegroundBrightColor                  = [ConsoleColor]::Gray
-    TagBackgroundColor                        = $Host.UI.RawUI.BackgroundColor
+    EnableTagDisplay                            = $true
+    TagForegroundColor                          = [ConsoleColor]::DarkGray
+    TagForegroundBrightColor                    = [ConsoleColor]::Gray
+    TagBackgroundColor                          = $Host.UI.RawUI.BackgroundColor
 
     BeforeIndexText                             = ""
     BeforeIndexForegroundColor                  = [ConsoleColor]::DarkGreen
@@ -161,9 +162,11 @@ function Write-GitStatus($status) {
 
         Write-Prompt (Format-BranchName($status.Branch)) -BackgroundColor $branchStatusBackgroundColor -ForegroundColor $branchStatusForegroundColor
         
-        $tag = Get-Tag
-        if ($tag -ne "undefined") {
-            Write-Prompt "|$($tag)" -BackgroundColor $s.TagBackgroundColor -ForegroundColor $s.TagForegroundColor
+        if ($s.EnableTagDisplay) {
+            $tag = Get-Tag
+            if ($tag -ne "undefined") {
+                Write-Prompt "|$($tag)" -BackgroundColor $s.TagBackgroundColor -ForegroundColor $s.TagForegroundColor
+            }
         }
         
         if ($branchStatusSymbol) {

--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -170,7 +170,14 @@ function Write-GitStatus($status) {
         }
         
         if ($branchStatusSymbol) {
-            Write-Prompt  (" {0}" -f $branchStatusSymbol) -BackgroundColor $branchStatusBackgroundColor -ForegroundColor $branchStatusForegroundColor
+            Write-Prompt  (" ") -BackgroundColor $branchStatusBackgroundColor -ForegroundColor $branchStatusForegroundColor
+            if ($status.AheadBy -ge 1) {
+                Write-Prompt  ("{0}" -f $status.AheadBy) -BackgroundColor $branchStatusBackgroundColor -ForegroundColor $branchStatusForegroundColor
+            }
+            Write-Prompt  ("{0}" -f $branchStatusSymbol) -BackgroundColor $branchStatusBackgroundColor -ForegroundColor $branchStatusForegroundColor
+            if ($status.BehindBy -ge 1) {
+                Write-Prompt  ("{0}" -f $status.BehindBy) -BackgroundColor $branchStatusBackgroundColor -ForegroundColor $branchStatusForegroundColor
+            }
         }
 
         if($s.EnableFileStatus -and $status.HasIndex) {

--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -164,7 +164,7 @@ function Write-GitStatus($status) {
         
         if ($s.EnableTagDisplay) {
             $tag = Get-Tag
-            if ($tag -ne "undefined") {
+            if ($tag) {
                 Write-Prompt "|$($tag)" -BackgroundColor $s.TagBackgroundColor -ForegroundColor $s.TagForegroundColor
             }
         }

--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -49,6 +49,10 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     BranchBehindAndAheadStatusSymbol            = [char]0x2195 # Up & Down arrow
     BranchBehindAndAheadStatusForegroundColor   = [ConsoleColor]::Yellow
     BranchBehindAndAheadStatusBackgroundColor   = $Host.UI.RawUI.BackgroundColor
+    
+    TagForegroundColor                        = [ConsoleColor]::DarkGray
+    TagForegroundBrightColor                  = [ConsoleColor]::Gray
+    TagBackgroundColor                        = $Host.UI.RawUI.BackgroundColor
 
     BeforeIndexText                             = ""
     BeforeIndexForegroundColor                  = [ConsoleColor]::DarkGreen
@@ -156,6 +160,11 @@ function Write-GitStatus($status) {
         }
 
         Write-Prompt (Format-BranchName($status.Branch)) -BackgroundColor $branchStatusBackgroundColor -ForegroundColor $branchStatusForegroundColor
+        
+        $tag = Get-Tag
+        if ($tag -ne "undefined") {
+            Write-Prompt "|$($tag)" -BackgroundColor $s.TagBackgroundColor -ForegroundColor $s.TagForegroundColor
+        }
         
         if ($branchStatusSymbol) {
             Write-Prompt  (" {0}" -f $branchStatusSymbol) -BackgroundColor $branchStatusBackgroundColor -ForegroundColor $branchStatusForegroundColor

--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -214,7 +214,7 @@ function InDisabledRepository {
 }
 
 function Get-Tag {
-    return git name-rev --tags --name-only $(git rev-parse HEAD)
+    return git tag --points-at HEAD
 }
 
 function Enable-GitColors {

--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -213,6 +213,10 @@ function InDisabledRepository {
     return $false
 }
 
+function Get-Tag {
+    return git name-rev --tags --name-only $(git rev-parse HEAD)
+}
+
 function Enable-GitColors {
     Write-Warning 'Enable-GitColors is Obsolete and will be removed in a future version of posh-git.'
 }

--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -270,7 +270,7 @@ function Get-SshAgent() {
 }
 
 # Attempt to guess Pageant's location
-function Guess-Pageant() {
+function Find-Pageant() {
     Write-Verbose "Pageant not in path. Trying to guess location."
     $gitSsh = $env:GIT_SSH
     if ($gitSsh -and (test-path $gitSsh)) {
@@ -281,7 +281,7 @@ function Guess-Pageant() {
 }
 
 # Attempt to guess $program's location. For ssh-agent/ssh-add.
-function Guess-Ssh($program = 'ssh-agent') {
+function Find-Ssh($program = 'ssh-agent') {
     Write-Verbose "$program not in path. Trying to guess location."
     $gitItem = Get-Command git -Erroraction SilentlyContinue | Get-Item
     if ($gitItem -eq $null) { Write-Warning 'git not in path'; return }
@@ -308,12 +308,12 @@ function Start-SshAgent([switch]$Quiet) {
     if ($env:GIT_SSH -imatch 'plink') {
         Write-Host "GIT_SSH set to $($env:GIT_SSH), using Pageant as SSH agent."
         $pageant = Get-Command pageant -TotalCount 1 -Erroraction SilentlyContinue
-        $pageant = if ($pageant) {$pageant} else {Guess-Pageant}
+        $pageant = if ($pageant) {$pageant} else {Find-Pageant}
         if (!$pageant) { Write-Warning "Could not find Pageant."; return }
         Start-Process -NoNewWindow $pageant
     } else {
         $sshAgent = Get-Command ssh-agent -TotalCount 1 -ErrorAction SilentlyContinue
-        $sshAgent = if ($sshAgent) {$sshAgent} else {Guess-Ssh('ssh-agent')}
+        $sshAgent = if ($sshAgent) {$sshAgent} else {Find-Ssh('ssh-agent')}
         if (!$sshAgent) { Write-Warning 'Could not find ssh-agent'; return }
 
         & $sshAgent | foreach {
@@ -335,7 +335,7 @@ function Get-SshPath($File = 'id_rsa')
 function Add-SshKey() {
     if ($env:GIT_SSH -imatch 'plink') {
         $pageant = Get-Command pageant -Erroraction SilentlyContinue | Select -First 1 -ExpandProperty Name
-        $pageant = if ($pageant) {$pageant} else {Guess-Pageant}
+        $pageant = if ($pageant) {$pageant} else {Find-Pageant}
         if (!$pageant) { Write-Warning 'Could not find Pageant'; return }
 
         if ($args.Count -eq 0) {
@@ -351,7 +351,7 @@ function Add-SshKey() {
         }
     } else {
         $sshAdd = Get-Command ssh-add -TotalCount 1 -ErrorAction SilentlyContinue
-        $sshAdd = if ($sshAdd) {$sshAdd} else {Guess-Ssh('ssh-add')}
+        $sshAdd = if ($sshAdd) {$sshAdd} else {Find-Ssh('ssh-add')}
         if (!$sshAdd) { Write-Warning 'Could not find ssh-add'; return }
 
         if ($args.Count -eq 0) {


### PR DESCRIPTION
This pull request tries to handle two situations (should they be separated?):
1. I use git as a work horse for my local development, but the code is committed to SVN in the end, thus I also use posh-svn. And I use tags in git to keep track of the points where I committed to SVN or updated from SVN. I figured it might be nice to see these tags on the posh-git command line.
2. If the current branch is ahead of the master or behind it would be nice to see just how far it is. So I added the numbers to the prompt.

Tag is displayed along the branch name similar to this:

```
[master|release-1.0]
```

The tag is colored in dark gray so that it does not stand out too much.
Might help in certain situations.

The behind/ahead by number is displayed as follows:
`[master ↓12]` behind by is always printer after the arrow
`[master 1↑]` ahead by is always printer before the arrow
`[master 1↕12]` This should be consistent (ahead-by arrow behind-by)

Please review my changes and please tell me, if this is a valuable contribution or not :)
