### PR TITLE
Cast the output of git --version as a String

### DIFF
--- a/CheckVersion.ps1
+++ b/CheckVersion.ps1
@@ -7,7 +7,7 @@ if (!(Get-Command git -TotalCount 1 -ErrorAction SilentlyContinue)) {
 }
 
 $requiredVersion = [Version]'1.7.2'
-if ((git --version 2> $null) -match '(?<ver>\d+(?:\.\d+)+)') {
+if ([String](git --version 2> $null) -match '(?<ver>\d+(?:\.\d+)+)') {
     $version = [Version]$Matches['ver']
 }
 if ($version -lt $requiredVersion) {


### PR DESCRIPTION
Prevents aliasing hub as git breaking our version check.

Fixes #248