### PR TITLE
Fix Get-SshPath Pester tests on Linux.

### DIFF
--- a/test/Ssh.Tests.ps1
+++ b/test/Ssh.Tests.ps1
@@ -2,11 +2,14 @@
 
 Describe 'SSH Function Tests' {
     Context 'Get-SshPath Tests' {
+        BeforeAll {
+            $sepChar = [System.IO.Path]::DirectorySeparatorChar
+        }
         It 'Returns the correct default path' {
-            Get-SshPath | Should BeExactly $Home\.ssh\id_rsa
+            Get-SshPath | Should BeExactly "${Home}${sepChar}.ssh${sepChar}id_rsa"
         }
         It 'Returns the correct path given a filename' {
-            Get-SshPath mykey | Should BeExactly $Home\.ssh\mykey
+            Get-SshPath mykey | Should BeExactly "${Home}${sepChar}.ssh${sepChar}mykey"
         }
     }
 }


### PR DESCRIPTION
Tested on Ubuntu 16.04.