### PR TITLE
Export Write-VcsStatus to help module autoloading

### DIFF
--- a/posh-git.psd1
+++ b/posh-git.psd1
@@ -25,6 +25,7 @@ PowerShellVersion = '2.0'
 FunctionsToExport = @('Invoke-NullCoalescing',
         'Write-GitStatus',
         'Write-Prompt',
+	'Write-VcsStatus',
         'Get-GitStatus',
         'Enable-GitColors',
         'Get-GitDirectory',


### PR DESCRIPTION
Hey, When we use your module in the profile on Cmder we try to import it as late as we can because it slows down the console startup. 

We can just call `Write-VcsStatus` when within a git repo but you don't export that command so we can't leave powershell to auto import it. This fixed that. 