### PR TITLE
Don't use $pwd to get current location

### DIFF
--- a/profile.example.ps1
+++ b/profile.example.ps1
@@ -12,7 +12,7 @@ Import-Module .\posh-git
 function global:prompt {
     $realLASTEXITCODE = $LASTEXITCODE
 
-    Write-Host($pwd.ProviderPath) -nonewline
+    Write-Host $ExecutionContext.SessionState.Path.CurrentLocation.ProviderPath -nonewline
 
     Write-VcsStatus
 


### PR DESCRIPTION
`$pwd` is rewritable, so can be wrong. Use the same method PowerShell's (v3 and above) built-in prompt gets the location.

PowerShell 2 used `Get-Location` instead. I'm not sure why they changed, but using their current method seems to make more sense. This method works in PowerShell 2, as well.
