### PR TITLE
Save current working branch to variable

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -160,6 +160,7 @@ function Write-GitStatus($status) {
             $branchStatusSymbol          = "?"
         }
 
+        $Global:GitBranch = $status.Branch
         Write-Prompt (Format-BranchName($status.Branch)) -BackgroundColor $branchStatusBackgroundColor -ForegroundColor $branchStatusForegroundColor
 
         if ($branchStatusSymbol) {


### PR DESCRIPTION
This will save the current branch to a variable, useful for scripting purposes.
This will also enable commands like `git push -u origin $GitBranch`