### PR TITLE
Renamed prompt workaround

### DIFF
--- a/posh-git.psm1
+++ b/posh-git.psm1
@@ -37,6 +37,12 @@ else {
 $poshGitPromptScriptBlock = $null
 
 $currentPromptDef = if ($funcInfo = Get-Command prompt -ErrorAction SilentlyContinue) { $funcInfo.Definition }
+
+# HACK: If prompt is missing, create a global one we can overwrite with Set-Item
+if (!$currentPromptDef) {
+    function global:prompt { ' ' }
+}
+
 if (!$currentPromptDef -or ($currentPromptDef -eq $defaultPromptDef)) {
     # Have to use [scriptblock]::Create() to get debugger detection to work in PS v2
     $poshGitPromptScriptBlock = [scriptblock]::Create(@'


### PR DESCRIPTION
Fix #355, regression from #349.

The [Chocolatey install](https://github.com/dahlbyk/posh-git/blob/f77a781967eaba8d0b2866425e34a6e581906da6/chocolatey/tools/chocolateyInstall.ps1) writes some extra stuff to `$PROFILE` to try to preserve an existing `prompt` function. I'm not really a fan of that behavior, but until we can try to clean that up we need to make sure that we're not broken if `prompt` doesn't exist (presumably because it has been renamed).

So if we find that `prompt` doesn't exist, we create a new global one that we promptly override.