### PR TITLE
Do not override user's Window Title, add to it instead.

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -138,7 +138,7 @@ function Write-GitStatus($status) {
             }
             $repoName = Split-Path -Leaf (Split-Path $status.GitDir)
             $prefix = if ($s.EnableWindowTitle -is [string]) { $s.EnableWindowTitle } else { '' }
-            $Host.UI.RawUI.WindowTitle = "$prefix$repoName [$($status.Branch)]"
+            $Host.UI.RawUI.WindowTitle = "$Global:PreviousWindowTitle ~ $prefix$repoName [$($status.Branch)]"
         }
     } elseif ( $Global:PreviousWindowTitle ) {
         $Host.UI.RawUI.WindowTitle = $Global:PreviousWindowTitle


### PR DESCRIPTION
Current script messes user's Window Title. This does not work for people like me who has a customized Window Title to see whether I am on an elevated prompt, or which user account I am using at the moment which differs depending on the environment I am on. This change simply maintains that information while updating Window Title with Posh-Git repo information.