### PR TITLE
Removed error thrown by symbolic-ref and describe

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -46,7 +46,7 @@ function Get-GitBranch($gitDir = $(Get-GitDirectory), [Diagnostics.Stopwatch]$sw
             }
 
             $b = Invoke-NullCoalescing `
-                { dbg 'Trying symbolic-ref' $sw; git symbolic-ref HEAD 2>$null } `
+                { dbg 'Trying symbolic-ref' $sw; git symbolic-ref HEAD -q 2>$null } `
                 { '({0})' -f (Invoke-NullCoalescing `
                     {
                         dbg 'Trying describe' $sw
@@ -54,7 +54,7 @@ function Get-GitBranch($gitDir = $(Get-GitDirectory), [Diagnostics.Stopwatch]$sw
                             'contains' { git describe --contains HEAD 2>$null }
                             'branch' { git describe --contains --all HEAD 2>$null }
                             'describe' { git describe HEAD 2>$null }
-                            default { git describe --tags --exact-match HEAD 2>$null }
+                            default { git tag --points-at HEAD 2>$null }
                         }
                     } `
                     {


### PR DESCRIPTION
git describe can be replaced by tag --points-at <commitish>. Other than symbolic-ref, describe does not have a --quiet switch, thus always adds to $error in case of a detached head with no tag pointing to that commit. Using tag --point-at HEAD will return a tag if one is found but not throw an error when there is none.

It is a bug which was reported through a user of [oh-my-posh](https://github.com/JanJoris/oh-my-posh/issues/27).