### PR TITLE
WIP allow prompt char > to reflect nesting level.

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -96,8 +96,8 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
 
     EnableWindowTitle                           = 'posh~git ~ '
 
-    PromptSuffix                                = '> '
-    PromptDebugSuffix                           = ' [DBG]>> '
+    PromptSuffix                                = '$(''>'' * ($nestedPromptLevel + 1)) '
+    PromptDebugSuffix                           = ' [DBG]$(''>'' * ($nestedPromptLevel + 1)) '
 
     Debug                                       = $false
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ This gives us a prompt with a current path that is never greater than 40 charact
 [rkeithhill/more-readme-tweaks +0 ~1 -0 | +0 ~1 -0 !] ...sers\Keith\GitHub\rkeithhill\posh-git
 > _
 ```
+For more in-depth information on PowerShell prompts, see the online PowerShell help topic [about_prompts](https://msdn.microsoft.com/en-us/powershell/reference/5.1/microsoft.powershell.core/about/about_prompts).
 
 ## Git Status Summary Information
 The Git status summary information provides a wealth of "Git status" information at a glance, all the time in your prompt.

--- a/posh-git.psm1
+++ b/posh-git.psm1
@@ -85,7 +85,7 @@ if (!$currentPromptDef -or ($currentPromptDef -eq $defaultPromptDef)) {
         }
 
         $global:LASTEXITCODE = $origLastExitCode
-        $promptSuffix
+        $ExecutionContext.SessionState.InvokeCommand.ExpandString($promptSuffix)
 '@)
 
     # Set the posh-git prompt as the default prompt


### PR DESCRIPTION
To be a good prompt citizen in PowerShell, the > (or whatever prompt char) should be displayed once for nesting level 0, twice for nesting level 1, and so on.

In order to make that happen, we have to allow for deferred expansion of the Prompt*Suffix settings.

See https://msdn.microsoft.com/en-us/powershell/reference/5.1/microsoft.powershell.core/about/about_prompts for more details.