### PR TITLE
Fix that module can be found by not imported?

### DIFF
--- a/profile.example.ps1
+++ b/profile.example.ps1
@@ -1,6 +1,6 @@
 # Import the posh-git module, first via installed posh-git module.
 # If the module isn't installed, then attempt to load it from the cloned posh-git Git repo.
-$poshGitModule = Get-Module posh-git -ListAvailable
+$poshGitModule = Get-Module posh-git -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
 if ($poshGitModule) {
     $poshGitModule | Import-Module
 }

--- a/profile.example.ps1
+++ b/profile.example.ps1
@@ -1,7 +1,8 @@
 # Import the posh-git module, first via installed posh-git module.
 # If the module isn't installed, then attempt to load it from the cloned posh-git Git repo.
-if (Get-Module posh-git -ListAvailable) {
-    Import-Module posh-git
+$poshGitModule = Get-Module posh-git -ListAvailable
+if ($poshGitModule) {
+    $poshGitModule | Import-Module
 }
 elseif (Test-Path -LiteralPath $PSScriptRoot\posh-git.psd1) {
     Import-Module $PSScriptRoot\posh-git.psd1


### PR DESCRIPTION
Fix #350 and https://github.com/dahlbyk/posh-git/pull/322#issuecomment-269663743, I think?

I can't explain why `Get-Module posh-git` would find a module but `Import-Module posh-git` wouldn't find the same. I'm wondering if the `Get-Module` result should be filtered through `Select-Object -First 1` and maybe sorted by version or something?