### PR TITLE
fix #298

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -228,7 +228,7 @@ function setenv($key, $value) {
 }
 
 function Get-TempEnv($key) {
-    $path = Join-Path ($Env:TEMP) ".ssh\$key.env"
+    $path = Get-TempEnvPath($key)
     if (Test-Path $path) {
         $value =  Get-Content $path
         [void][Environment]::SetEnvironmentVariable($key, $value, [EnvironmentVariableTarget]::Process)
@@ -236,7 +236,7 @@ function Get-TempEnv($key) {
 }
 
 function Set-TempEnv($key, $value) {
-    $path = Join-Path ([System.IO.Path]::GetTempPath()) ".ssh\$key.env"
+    $path = Get-TempEnvPath($key)
     if ($value -eq $null) {
         if (Test-Path $path) {
             Remove-Item $path
@@ -245,6 +245,11 @@ function Set-TempEnv($key, $value) {
         New-Item $path -Force -ItemType File > $null
         $value | Out-File -FilePath $path -Encoding ascii -Force
     }
+}
+
+function Get-TempEnvPath($key){
+    $path = Join-Path ([System.IO.Path]::GetTempPath()) ".ssh\$key.env"
+    return $path
 }
 
 # Retrieve the current SSH agent PID (or zero). Can be used to determine if there

--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -236,7 +236,7 @@ function Get-TempEnv($key) {
 }
 
 function Set-TempEnv($key, $value) {
-    $path = Join-Path ($Env:TEMP) ".ssh\$key.env"
+    $path = Join-Path ([System.IO.Path]::GetTempPath()) ".ssh\$key.env"
     if ($value -eq $null) {
         if (Test-Path $path) {
             Remove-Item $path


### PR DESCRIPTION
use `System.IO.Path]::GetTempPath()` instead of `$env:temp` to get rid of 8.3 filename problem