### PR TITLE
Remove reference to EnvironmentVariableTarget.

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -223,7 +223,7 @@ function Get-AliasPattern($exe) {
 }
 
 function setenv($key, $value) {
-    [void][Environment]::SetEnvironmentVariable($key, $value, [EnvironmentVariableTarget]::Process)
+    [void][Environment]::SetEnvironmentVariable($key, $value)
     Set-TempEnv $key $value
 }
 
@@ -231,7 +231,7 @@ function Get-TempEnv($key) {
     $path = Get-TempEnvPath($key)
     if (Test-Path $path) {
         $value =  Get-Content $path
-        [void][Environment]::SetEnvironmentVariable($key, $value, [EnvironmentVariableTarget]::Process)
+        [void][Environment]::SetEnvironmentVariable($key, $value)
     }
 }
 


### PR DESCRIPTION
Fix #317.  This type is not defined in .NET Core 1.0/1.1.  Even though it is coming back in .NET Core 1.2, our use isn't necessary because the SetEnvironmentVariable(string name, string value) overload defaults to setting the variable for the current process even on Linux/macOS.  See https://docs.microsoft.com/en-us/dotnet/core/api/system.environment#System_Environment_SetEnvironmentVariable_System_String_System_String_