### PR TITLE
Start-SshAgent only in interactive session

### DIFF
--- a/profile.example.ps1
+++ b/profile.example.ps1
@@ -22,4 +22,6 @@ function global:prompt {
 
 Pop-Location
 
-Start-SshAgent -Quiet
+If ((Test-Path env:\SESSIONNAME) -And ($env:SESSIONNAME -eq "Console")) {
+  Start-SshAgent -Quiet
+}


### PR DESCRIPTION
First of all thanks for posh-git which makes working on Windows much more fun!

I had a problem using posh-git within a Vagrant box. After installing it and powering down the VM the next `vagrant up` hangs trying to connect through WinRM. I found the issue Parallels/vagrant-parallels#217 with a hint to posh-git.

So I have changed the `profile.example.ps1` script to start the SSH agent only if the PowerShell is run as interactive session.

Is it possible to put this in the script as default? Or does this break in other situations?
