### PR TITLE
Report UpstreamGone from cache responses.

### DIFF
--- a/GitUtils.ps1
+++ b/GitUtils.ps1
@@ -175,6 +175,7 @@ function Get-GitStatus($gitDir = (Get-GitDirectory)) {
 
                 $branch = $cacheResponse.Branch
                 $upstream = $cacheResponse.Upstream
+                $gone = $cacheResponse.UpstreamGone
                 $aheadBy = $cacheResponse.AheadBy
                 $behindBy = $cacheResponse.BehindBy
 


### PR DESCRIPTION
Latest GitStatusCache executable can be pulled with Update-GitStatusCache. Functionality won't light up on existing clients without pulling it down.