### PR TITLE
Add 'push' to the list of commands to handle tab tag completion

### DIFF
--- a/GitTabExpansion.ps1
+++ b/GitTabExpansion.ps1
@@ -234,10 +234,11 @@ function GitTabExpansion($lastBlock) {
             gitRemoteBranches $matches['remote'] $matches['ref'] $matches['branch']
         }
 
-        # Handles git push remote <branch>
-        # Handles git pull remote <branch>
-        "^(?:push|pull).* (?:\S+) (?<branch>[^\s\:]*)$" {
-            gitBranches $matches['branch']
+        # Handles git push remote <ref>
+        # Handles git pull remote <ref>
+        "^(?:push|pull).* (?:\S+) (?<ref>[^\s\:]*)$" {
+            gitBranches $matches['ref']
+            gitTags $matches['ref']
         }
 
         # Handles git pull <remote>


### PR DESCRIPTION
Hi Keith, First time using posh-git. I'm not a powershell guy, but I was able to follow the code and make the minor modification. Hopefully, that's all that is needed. I added this because tab completion for tags exist in Git Bash when using "git push".