### PR TITLE
Update the exports to include the repo status call for prompts.

### DIFF
--- a/posh-git.psd1
+++ b/posh-git.psd1
@@ -25,6 +25,7 @@ PowerShellVersion = '2.0'
 FunctionsToExport = @('Invoke-NullCoalescing',
         'Write-GitStatus',
         'Write-Prompt',
+        'Write-VcsStatus',
         'Get-GitStatus',
         'Enable-GitColors',
         'Get-GitDirectory',

--- a/posh-git.psm1
+++ b/posh-git.psm1
@@ -34,6 +34,7 @@ Export-ModuleMember `
         'Invoke-NullCoalescing',
         'Write-GitStatus',
         'Write-Prompt',
+        'Write-VcsStatus',
         'Get-GitStatus',
         'Enable-GitColors',
         'Get-GitDirectory',


### PR DESCRIPTION
Better commit than #283. Now with spaces. Should have known notepad wouldn't manage the edit. Mirror the changes in psm1 since I had the repo but I thought you only needed to put them in the psd1 if you had it.

Improves module Autoloading support in PS3.0+