### PR TITLE
Fix multiple Pageant keys handling

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -341,9 +341,8 @@ function Add-SshKey() {
         if ($args.Count -eq 0) {
             $keystring = ""
             $keyPath = Join-Path $Env:HOME ".ssh"
-            $keys = Get-ChildItem $keyPath/"*.ppk" | Select -ExpandProperty Name
-            foreach ( $key in $keys ) { $keystring += "`"$keyPath\$key`" " }
-            if ( $keystring ) { & $pageant "$keystring" }
+            $keys = Get-ChildItem $keyPath/"*.ppk" -ErrorAction SilentlyContinue | Select -ExpandProperty FullName
+            & $pageant $keys
         } else {
             foreach ($value in $args) {
                 & $pageant $value


### PR DESCRIPTION
Handling multiple pageant keys and keys with spaces in didn't work
properly, now fixed and functioning in a more powershell-y way.

Fixes #249 