### PR TITLE
Worth adding optional timing output to def prompt?

### DIFF
--- a/GitPrompt.ps1
+++ b/GitPrompt.ps1
@@ -97,8 +97,9 @@ $global:GitPromptSettings = New-Object PSObject -Property @{
 
     EnableWindowTitle                           = 'posh~git ~ '
 
-    PromptSuffix                                = '$(''>'' * ($nestedPromptLevel + 1)) '
-    PromptDebugSuffix                           = ' [DBG]$(''>'' * ($nestedPromptLevel + 1)) '
+    DefaultPromptSuffix                         = '$(''>'' * ($nestedPromptLevel + 1)) '
+    DefaultPromptDebugSuffix                    = ' [DBG]$(''>'' * ($nestedPromptLevel + 1)) '
+    DefaultPromptEnableTiming                   = $false
 
     Debug                                       = $false
 

--- a/posh-git.psm1
+++ b/posh-git.psm1
@@ -92,7 +92,7 @@ if (!$currentPromptDef -or ($currentPromptDef -eq $defaultPromptDef)) {
         if ($GitPromptSettings.DefaultPromptEnableTiming) {
             $sw.Stop()
             $elapsed = $sw.ElapsedMilliseconds
-            Write-Host " $($elapsed)ms" -NoNewline
+            Write-Host " ${elapsed}ms" -NoNewline
         }
 
         $global:LASTEXITCODE = $origLastExitCode

--- a/posh-git.psm1
+++ b/posh-git.psm1
@@ -45,6 +45,9 @@ if (!$currentPromptDef) {
 if (!$currentPromptDef -or ($currentPromptDef -eq $defaultPromptDef)) {
     # Have to use [scriptblock]::Create() to get debugger detection to work in PS v2
     $poshGitPromptScriptBlock = [scriptblock]::Create(@'
+        if ($GitPromptSettings.DefaultPromptEnableTiming) {
+            $sw = [System.Diagnostics.Stopwatch]::StartNew()
+        }
         $origLastExitCode = $global:LASTEXITCODE
 
         # A UNC path has no drive so it's better to use the ProviderPath e.g. "\\server\share".
@@ -76,15 +79,24 @@ if (!$currentPromptDef -or ($currentPromptDef -eq $defaultPromptDef)) {
 
         # If stopped in the debugger, the prompt needs to indicate that in some fashion
         $debugMode = (Test-Path Variable:/PSDebugContext) -or [runspace]::DefaultRunspace.Debugger.InBreakpoint
-        $promptSuffix = if ($debugMode) { $GitPromptSettings.PromptDebugSuffix } else { $GitPromptSettings.PromptSuffix }
+        $promptSuffix = if ($debugMode) { $GitPromptSettings.DefaultPromptDebugSuffix } else { $GitPromptSettings.DefaultPromptSuffix }
 
         # If user specifies $null or empty string, set to ' ' to avoid "PS>" unexpectedly being displayed
         if (!$promptSuffix) {
             $promptSuffix = ' '
         }
 
+        $expandedPromptSuffix = $ExecutionContext.SessionState.InvokeCommand.ExpandString($promptSuffix)
+
+        # If prompt timing enabled, display elapsed milliseconds
+        if ($GitPromptSettings.DefaultPromptEnableTiming) {
+            $sw.Stop()
+            $elapsed = $sw.ElapsedMilliseconds
+            Write-Host " $elapsed mS" -NoNewline
+        }
+
         $global:LASTEXITCODE = $origLastExitCode
-        $ExecutionContext.SessionState.InvokeCommand.ExpandString($promptSuffix)
+        $expandedPromptSuffix
 '@)
 
     # Set the posh-git prompt as the default prompt

--- a/posh-git.psm1
+++ b/posh-git.psm1
@@ -92,7 +92,7 @@ if (!$currentPromptDef -or ($currentPromptDef -eq $defaultPromptDef)) {
         if ($GitPromptSettings.DefaultPromptEnableTiming) {
             $sw.Stop()
             $elapsed = $sw.ElapsedMilliseconds
-            Write-Host " $elapsed mS" -NoNewline
+            Write-Host " $($elapsed)ms" -NoNewline
         }
 
         $global:LASTEXITCODE = $origLastExitCode


### PR DESCRIPTION
This is enabled with `$GitPromptSettings.DefaultPromptEnableTiming=$true` and then the prompt function outputs `~\GitHub\rkeithhill\posh-git [rkeithhill/enable-default-prompt-timing +0 ~2 -0 !] 55 mS>`.

It also occurred to me that the GitPromptSettings should be prefixed "DefaultPrompt" so folks don't think they apply to their own custom prompt functions.

I'm not entirely sure this is worth it but I could see it coming in handy to get "hard" perf data from users of the default prompt.  If  we decide not to go with this PR, I still think we should consider adding the "Default" prefix to the existing two Prompt*Suffix settings.

In the VSCode dir on my machine (status equiv to origin), the prompt takes 150 mS.  VSCode has 6466 files in the repo.