### PR TITLE
Use Out-File to specify ascii encoding.

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -243,7 +243,7 @@ function Set-TempEnv($key, $value) {
         }
     } else {
         New-Item $path -Force -ItemType File > $null
-        $value > $path
+        $value | Out-File -FilePath $path -Encoding ascii -Force
     }
 }
 


### PR DESCRIPTION
By default the files are created with UTF-16 encoding. By specifying ascii, I can integrate `posh-git` and `keychain` this way:

https://github.com/lukebakken/dotfiles/blob/master/sh-init/bashrc#L41-L73