### PR TITLE
Add Pester test for module manifest.

### DIFF
--- a/test/ModuleManifest.Tests.ps1
+++ b/test/ModuleManifest.Tests.ps1
@@ -1,0 +1,11 @@
+
+Describe 'Module Manifest Tests' {
+    BeforeAll {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
+        $moduleManifestPath = "$PSScriptRoot\..\posh-git.psd1"
+    }
+    It 'Passes Test-ModuleManifest' {
+        Test-ModuleManifest -Path $moduleManifestPath
+        $? | Should Be $true
+    }
+}

--- a/test/ModuleManifest.Tests.ps1
+++ b/test/ModuleManifest.Tests.ps1
@@ -5,7 +5,7 @@ Describe 'Module Manifest Tests' {
         $moduleManifestPath = "$PSScriptRoot\..\posh-git.psd1"
     }
     It 'Passes Test-ModuleManifest' {
-        Test-ModuleManifest -Path $moduleManifestPath
+        Test-ModuleManifest -Path $moduleManifestPath | Should Not BeNullOrEmpty
         $? | Should Be $true
     }
 }

--- a/test/Ssh.Tests.ps1
+++ b/test/Ssh.Tests.ps1
@@ -3,6 +3,7 @@
 Describe 'SSH Function Tests' {
     Context 'Get-SshPath Tests' {
         BeforeAll {
+            [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
             $sepChar = [System.IO.Path]::DirectorySeparatorChar
         }
         It 'Returns the correct default path' {


### PR DESCRIPTION
Clean up a PSSA lint warning in the Ssh.Tests.ps1 file.

I should mention that if you open the posh-git root folder in VSCode, you can run the Pester tests by typing <kbd>Ctrl+P</kbd> and then `Task Test` and press <kbd>Enter</kbd>. And you can view the PSScriptAnalyzer (linter) errors and warnings by pressing <kbd>Ctrl+Shift+M</kbd>.  At some point, I'll put this in a CONTRIBUTING.md doc.