### PR TITLE
Make module manifest v2 compatible

### DIFF
--- a/posh-git.psd1
+++ b/posh-git.psd1
@@ -1,7 +1,7 @@
 @{
 
 # Script module or binary module file associated with this manifest.
-RootModule = 'posh-git.psm1'
+ModuleToProcess = 'posh-git.psm1'
 
 # Version number of this module.
 ModuleVersion = '0.5.0.2015'


### PR DESCRIPTION
The RootModule key was renamed from ModuleToProcess in PowerShell v3
so is not compatible with PowerShell v2. ModuleToProcess still exists
as an alias, so use that instead.

See discussion in #242