### PR TITLE
Chocolatey Simplification + Uninstall

### DIFF
--- a/chocolatey/packAndLocalInstall.ps1
+++ b/chocolatey/packAndLocalInstall.ps1
@@ -3,13 +3,14 @@ pushd $PSScriptRoot
 
 $nuspec = [xml](Get-Content poshgit.nuspec)
 $version = $nuspec.package.metadata.version
-
+$tag = "v$version"
 
 if ($Force) {
-    git push -f $Remote "HEAD:refs/tags/v$version"
+    git tag -f $tag
+    git push -f $Remote $tag
 }
-elseif (!$(git ls-remote $Remote "v$version")) {
-    Write-Warning "'$Remote/v$version' not found! Use -Force to create tag at HEAD."
+elseif (!$(git ls-remote $Remote $tag)) {
+    Write-Warning "'$Remote/$tag' not found! Use -Force to create tag at HEAD."
     return
 }
 

--- a/chocolatey/packAndLocalInstall.ps1
+++ b/chocolatey/packAndLocalInstall.ps1
@@ -1,0 +1,4 @@
+pushd $PSScriptRoot
+choco pack poshgit.nuspec
+choco install -f -y poshgit -pre -s .
+popd

--- a/chocolatey/packAndLocalInstall.ps1
+++ b/chocolatey/packAndLocalInstall.ps1
@@ -1,4 +1,9 @@
 pushd $PSScriptRoot
+
+$nuspec = [xml](Get-Content poshgit.nuspec)
+$version = $nuspec.package.metadata.version
+
 choco pack poshgit.nuspec
-choco install -f -y poshgit -pre -s .
+choco install -f -y poshgit -pre --version=$version -s .
+
 popd

--- a/chocolatey/packAndLocalInstall.ps1
+++ b/chocolatey/packAndLocalInstall.ps1
@@ -4,16 +4,13 @@ pushd $PSScriptRoot
 $nuspec = [xml](Get-Content poshgit.nuspec)
 $version = $nuspec.package.metadata.version
 
-$ErrorActionPreference = 'Stop'
-$remoteRef = $(git ls-remote $Remote "v$version")
-if (!$remoteRef) {
-    if ($Force) {
-        git push -f $Remote "HEAD:refs/tags/v$version"
-    }
-    else {
-        Write-Warning "'$Remote/v$version' not found! Use -Force to create tag at HEAD."
-        return
-    }
+
+if ($Force) {
+    git push -f $Remote "HEAD:refs/tags/v$version"
+}
+elseif (!$(git ls-remote $Remote "v$version")) {
+    Write-Warning "'$Remote/v$version' not found! Use -Force to create tag at HEAD."
+    return
 }
 
 choco pack poshgit.nuspec

--- a/chocolatey/packAndLocalInstall.ps1
+++ b/chocolatey/packAndLocalInstall.ps1
@@ -3,6 +3,9 @@ pushd $PSScriptRoot
 $nuspec = [xml](Get-Content poshgit.nuspec)
 $version = $nuspec.package.metadata.version
 
+$ErrorActionPreference = 'Stop'
+git rev-parse "v$version" 2>$null
+
 choco pack poshgit.nuspec
 choco install -f -y poshgit -pre --version=$version -s .
 

--- a/chocolatey/packAndLocalInstall.ps1
+++ b/chocolatey/packAndLocalInstall.ps1
@@ -1,10 +1,20 @@
+param ($Remote = 'origin', [switch]$Force)
 pushd $PSScriptRoot
 
 $nuspec = [xml](Get-Content poshgit.nuspec)
 $version = $nuspec.package.metadata.version
 
 $ErrorActionPreference = 'Stop'
-git rev-parse "v$version" 2>$null
+$remoteRef = $(git ls-remote $Remote "v$version")
+if (!$remoteRef) {
+    if ($Force) {
+        git push -f $Remote "HEAD:refs/tags/v$version"
+    }
+    else {
+        Write-Warning "'$Remote/v$version' not found! Use -Force to create tag at HEAD."
+        return
+    }
+}
 
 choco pack poshgit.nuspec
 choco install -f -y poshgit -pre --version=$version -s .

--- a/chocolatey/poshgit.nuspec
+++ b/chocolatey/poshgit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>poshgit</id>
     <title>posh-git</title>
-    <version>0.7.0-pre4</version>
+    <version>0.7.0-pre5</version>
     <authors>Keith Dahlby, Mark Embling, Jeremy Skinner</authors>
     <owners>Keith Dahlby</owners>
     <description>### posh-git

--- a/chocolatey/poshgit.nuspec
+++ b/chocolatey/poshgit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>poshgit</id>
     <title>posh-git</title>
-    <version>0.7.0-pre1</version>
+    <version>0.7.0-pre2</version>
     <authors>Keith Dahlby, Mark Embling, Jeremy Skinner</authors>
     <owners>Keith Dahlby</owners>
     <description>### posh-git

--- a/chocolatey/poshgit.nuspec
+++ b/chocolatey/poshgit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>poshgit</id>
     <title>posh-git</title>
-    <version>0.6.1.20160330</version>
+    <version>0.7.0-pre1</version>
     <authors>Keith Dahlby, Mark Embling, Jeremy Skinner</authors>
     <owners>Keith Dahlby</owners>
     <description>### posh-git

--- a/chocolatey/poshgit.nuspec
+++ b/chocolatey/poshgit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>poshgit</id>
     <title>posh-git</title>
-    <version>0.7.0-pre3</version>
+    <version>0.7.0-pre4</version>
     <authors>Keith Dahlby, Mark Embling, Jeremy Skinner</authors>
     <owners>Keith Dahlby</owners>
     <description>### posh-git

--- a/chocolatey/poshgit.nuspec
+++ b/chocolatey/poshgit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>poshgit</id>
     <title>posh-git</title>
-    <version>0.7.0-pre2</version>
+    <version>0.7.0-pre3</version>
     <authors>Keith Dahlby, Mark Embling, Jeremy Skinner</authors>
     <owners>Keith Dahlby</owners>
     <description>### posh-git

--- a/chocolatey/tools/chocolateyInstall.ps1
+++ b/chocolatey/tools/chocolateyInstall.ps1
@@ -1,9 +1,5 @@
 ﻿try {
     $binRoot = Get-BinRoot
-
-    $oldPromptOverride = "if(Test-Path Function:\Prompt) {Rename-Item Function:\Prompt PrePoshGitPrompt -Force}"
-    $newPromptOverride = "function Prompt() {if(Test-Path Function:\PrePoshGitPrompt){++`$global:poshScope; New-Item function:\script:Write-host -value `"param([object] ```$object, ```$backgroundColor, ```$foregroundColor, [switch] ```$nonewline) `" -Force | Out-Null;`$private:p = PrePoshGitPrompt; if(--`$global:poshScope -eq 0) {Remove-Item function:\Write-Host -Force}}PoshGitPrompt}"
-
     $poshgitPath = join-path $binRoot 'poshgit'
 
     try {
@@ -25,6 +21,8 @@
         #If old profile exists replace with new one and make sure prompt preservation function is on top
         $pgitExample = "$pgitDir\profile.example.ps1"
         foreach($line in $oldProfile) {
+            if ($line -like '*PoshGitPrompt*') { continue; }
+
             if($line.ToLower().Contains("$poshgitPath".ToLower())) {
                 $line = ". '$pgitExample'"
             }

--- a/chocolatey/tools/chocolateyInstall.ps1
+++ b/chocolatey/tools/chocolateyInstall.ps1
@@ -14,7 +14,7 @@
     $version = "v$Env:chocolateyPackageVersion"
     if ($version -eq 'v') { $version = 'master' }
     $poshGitInstall = if ($env:poshGit ) { $env:poshGit } else { "https://github.com/dahlbyk/posh-git/zipball/$version" }
-    Install-ChocolateyZipPackage 'poshgit' $poshGitInstall $poshgitPath
+    $zip = Install-ChocolateyZipPackage 'poshgit' $poshGitInstall $poshgitPath
     $currentVersionPath = Get-ChildItem "$poshgitPath\*posh-git*\" | Sort-Object -Property LastWriteTime | Select-Object -Last 1
 
     if(Test-Path $PROFILE) {

--- a/chocolatey/tools/chocolateyInstall.ps1
+++ b/chocolatey/tools/chocolateyInstall.ps1
@@ -1,8 +1,4 @@
-﻿function Insert-Script([ref]$originalScript, $script) {
-    if(!($originalScript.Value -Contains $script)) { $originalScript.Value += $script }
-}
-
-try {
+﻿try {
     $binRoot = Get-BinRoot
 
     $oldPromptOverride = "if(Test-Path Function:\Prompt) {Rename-Item Function:\Prompt PrePoshGitPrompt -Force}"
@@ -16,7 +12,7 @@ try {
         remove-item $poshgitPath -recurse -force
       }
     } catch {
-      Write-Host 'Could not remove poshgit folder'
+      Write-Host "Could not remove `'$poshgitPath`'"
     }
 
     $poshGitInstall = if($env:poshGit -ne $null){ $env:poshGit } else {'https://github.com/dahlbyk/posh-git/zipball/master'}
@@ -30,26 +26,15 @@ try {
         $pgitExample = "$pgitDir\profile.example.ps1"
         foreach($line in $oldProfile) {
             if($line.ToLower().Contains("$poshgitPath".ToLower())) {
-                Insert-Script ([REF]$newProfile) $oldPromptOverride
                 $line = ". '$pgitExample'"
             }
             if($line.Trim().Length -gt 0) {  $newProfile += $line }
         }
-        # Save any previous Prompt logic
-        Insert-Script ([REF]$newProfile) $oldPromptOverride
         Set-Content -path $profile -value $newProfile -Force
     }
 
     $installer = Join-Path $pgitDir 'install.ps1'
     & $installer
-
-    $newProfile = @(Get-Content $PROFILE)
-    Insert-Script ([REF]$newProfile) "Rename-Item Function:\Prompt PoshGitPrompt -Force"
-
-    # function that will run previous prompt logic and then the poshgit logic
-    # all output from previous prompts will be swallowed
-    Insert-Script ([REF]$newProfile) $newPromptOverride
-    Set-Content -path $profile  -value $newProfile -Force
 } catch {
   try {
     if($oldProfile){ Set-Content -path $PROFILE -value $oldProfile -Force }

--- a/chocolatey/tools/chocolateyInstall.ps1
+++ b/chocolatey/tools/chocolateyInstall.ps1
@@ -24,6 +24,9 @@
             if($line -like '. *posh-git*profile.example.ps1*') {
                 $line = ". '$currentVersionPath\profile.example.ps1'"
             }
+            if($line -like 'Import-Module *\src\posh-git.psd1*') {
+                $line = "Import-Module '$currentVersionPath\src\posh-git.psd1'"
+            }
             $newProfile += $line
         }
         Set-Content -path $profile -value $newProfile -Force

--- a/chocolatey/tools/chocolateyInstall.ps1
+++ b/chocolatey/tools/chocolateyInstall.ps1
@@ -11,7 +11,9 @@
       Write-Host "Could not remove `'$poshgitPath`'"
     }
 
-    $poshGitInstall = if ($env:poshGit ) { $env:poshGit } else { 'https://github.com/dahlbyk/posh-git/zipball/master' }
+    $version = "v$Env:chocolateyPackageVersion"
+    if ($version -eq 'v') { $version = 'master' }
+    $poshGitInstall = if ($env:poshGit ) { $env:poshGit } else { "https://github.com/dahlbyk/posh-git/zipball/$version" }
     Install-ChocolateyZipPackage 'poshgit' $poshGitInstall $poshgitPath
     $currentVersionPath = Get-ChildItem "$poshgitPath\*posh-git*\" | Sort-Object -Property LastWriteTime | Select-Object -Last 1
 

--- a/chocolatey/tools/chocolateyInstall.ps1
+++ b/chocolatey/tools/chocolateyInstall.ps1
@@ -17,6 +17,10 @@
 
     if(Test-Path $PROFILE) {
         $oldProfile = @(Get-Content $PROFILE)
+
+        . $currentVersionPath\src\Utils.ps1
+        $oldProfileEncoding = Get-FileEncoding $PROFILE
+
         $newProfile = @()
         foreach($line in $oldProfile) {
             if ($line -like '*PoshGitPrompt*') { continue; }
@@ -29,14 +33,14 @@
             }
             $newProfile += $line
         }
-        Set-Content -path $profile -value $newProfile -Force
+        Set-Content -path $profile -value $newProfile -Force -Encoding $oldProfileEncoding
     }
 
     $installer = Join-Path $currentVersionPath 'install.ps1'
     & $installer
 } catch {
   try {
-    if($oldProfile){ Set-Content -path $PROFILE -value $oldProfile -Force }
+    if($oldProfile){ Set-Content -path $PROFILE -value $oldProfile -Force -Encoding $oldProfileEncoding }
   }
   catch {}
   throw

--- a/chocolatey/tools/chocolateyInstall.ps1
+++ b/chocolatey/tools/chocolateyInstall.ps1
@@ -13,25 +13,23 @@
 
     $poshGitInstall = if ($env:poshGit ) { $env:poshGit } else { 'https://github.com/dahlbyk/posh-git/zipball/master' }
     Install-ChocolateyZipPackage 'poshgit' $poshGitInstall $poshgitPath
-    $pgitDir = Dir "$poshgitPath\*posh-git*\" | Sort-Object -Property LastWriteTime | Select -Last 1
+    $currentVersionPath = Get-ChildItem "$poshgitPath\*posh-git*\" | Sort-Object -Property LastWriteTime | Select-Object -Last 1
 
     if(Test-Path $PROFILE) {
         $oldProfile = @(Get-Content $PROFILE)
         $newProfile = @()
-        #If old profile exists replace with new one and make sure prompt preservation function is on top
-        $pgitExample = "$pgitDir\profile.example.ps1"
         foreach($line in $oldProfile) {
             if ($line -like '*PoshGitPrompt*') { continue; }
 
-            if($line.ToLower().Contains("$poshgitPath".ToLower())) {
-                $line = ". '$pgitExample'"
+            if($line -like '. *posh-git*profile.example.ps1*') {
+                $line = ". '$currentVersionPath\profile.example.ps1'"
             }
             $newProfile += $line
         }
         Set-Content -path $profile -value $newProfile -Force
     }
 
-    $installer = Join-Path $pgitDir 'install.ps1'
+    $installer = Join-Path $currentVersionPath 'install.ps1'
     & $installer
 } catch {
   try {

--- a/chocolatey/tools/chocolateyInstall.ps1
+++ b/chocolatey/tools/chocolateyInstall.ps1
@@ -4,14 +4,14 @@
 
     try {
       if (test-path($poshgitPath)) {
-        Write-Host "Attempting to remove existing `'$poshgitPath`' prior to install."
+        Write-Host "Attempting to remove existing `'$poshgitPath`'."
         remove-item $poshgitPath -recurse -force
       }
     } catch {
       Write-Host "Could not remove `'$poshgitPath`'"
     }
 
-    $poshGitInstall = if($env:poshGit -ne $null){ $env:poshGit } else {'https://github.com/dahlbyk/posh-git/zipball/master'}
+    $poshGitInstall = if ($env:poshGit ) { $env:poshGit } else { 'https://github.com/dahlbyk/posh-git/zipball/master' }
     Install-ChocolateyZipPackage 'poshgit' $poshGitInstall $poshgitPath
     $pgitDir = Dir "$poshgitPath\*posh-git*\" | Sort-Object -Property LastWriteTime | Select -Last 1
 
@@ -26,7 +26,7 @@
             if($line.ToLower().Contains("$poshgitPath".ToLower())) {
                 $line = ". '$pgitExample'"
             }
-            if($line.Trim().Length -gt 0) {  $newProfile += $line }
+            $newProfile += $line
         }
         Set-Content -path $profile -value $newProfile -Force
     }

--- a/chocolatey/tools/chocolateyUninstall.ps1
+++ b/chocolatey/tools/chocolateyUninstall.ps1
@@ -1,0 +1,48 @@
+﻿try {
+    $binRoot = Get-BinRoot
+    $poshgitPath = join-path $binRoot 'poshgit'
+
+    try {
+      if (test-path($poshgitPath)) {
+        Write-Host "Attempting to remove existing `'$poshgitPath`'."
+        remove-item $poshgitPath -recurse -force
+      }
+    } catch {
+      Write-Host "Could not remove `'$poshgitPath`'"
+    }
+
+    $poshGitInstall = if ($env:poshGit ) { $env:poshGit } else { 'https://github.com/dahlbyk/posh-git/zipball/master' }
+    Install-ChocolateyZipPackage 'poshgit' $poshGitInstall $poshgitPath
+    $currentVersionPath = Get-ChildItem "$poshgitPath\*posh-git*\" | Sort-Object -Property LastWriteTime | Select-Object -Last 1
+
+    if(Test-Path $PROFILE) {
+        $oldProfile = @(Get-Content $PROFILE)
+
+        . $currentVersionPath\src\Utils.ps1
+        $oldProfileEncoding = Get-FileEncoding $PROFILE
+
+        $newProfile = @()
+        foreach($line in $oldProfile) {
+            if ($line -like '*PoshGitPrompt*') { continue; }
+
+            if($line -like '. *posh-git*profile.example.ps1*') {
+                $line = ". '$currentVersionPath\profile.example.ps1'"
+            }
+            if($line -like 'Import-Module *\src\posh-git.psd1*') {
+                $line = "Import-Module '$currentVersionPath\src\posh-git.psd1'"
+            }
+            $newProfile += $line
+        }
+        Set-Content -path $profile -value $newProfile -Force -Encoding $oldProfileEncoding
+    }
+
+    $installer = Join-Path $currentVersionPath 'install.ps1'
+    & $installer
+} catch {
+  try {
+    if($oldProfile){ Set-Content -path $PROFILE -value $oldProfile -Force -Encoding $oldProfileEncoding }
+  }
+  catch {}
+  throw
+}
+

--- a/chocolatey/tools/chocolateyUninstall.ps1
+++ b/chocolatey/tools/chocolateyUninstall.ps1
@@ -2,17 +2,6 @@
     $binRoot = Get-BinRoot
     $poshgitPath = join-path $binRoot 'poshgit'
 
-    try {
-      if (test-path($poshgitPath)) {
-        Write-Host "Attempting to remove existing `'$poshgitPath`'."
-        remove-item $poshgitPath -recurse -force
-      }
-    } catch {
-      Write-Host "Could not remove `'$poshgitPath`'"
-    }
-
-    $poshGitInstall = if ($env:poshGit ) { $env:poshGit } else { 'https://github.com/dahlbyk/posh-git/zipball/master' }
-    Install-ChocolateyZipPackage 'poshgit' $poshGitInstall $poshgitPath
     $currentVersionPath = Get-ChildItem "$poshgitPath\*posh-git*\" | Sort-Object -Property LastWriteTime | Select-Object -Last 1
 
     if(Test-Path $PROFILE) {
@@ -24,20 +13,27 @@
         $newProfile = @()
         foreach($line in $oldProfile) {
             if ($line -like '*PoshGitPrompt*') { continue; }
+            if ($line -like '*Load posh-git example profile*') { continue; }
 
             if($line -like '. *posh-git*profile.example.ps1*') {
-                $line = ". '$currentVersionPath\profile.example.ps1'"
+                continue;
             }
             if($line -like 'Import-Module *\src\posh-git.psd1*') {
-                $line = "Import-Module '$currentVersionPath\src\posh-git.psd1'"
+                continue;
             }
             $newProfile += $line
         }
         Set-Content -path $profile -value $newProfile -Force -Encoding $oldProfileEncoding
     }
 
-    $installer = Join-Path $currentVersionPath 'install.ps1'
-    & $installer
+    try {
+      if (test-path($poshgitPath)) {
+        Write-Host "Attempting to remove existing `'$poshgitPath`'."
+        remove-item $poshgitPath -recurse -force
+      }
+    } catch {
+      Write-Host "Could not remove `'$poshgitPath`'"
+    }
 } catch {
   try {
     if($oldProfile){ Set-Content -path $PROFILE -value $oldProfile -Force -Encoding $oldProfileEncoding }

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -121,6 +121,7 @@ function Add-PoshGitToProfile([switch]$AllHosts, [switch]$Force, [switch]$WhatIf
     if (!$profilePath) {
         Write-Warning "Skipping add of posh-git import; no profile found."
         Write-Verbose "`$profilePath          = '$profilePath'"
+        Write-Verbose "`$PROFILE              = '$PROFILE'"
         Write-Verbose "CurrentUserCurrentHost = '${PROFILE.CurrentUserCurrentHost}'"
         Write-Verbose "CurrentUserAllHosts    = '${PROFILE.CurrentUserAllHosts}'"
         Write-Verbose "AllUsersCurrentHost    = '${PROFILE.AllUsersCurrentHost}'"

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -120,6 +120,11 @@ function Add-PoshGitToProfile([switch]$AllHosts, [switch]$Force, [switch]$WhatIf
 
     if (!$profilePath) {
         Write-Warning "Skipping add of posh-git import; no profile found."
+        Write-Verbose "`$profilePath          = '$profilePath'"
+        Write-Verbose "CurrentUserCurrentHost = '${PROFILE.CurrentUserCurrentHost}'"
+        Write-Verbose "CurrentUserAllHosts    = '${PROFILE.CurrentUserAllHosts}'"
+        Write-Verbose "AllUsersCurrentHost    = '${PROFILE.AllUsersCurrentHost}'"
+        Write-Verbose "AllUsersAllHosts       = '${PROFILE.AllUsersAllHosts}'"
         return
     }
 
@@ -220,7 +225,9 @@ function Test-PoshGitImportedInScript {
         return $false
     }
 
-    (@(Get-Content $Path -ErrorAction SilentlyContinue) -match 'posh-git').Count -gt 0
+    $match = (@(Get-Content $Path -ErrorAction SilentlyContinue) -match 'posh-git').Count -gt 0
+    if ($match) { Write-Verbose "posh-git found in '$Path'" }
+    $match
 }
 
 function dbg($Message, [Diagnostics.Stopwatch]$Stopwatch) {

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -93,10 +93,15 @@ function Add-PoshGitToProfile([switch]$AllHosts, [switch]$Force, [switch]$WhatIf
         }
     }
 
+    if (!$profilePath) { $profilePath = $PROFILE }
+
     if (!$Force) {
         # Search the user's profiles to see if any are using posh-git already, there is an extra search
         # ($profilePath) taking place to accomodate the Pester tests.
         $importedInProfile = Test-PoshGitImportedInScript $profilePath
+        if (!$importedInProfile -and !$underTest) {
+            $importedInProfile = Test-PoshGitImportedInScript $PROFILE
+        }
         if (!$importedInProfile -and !$underTest) {
             $importedInProfile = Test-PoshGitImportedInScript $PROFILE.CurrentUserCurrentHost
         }

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -122,10 +122,10 @@ function Add-PoshGitToProfile([switch]$AllHosts, [switch]$Force, [switch]$WhatIf
         Write-Warning "Skipping add of posh-git import; no profile found."
         Write-Verbose "`$profilePath          = '$profilePath'"
         Write-Verbose "`$PROFILE              = '$PROFILE'"
-        Write-Verbose "CurrentUserCurrentHost = '${PROFILE.CurrentUserCurrentHost}'"
-        Write-Verbose "CurrentUserAllHosts    = '${PROFILE.CurrentUserAllHosts}'"
-        Write-Verbose "AllUsersCurrentHost    = '${PROFILE.AllUsersCurrentHost}'"
-        Write-Verbose "AllUsersAllHosts       = '${PROFILE.AllUsersAllHosts}'"
+        Write-Verbose "CurrentUserCurrentHost = '$($PROFILE.CurrentUserCurrentHost)'"
+        Write-Verbose "CurrentUserAllHosts    = '$($PROFILE.CurrentUserAllHosts)'"
+        Write-Verbose "AllUsersCurrentHost    = '$($PROFILE.AllUsersCurrentHost)'"
+        Write-Verbose "AllUsersAllHosts       = '$($PROFILE.AllUsersAllHosts)'"
         return
     }
 

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -118,6 +118,11 @@ function Add-PoshGitToProfile([switch]$AllHosts, [switch]$Force, [switch]$WhatIf
         }
     }
 
+    if (!$profilePath) {
+        Write-Warning "Skipping add of posh-git import; no profile found."
+        return
+    }
+
     # Check if the location of this module file is in the PSModulePath
     if (Test-InPSModulePath $ModuleBasePath) {
         $profileContent = "`nImport-Module posh-git"


### PR DESCRIPTION
Closes #239, inspired by need for #357 hack to fix #355.

Specific changes:

1. Chocolatey installer no longer adds code to `$PROFILE` that saves the pre–posh-git `prompt`
2. Chocolatey installer also strips that legacy code from `$PROFILE` (if you want to keep the old behavior, make sure `PoshGitPrompt` doesn't appear in those lines)
3. Added uninstaller that both deletes `%ChocolateyBinRoot%\poshgit` and removes lines we might have added to `$PROFILE`

We might consider reverting the second commit (and maybe the first) for now, to avoid a breaking change before  [1.0](https://github.com/dahlbyk/posh-git/issues/328) drops.