### PR TITLE
Upstream Gone

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -39,6 +39,10 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     BranchForegroundColor                       = [ConsoleColor]::Cyan
     BranchBackgroundColor                       = $Host.UI.RawUI.BackgroundColor
 
+    BranchGoneStatusSymbol                      = [char]0x00D7 # × Multiplication sign
+    BranchGoneStatusForegroundColor             = [ConsoleColor]::DarkCyan
+    BranchGoneStatusBackgroundColor             = $Host.UI.RawUI.BackgroundColor
+
     BranchIdenticalStatusToSymbol               = [char]0x2261 # ≡ Three horizontal lines
     BranchIdenticalStatusToForegroundColor      = [ConsoleColor]::Cyan
     BranchIdenticalStatusToBackgroundColor      = $Host.UI.RawUI.BackgroundColor
@@ -143,6 +147,11 @@ function Write-GitStatus($status) {
 
         if (!$status.Upstream) {
             $branchStatusSymbol          = $s.BranchUntrackedSymbol
+        } elseif ($status.UpstreamGone -eq $true) {
+            # Upstream branch is gone
+            $branchStatusSymbol          = $s.BranchGoneStatusSymbol
+            $branchStatusBackgroundColor = $s.BranchGoneStatusBackgroundColor
+            $branchStatusForegroundColor = $s.BranchGoneStatusForegroundColor
         } elseif ($status.BehindBy -eq 0 -and $status.AheadBy -eq 0) {
             # We are aligned with remote
             $branchStatusSymbol          = $s.BranchIdenticalStatusToSymbol

--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -1,4 +1,4 @@
-# Inspired by Mark Embling
+﻿# Inspired by Mark Embling
 # http://www.markembling.info/view/my-ideal-powershell-prompt-with-git-integration
 
 $global:GitPromptSettings = New-Object PSObject -Property @{
@@ -39,19 +39,19 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
     BranchForegroundColor                       = [ConsoleColor]::Cyan
     BranchBackgroundColor                       = $Host.UI.RawUI.BackgroundColor
 
-    BranchIdenticalStatusToSymbol               = [char]0x2261 # Three horizontal lines
+    BranchIdenticalStatusToSymbol               = [char]0x2261 # ≡ Three horizontal lines
     BranchIdenticalStatusToForegroundColor      = [ConsoleColor]::Cyan
     BranchIdenticalStatusToBackgroundColor      = $Host.UI.RawUI.BackgroundColor
 
-    BranchAheadStatusSymbol                     = [char]0x2191 # Up arrow
+    BranchAheadStatusSymbol                     = [char]0x2191 # ↑ Up arrow
     BranchAheadStatusForegroundColor            = [ConsoleColor]::Green
     BranchAheadStatusBackgroundColor            = $Host.UI.RawUI.BackgroundColor
 
-    BranchBehindStatusSymbol                    = [char]0x2193 # Down arrow
+    BranchBehindStatusSymbol                    = [char]0x2193 # ↓ Down arrow
     BranchBehindStatusForegroundColor           = [ConsoleColor]::Red
     BranchBehindStatusBackgroundColor           = $Host.UI.RawUI.BackgroundColor
 
-    BranchBehindAndAheadStatusSymbol            = [char]0x2195 # Up & Down arrow
+    BranchBehindAndAheadStatusSymbol            = [char]0x2195 # ↕ Up & Down arrow
     BranchBehindAndAheadStatusForegroundColor   = [ConsoleColor]::Yellow
     BranchBehindAndAheadStatusBackgroundColor   = $Host.UI.RawUI.BackgroundColor
 

--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -132,6 +132,7 @@ function Get-GitStatus($gitDir = (Get-GitDirectory)) {
         $branch = $null
         $aheadBy = 0
         $behindBy = 0
+        $gone = $false
         $indexAdded = New-Object System.Collections.Generic.List[string]
         $indexModified = New-Object System.Collections.Generic.List[string]
         $indexDeleted = New-Object System.Collections.Generic.List[string]
@@ -177,13 +178,14 @@ function Get-GitStatus($gitDir = (Get-GitDirectory)) {
                 continue
             }
 
-            '^## (?<branch>\S+?)(?:\.\.\.(?<upstream>\S+))?(?: \[(?:ahead (?<ahead>\d+))?(?:, )?(?:behind (?<behind>\d+))?\])?$' {
+            '^## (?<branch>\S+?)(?:\.\.\.(?<upstream>\S+))?(?: \[(?:ahead (?<ahead>\d+))?(?:, )?(?:behind (?<behind>\d+))?(?<gone>gone)?\])?$' {
                 if ($sw) { dbg "Status: $_" $sw }
 
                 $branch = $matches['branch']
                 $upstream = $matches['upstream']
                 $aheadBy = [int]$matches['ahead']
                 $behindBy = [int]$matches['behind']
+                $gone = [string]$matches['gone'] -eq 'gone'
                 continue
             }
 
@@ -224,6 +226,7 @@ function Get-GitStatus($gitDir = (Get-GitDirectory)) {
             Branch          = $branch
             AheadBy         = $aheadBy
             BehindBy        = $behindBy
+            UpstreamGone    = $gone
             Upstream        = $upstream
             HasIndex        = [bool]$index
             Index           = $index

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ By default, the status summary has the following format:
   * ↑ = The local branch is ahead of the remote branch, a 'git push' is required to update the remote branch (`BranchAheadStatus`)
   * ↓ = The local branch is behind the remote branch, a 'git pull' is required to update the local branch (`BranchBehindStatus`)
   * ↕ = The local branch is both ahead and behind the remote branch, a rebase of the local branch is required before pushing local changes to the remote branch (`BranchBehindAndAheadStatus`)
+  * × = The local branch is tracking a branch that is gone from the remote (`BranchGoneStatus')
 * ABCD represent the index; ` | ` (`DelimText`); EFGH represent the working directory
  * `+` = Added files
  * `~` = Modified files

--- a/README.md
+++ b/README.md
@@ -229,9 +229,9 @@ By default, the status summary has the following format:
  * Yellow means the branch is both ahead of and behind its remote
 * S represents the branch status in relation to remote (tracked origin) branch. Note: This information reflects the state of the remote tracked branch after the last `git fetch/pull` of the remote.
   * ≡ = The local branch in at the same commit level as the remote branch (`BranchIdenticalStatus`)
-  * ↑ = The local branch is ahead of the remote branch, a 'git push' is required to update the remote branch (`BranchAheadStatus`)
-  * ↓ = The local branch is behind the remote branch, a 'git pull' is required to update the local branch (`BranchBehindStatus`)
-  * ↕ = The local branch is both ahead and behind the remote branch, a rebase of the local branch is required before pushing local changes to the remote branch (`BranchBehindAndAheadStatus`)
+  * ↑ = The local branch is ahead of the remote branch; a 'git push' is required to update the remote branch (`BranchAheadStatus`)
+  * ↓ = The local branch is behind the remote branch; a 'git pull' is required to update the local branch (`BranchBehindStatus`)
+  * ↕ = The local branch is both ahead and behind the remote branch; a rebase of the local branch is required before pushing local changes to the remote branch (`BranchBehindAndAheadStatus`)
   * × = The local branch is tracking a branch that is gone from the remote (`BranchGoneStatus')
 * ABCD represent the index; ` | ` (`DelimText`); EFGH represent the working directory
  * `+` = Added files


### PR DESCRIPTION
Just stumbled on this edge case. To reproduce (assuming `origin/gone` doesn't exist):

```
> git branch gone
> git config branch.gone.remote origin
> git config branch.gone.merge refs/heads/gone
> git checkout gone
Switched to branch 'gone'
Your branch is based on 'origin/gone', but the upstream is gone.
  (use "git branch --unset-upstream" to fixup)
```

I had originally thought to use ✘ for the symbol, but font support seems limited. I settled on either × or ∙ . Thoughts?

<img alt="powershell_2016-12-29_10-26-38" src="https://cloud.githubusercontent.com/assets/133987/21549953/90c71b48-cdbb-11e6-89ec-5aaf53d57b80.png">

----------

Also, semicolons are :cool: