### PR TITLE
Pass git-dir and work-tree to git command explicitly.

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -119,11 +119,12 @@ function Get-GitStatus($gitDir = (Get-GitDirectory)) {
 
         if($settings.EnableFileStatus -and !$(InDisabledRepository)) {
             dbg 'Getting status' $sw
-            $status = git -c color.status=false status --short --branch 2>$null
+            $workTree = $gitDir.Substring(0, $gitDir.Length - 4)
+	    $status = git --git-dir=$gitDir --work-tree=$workTree -c color.status=false status --short --branch 2>$null
             if($settings.EnableStashStatus) {
                 dbg 'Getting stash count' $sw
-                $stashCount = $null | git stash list 2>$null | measure-object | select -expand Count
-            }
+                $stashCount = $null | git --git-dir=$gitDir --work-tree=$workTree stash list 2>$null | measure-object | select -expand Count
+	     }
         } else {
             $status = @()
         }


### PR DESCRIPTION
Pass git-dir and work-tree to git command explicitly to allow creating functions like

```
 function Git-ShowStatus($dir = '.', $pad = 35) {
    Get-ChildItem $dir -Attributes Directory |
    Foreach-Object {
        $gitDir = $_.FullName+ '\.git'
        $dirName = $_.Name

        Write-Host $dirName.PadRight($pad) -NoNewLine
        Write-GitStatus $(Get-GitStatus $gitDir)
        Write-Host ''
    }
}
```

Out:

```
C:\Users\user\src> Git-ShowStatus
idea-settings                       [master ≡]
posh-git                            [status-work-tree]
```

Tested on `git version 1.9.5.msysgit.0` (Unfortunately can't check on newer version): `git stash` command ignore `git-dir` and `work-tree` params.
