### PR TITLE
Fixed syntax error on setenv calls.

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -260,8 +260,8 @@ function Get-SshAgent() {
             if ($null -ne $sshAgentProcess) {
                 return $agentPid
             } else {
-                setenv 'SSH_AGENT_PID', $null
-                setenv 'SSH_AUTH_SOCK', $null
+                setenv 'SSH_AGENT_PID' $null
+                setenv 'SSH_AUTH_SOCK' $null
             }
         }
     }
@@ -373,8 +373,8 @@ function Stop-SshAgent() {
             Stop-Process $agentPid
         }
 
-        setenv 'SSH_AGENT_PID', $null
-        setenv 'SSH_AUTH_SOCK', $null
+        setenv 'SSH_AGENT_PID' $null
+        setenv 'SSH_AUTH_SOCK' $null
     }
 }
 


### PR DESCRIPTION
While trying to understand how posh-git handles environment variables, I found a bug when removing the environment variables. The function calls were separating parameters out with commas when they should be separated by spaces.