### PR TITLE
Fix PR 319 to work on PS v2/v3.

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -207,17 +207,33 @@ function Get-GitStatus($gitDir = (Get-GitDirectory)) {
 
         $indexPaths = @(GetUniquePaths $indexAdded,$indexModified,$indexDeleted,$indexUnmerged)
         $workingPaths = @(GetUniquePaths $filesAdded,$filesModified,$filesDeleted,$filesUnmerged)
-        $index = Write-Output -NoEnumerate $indexPaths |
-            Add-Member -PassThru NoteProperty Added    $indexAdded.ToArray() |
-            Add-Member -PassThru NoteProperty Modified $indexModified.ToArray() |
-            Add-Member -PassThru NoteProperty Deleted  $indexDeleted.ToArray() |
-            Add-Member -PassThru NoteProperty Unmerged $indexUnmerged.ToArray()
 
-        $working = Write-Output -NoEnumerate $workingPaths|
-            Add-Member -PassThru NoteProperty Added    $filesAdded |
-            Add-Member -PassThru NoteProperty Modified $filesModified.ToArray() |
-            Add-Member -PassThru NoteProperty Deleted  $filesDeleted.ToArray() |
-            Add-Member -PassThru NoteProperty Unmerged $filesUnmerged.ToArray()
+        # PowerShell v2 and v3 Write-Output doesn't have a NoEnumerate parameter
+        if ($PSVersionTable.PSVersion.Major -le 3) {
+            $index = New-Object PSObject @(,@($indexPaths | Where-Object { $_ })) |
+                Add-Member -PassThru NoteProperty Added    $indexAdded |
+                Add-Member -PassThru NoteProperty Modified $indexModified |
+                Add-Member -PassThru NoteProperty Deleted  $indexDeleted |
+                Add-Member -PassThru NoteProperty Unmerged $indexUnmerged
+            $working = New-Object PSObject @(,@($workingPaths | Where-Object { $_ })) |
+                Add-Member -PassThru NoteProperty Added    $filesAdded |
+                Add-Member -PassThru NoteProperty Modified $filesModified |
+                Add-Member -PassThru NoteProperty Deleted  $filesDeleted |
+                Add-Member -PassThru NoteProperty Unmerged $filesUnmerged
+        }
+        else {
+            $index = Write-Output -NoEnumerate $indexPaths |
+                Add-Member -PassThru NoteProperty Added    $indexAdded.ToArray() |
+                Add-Member -PassThru NoteProperty Modified $indexModified.ToArray() |
+                Add-Member -PassThru NoteProperty Deleted  $indexDeleted.ToArray() |
+                Add-Member -PassThru NoteProperty Unmerged $indexUnmerged.ToArray()
+
+            $working = Write-Output -NoEnumerate $workingPaths|
+                Add-Member -PassThru NoteProperty Added    $filesAdded |
+                Add-Member -PassThru NoteProperty Modified $filesModified.ToArray() |
+                Add-Member -PassThru NoteProperty Deleted  $filesDeleted.ToArray() |
+                Add-Member -PassThru NoteProperty Unmerged $filesUnmerged.ToArray()
+        }
 
         $result = New-Object PSObject -Property @{
             GitDir          = $gitDir


### PR DESCRIPTION
Verified that v4 has the -NoEnumerate parameter on Write-Output.  Azure VMs come in handy.  BTW I removed the Select -uniq from the old version of the code since the GetUniquePaths function handles this.

cc @lzybkr