### PR TITLE
Improve tab expansion to handle params for push.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,10 +4,25 @@
         {
             "type": "PowerShell",
             "request": "launch",
+            "name": "PowerShell Launch Pester Tests",
+            "script": "${workspaceRoot}/test/testDebugHarness.ps1",
+            "args": [],
+            "cwd": "${file}"
+        },
+        {
+            "type": "PowerShell",
+            "request": "launch",
             "name": "PowerShell Launch (current file)",
             "script": "${file}",
             "args": [],
             "cwd": "${file}"
+        },
+        {
+            "type": "PowerShell",
+            "request": "attach",
+            "name": "PowerShell Attach to Host Process",
+            "processId": "${command.PickPSHostProcess}",
+            "runspaceId": 1
         }
     ]
 }

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -258,14 +258,14 @@ function GitTabExpansionInternal($lastBlock) {
 
         # Handles git push remote <ref>:<branch>
         # Handles git push remote +<ref>:<branch>
-        "^push${gitParams}\s+(?<remote>[^\s-]\S*)(${gitParams}\s+(?<force>\+?)(?<ref>[^\s\:]*\:)(?<branch>\S*))+$" {
+        "^push${gitParams}\s+(?<remote>[^\s-]\S*).*\s+(?<force>\+?)(?<ref>[^\s\:]*\:)(?<branch>\S*)$" {
             gitRemoteBranches $matches['remote'] $matches['ref'] $matches['branch'] -prefix $matches['force']
         }
 
         # Handles git push remote <ref>
         # Handles git push remote +<ref>
         # Handles git pull remote <ref>
-        "^(?:push|pull)${gitParams}\s+(?<remote>[^\s-]\S*)(${gitParams}\s+(?<force>\+?)(?<ref>[^\s\:]*))+$" {
+        "^(?:push|pull)${gitParams}\s+(?<remote>[^\s-]\S*).*\s+(?<force>\+?)(?<ref>[^\s\:]*)$" {
             gitBranches $matches['ref'] -prefix $matches['force']
             gitTags $matches['ref'] -prefix $matches['force']
         }

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -29,10 +29,8 @@ $gitflowsubcommands = @{
 }
 
 function script:gitCmdOperations($commands, $command, $filter) {
-    $commands.$command -split ' ' |
-        Where-Object { $_ -like "$filter*" }
+    $commands.$command -split ' ' | Where-Object { $_ -like "$filter*" }
 }
-
 
 $script:someCommands = @('add','am','annotate','archive','bisect','blame','branch','bundle','checkout','cherry',
                          'cherry-pick','citool','clean','clone','commit','config','describe','diff','difftool','fetch',
@@ -40,9 +38,9 @@ $script:someCommands = @('add','am','annotate','archive','bisect','blame','branc
                          'notes','prune','pull','push','rebase','reflog','remote','rerere','reset','revert','rm',
                          'shortlog','show','stash','status','submodule','svn','tag','whatchanged', 'worktree')
 try {
-  if ($null -ne (git help -a 2>&1 | Select-String flow)) {
-      $script:someCommands += 'flow'
-  }
+    if ($null -ne (git help -a 2>&1 | Select-String flow)) {
+        $script:someCommands += 'flow'
+    }
 }
 catch {
     Write-Debug "Search for 'flow' in 'git help' output failed with error: $_"
@@ -52,7 +50,8 @@ function script:gitCommands($filter, $includeAliases) {
     $cmdList = @()
     if (-not $global:GitTabSettings.AllCommands) {
         $cmdList += $someCommands -like "$filter*"
-    } else {
+    }
+    else {
         $cmdList += git help --all |
             Where-Object { $_ -match '^  \S.*' } |
             ForEach-Object { $_.Split(' ', [StringSplitOptions]::RemoveEmptyEntries) } |
@@ -62,12 +61,12 @@ function script:gitCommands($filter, $includeAliases) {
     if ($includeAliases) {
         $cmdList += gitAliases $filter
     }
+
     $cmdList | Sort-Object
 }
 
 function script:gitRemotes($filter) {
-    git remote |
-        Where-Object { $_ -like "$filter*" }
+    git remote | Where-Object { $_ -like "$filter*" }
 }
 
 function script:gitBranches($filter, $includeHEAD = $false, $prefix = '') {
@@ -75,9 +74,11 @@ function script:gitBranches($filter, $includeHEAD = $false, $prefix = '') {
         $prefix += $matches['from']
         $filter = $matches['to']
     }
-    $branches = @(git branch --no-color | ForEach-Object { if(($_ -notmatch "^\* \(HEAD detached .+\)$") -and ($_ -match "^\*?\s*(?<ref>.*)")) { $matches['ref'] } }) +
-                @(git branch --no-color -r | ForEach-Object { if($_ -match "^  (?<ref>\S+)(?: -> .+)?") { $matches['ref'] } }) +
+
+    $branches = @(git branch --no-color | ForEach-Object { if (($_ -notmatch "^\* \(HEAD detached .+\)$") -and ($_ -match "^\*?\s*(?<ref>.*)")) { $matches['ref'] } }) +
+                @(git branch --no-color -r | ForEach-Object { if ($_ -match "^  (?<ref>\S+)(?: -> .+)?") { $matches['ref'] } }) +
                 @(if ($includeHEAD) { 'HEAD','FETCH_HEAD','ORIG_HEAD','MERGE_HEAD' })
+
     $branches |
         Where-Object { $_ -ne '(no branch)' -and $_ -like "$filter*" } |
         ForEach-Object { $prefix + $_ }
@@ -85,7 +86,7 @@ function script:gitBranches($filter, $includeHEAD = $false, $prefix = '') {
 
 function script:gitRemoteUniqueBranches($filter) {
     git branch --no-color -r |
-        ForEach-Object { if($_ -match "^  (?<remote>[^/]+)/(?<branch>\S+)(?! -> .+)?$") { $matches['branch'] } } |
+        ForEach-Object { if ($_ -match "^  (?<remote>[^/]+)/(?<branch>\S+)(?! -> .+)?$") { $matches['branch'] } } |
         Group-Object -NoElement |
         Where-Object { $_.Count -eq 1 } |
         Select-Object -ExpandProperty Name |
@@ -100,7 +101,7 @@ function script:gitTags($filter, $prefix = '') {
 
 function script:gitFeatures($filter, $command){
 	$featurePrefix = git config --local --get "gitflow.prefix.$command"
-    $branches = @(git branch --no-color | ForEach-Object { if($_ -match "^\*?\s*$featurePrefix(?<ref>.*)") { $matches['ref'] } })
+    $branches = @(git branch --no-color | ForEach-Object { if ($_ -match "^\*?\s*$featurePrefix(?<ref>.*)") { $matches['ref'] } })
     $branches |
         Where-Object { $_ -ne '(no branch)' -and $_ -like "$filter*" } |
         ForEach-Object { $prefix + $_ }
@@ -127,7 +128,7 @@ function script:gitTfsShelvesets($filter) {
 function script:gitFiles($filter, $files) {
     $files | Sort-Object |
         Where-Object { $_ -like "$filter*" } |
-        ForEach-Object { if($_ -like '* *') { "'$_'" } else { $_ } }
+        ForEach-Object { if ($_ -like '* *') { "'$_'" } else { $_ } }
 }
 
 function script:gitIndex($filter) {
@@ -161,9 +162,9 @@ function script:gitDeleted($filter) {
 
 function script:gitAliases($filter) {
     git config --get-regexp ^alias\. | ForEach-Object{
-        if($_ -match "^alias\.(?<alias>\S+) .*") {
+        if ($_ -match "^alias\.(?<alias>\S+) .*") {
             $alias = $Matches['alias']
-            if($alias -like "$filter*") {
+            if ($alias -like "$filter*") {
                 $alias
             }
         }
@@ -180,12 +181,12 @@ function script:expandGitAlias($cmd, $rest) {
 }
 
 function GitTabExpansion($lastBlock) {
-    Invoke-Utf8ConsoleCommand {
-        GitTabExpansionInternal $lastBlock
-    }
+    $res = Invoke-Utf8ConsoleCommand { GitTabExpansionInternal $lastBlock }
+    $res
 }
 
 function GitTabExpansionInternal($lastBlock) {
+    $gitParams = '(?<params>\s+-(?:[aA-zZ0-9]+|-[aA-zZ0-9][aA-zZ0-9-]*)(?:=\S+)?)*'
 
     if ($lastBlock -match "^$(Get-AliasPattern git) (?<cmd>\S+)(?<args> .*)$") {
         $lastBlock = expandGitAlias $Matches['cmd'] $Matches['args']
@@ -208,7 +209,6 @@ function GitTabExpansionInternal($lastBlock) {
         "^(?<cmd>$($subcommands.Keys -join '|'))\s+(?<op>\S*)$" {
             gitCmdOperations $subcommands $matches['cmd'] $matches['op']
         }
-
 
         # Handles git flow <cmd> <op>
         "^flow (?<cmd>$($gitflowsubcommands.Keys -join '|'))\s+(?<op>\S*)$" {
@@ -258,14 +258,14 @@ function GitTabExpansionInternal($lastBlock) {
 
         # Handles git push remote <ref>:<branch>
         # Handles git push remote +<ref>:<branch>
-        "^push.* (?<remote>\S+) (?<force>\+?)(?<ref>[^\s\:]*\:)(?<branch>\S*)$" {
+        "^push.* ${gitParams}(?<remote>\S+)${gitParams}\s+(?<force>\+?)(?<ref>[^\s\:]*\:)(?<branch>\S*)$" {
             gitRemoteBranches $matches['remote'] $matches['ref'] $matches['branch'] -prefix $matches['force']
         }
 
         # Handles git push remote <ref>
         # Handles git push remote +<ref>
         # Handles git pull remote <ref>
-        "^(?:push|pull).* (?:\S+) (?<force>\+?)(?<ref>[^\s\:]*)$" {
+        "^(?:push|pull).* ${gitParams}(?<remote>[^\s-]\S*)${gitParams}\s+(?<force>\+?)(?<ref>[^\s\:]*)$" {
             gitBranches $matches['ref'] -prefix $matches['force']
             gitTags $matches['ref'] -prefix $matches['force']
         }
@@ -273,7 +273,7 @@ function GitTabExpansionInternal($lastBlock) {
         # Handles git pull <remote>
         # Handles git push <remote>
         # Handles git fetch <remote>
-        "^(?:push|pull|fetch).* (?<remote>\S*)$" {
+        "^(?:push|pull|fetch).* ${gitParams}(?<remote>\S*)$" {
             gitRemotes $matches['remote']
         }
 
@@ -360,6 +360,10 @@ function TabExpansion($line, $lastWord) {
         "^$(Get-AliasPattern gitk) (.*)" { GitTabExpansion $lastBlock }
 
         # Fall back on existing tab expansion
-        default { if (Test-Path Function:\TabExpansionBackup) { TabExpansionBackup $line $lastWord } }
+        default {
+            if (Test-Path Function:\TabExpansionBackup) {
+                TabExpansionBackup $line $lastWord
+            }
+        }
     }
 }

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -258,14 +258,14 @@ function GitTabExpansionInternal($lastBlock) {
 
         # Handles git push remote <ref>:<branch>
         # Handles git push remote +<ref>:<branch>
-        "^push${gitParams}\s+(?<remote>[^\s-]\S*)${gitParams}\s+(?<force>\+?)(?<ref>[^\s\:]*\:)(?<branch>\S*)$" {
+        "^push${gitParams}\s+(?<remote>[^\s-]\S*)(${gitParams}\s+(?<force>\+?)(?<ref>[^\s\:]*\:)(?<branch>\S*))+$" {
             gitRemoteBranches $matches['remote'] $matches['ref'] $matches['branch'] -prefix $matches['force']
         }
 
         # Handles git push remote <ref>
         # Handles git push remote +<ref>
         # Handles git pull remote <ref>
-        "^(?:push|pull)${gitParams}\s+(?<remote>[^\s-]\S*)${gitParams}\s+(?<force>\+?)(?<ref>[^\s\:]*)$" {
+        "^(?:push|pull)${gitParams}\s+(?<remote>[^\s-]\S*)(${gitParams}\s+(?<force>\+?)(?<ref>[^\s\:]*))+$" {
             gitBranches $matches['ref'] -prefix $matches['force']
             gitTags $matches['ref'] -prefix $matches['force']
         }

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -258,14 +258,14 @@ function GitTabExpansionInternal($lastBlock) {
 
         # Handles git push remote <ref>:<branch>
         # Handles git push remote +<ref>:<branch>
-        "^push.* ${gitParams}(?<remote>\S+)${gitParams}\s+(?<force>\+?)(?<ref>[^\s\:]*\:)(?<branch>\S*)$" {
+        "^push${gitParams}\s+(?<remote>[^\s-]\S*)${gitParams}\s+(?<force>\+?)(?<ref>[^\s\:]*\:)(?<branch>\S*)$" {
             gitRemoteBranches $matches['remote'] $matches['ref'] $matches['branch'] -prefix $matches['force']
         }
 
         # Handles git push remote <ref>
         # Handles git push remote +<ref>
         # Handles git pull remote <ref>
-        "^(?:push|pull).* ${gitParams}(?<remote>[^\s-]\S*)${gitParams}\s+(?<force>\+?)(?<ref>[^\s\:]*)$" {
+        "^(?:push|pull)${gitParams}\s+(?<remote>[^\s-]\S*)${gitParams}\s+(?<force>\+?)(?<ref>[^\s\:]*)$" {
             gitBranches $matches['ref'] -prefix $matches['force']
             gitTags $matches['ref'] -prefix $matches['force']
         }
@@ -273,7 +273,7 @@ function GitTabExpansionInternal($lastBlock) {
         # Handles git pull <remote>
         # Handles git push <remote>
         # Handles git fetch <remote>
-        "^(?:push|pull|fetch).* ${gitParams}(?<remote>\S*)$" {
+        "^(?:push|pull|fetch)${gitParams}\s+(?<remote>\S*)$" {
             gitRemotes $matches['remote']
         }
 

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -1,0 +1,78 @@
+. $PSScriptRoot\Shared.ps1
+
+Describe 'TabExpansion Tests' {
+    Context 'Fetch/Push/Pull TabExpansion Tests' {
+        It 'Tab completes all remotes' {
+            $result = & $module GitTabExpansionInternal 'git push '
+            $result | Should BeExactly 'origin'
+        }
+        It 'Tab completes matching remotes' {
+            $result = & $module GitTabExpansionInternal 'git push or'
+            $result | Should BeExactly 'origin'
+        }
+        It 'Tab completes matching remote/branches' {
+            $result = & $module GitTabExpansionInternal 'git push origin origin/ma'
+            $result | Should BeExactly 'origin/master'
+        }
+        It 'Tab completes remote and all branches' {
+            $result = & $module GitTabExpansionInternal 'git push origin '
+            $result -contains 'master' | Should Be $true
+            $result -contains 'origin/master' | Should Be $true
+            $result -contains 'origin/HEAD' | Should Be $true
+        }
+        It 'Tab completes remote and matching branches' {
+            $result = & $module GitTabExpansionInternal 'git push origin ma'
+            $result | Should BeExactly 'master'
+        }
+        It 'Tab completes matching remote with preceding parameters' {
+            $result = & $module GitTabExpansionInternal 'git push --follow-tags  -u   or'
+            $result | Should BeExactly 'origin'
+        }
+        It 'Tab completes remote and all branches with preceding parameters' {
+            $result = & $module GitTabExpansionInternal 'git push  --follow-tags  -u   origin '
+            $result -contains 'master' | Should Be $true
+            $result -contains 'origin/master' | Should Be $true
+            $result -contains 'origin/HEAD' | Should Be $true
+        }
+        It 'Tab completes remote and matching branch with preceding parameters' {
+            $result = & $module GitTabExpansionInternal 'git push  --follow-tags  -u   origin ma'
+            $result | Should BeExactly 'master'
+        }
+        It 'Tab completes remote and matching branch with intermixed parameters' {
+            $result = & $module GitTabExpansionInternal 'git push -u origin --follow-tags ma'
+            $result | Should BeExactly 'master'
+            $result = & $module GitTabExpansionInternal 'git push  -u  origin  --follow-tags   ma'
+            $result | Should BeExactly 'master'
+        }
+        It 'Tab complete returns empty result for missing remote' {
+            $result = & $module GitTabExpansionInternal 'git push zy'
+            $result | Should BeNullOrEmpty
+        }
+        It 'Tab complete returns empty result for missing branch' {
+            $result = & $module GitTabExpansionInternal 'git push origin zy'
+            $result | Should BeNullOrEmpty
+        }
+        It 'Tab complete returns empty result for missing remotebranch' {
+            $result = & $module GitTabExpansionInternal 'git fetch origin/zy'
+            $result | Should BeNullOrEmpty
+        }
+        It 'Tab completes branch names with - and -- in them' {
+            $branchName = 'branch--for-Pester-tests'
+            if (git branch --list -q $branchName) {
+                git branch -D $branchName
+            }
+
+            git branch $branchName
+            try {
+                $result = & $module GitTabExpansionInternal 'git push origin branch-'
+                $result | Should BeExactly $branchName
+
+                $result = & $module GitTabExpansionInternal 'git push  --follow-tags  -u   origin '
+                $result -contains $branchName | Should Be $true
+            }
+            finally {
+                git branch -D $branchName
+            }
+        }
+    }
+}

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -6,43 +6,67 @@ Describe 'TabExpansion Tests' {
             $result = & $module GitTabExpansionInternal 'git push '
             $result | Should BeExactly 'origin'
         }
-        It 'Tab completes matching remotes' {
-            $result = & $module GitTabExpansionInternal 'git push or'
-            $result | Should BeExactly 'origin'
-        }
-        It 'Tab completes matching remote/branches' {
-            $result = & $module GitTabExpansionInternal 'git push origin origin/ma'
-            $result | Should BeExactly 'origin/master'
-        }
-        It 'Tab completes remote and all branches' {
+        It 'Tab completes all branches' {
             $result = & $module GitTabExpansionInternal 'git push origin '
             $result -contains 'master' | Should Be $true
             $result -contains 'origin/master' | Should Be $true
             $result -contains 'origin/HEAD' | Should Be $true
         }
-        It 'Tab completes remote and matching branches' {
+        It 'Tab completes all :branches' {
+            $result = & $module GitTabExpansionInternal 'git push origin :'
+            $result -contains ':master' | Should Be $true
+            # Is the following a valid branch name in a refspec?
+            $result -contains ':HEAD -> origin/master' | Should Be $true
+        }
+        It 'Tab completes matching remotes' {
+            $result = & $module GitTabExpansionInternal 'git push or'
+            $result | Should BeExactly 'origin'
+        }
+        It 'Tab completes matching branches' {
             $result = & $module GitTabExpansionInternal 'git push origin ma'
             $result | Should BeExactly 'master'
+        }
+        It 'Tab completes matching remote/branches' {
+            $result = & $module GitTabExpansionInternal 'git push origin origin/ma'
+            $result | Should BeExactly 'origin/master'
+        }
+        It 'Tab completes matching :branches' {
+            $result = & $module GitTabExpansionInternal 'git push origin :ma'
+            $result | Should BeExactly ':master'
+        }
+        It 'Tab completes matching ref:branches' {
+            $result = & $module GitTabExpansionInternal 'git push origin /refs/heads/master:ma'
+            $result | Should BeExactly '/refs/heads/master:master'
+        }
+        It 'Tab completes matching +ref:branches' {
+            $result = & $module GitTabExpansionInternal 'git push origin +/refs/heads/master:ma'
+            $result | Should BeExactly '+/refs/heads/master:master'
         }
         It 'Tab completes matching remote with preceding parameters' {
             $result = & $module GitTabExpansionInternal 'git push --follow-tags  -u   or'
             $result | Should BeExactly 'origin'
         }
-        It 'Tab completes remote and all branches with preceding parameters' {
+        It 'Tab completes all branches with preceding parameters' {
             $result = & $module GitTabExpansionInternal 'git push  --follow-tags  -u   origin '
             $result -contains 'master' | Should Be $true
             $result -contains 'origin/master' | Should Be $true
             $result -contains 'origin/HEAD' | Should Be $true
         }
-        It 'Tab completes remote and matching branch with preceding parameters' {
+        It 'Tab completes matching branch with preceding parameters' {
             $result = & $module GitTabExpansionInternal 'git push  --follow-tags  -u   origin ma'
             $result | Should BeExactly 'master'
         }
-        It 'Tab completes remote and matching branch with intermixed parameters' {
+        It 'Tab completes matching branch with intermixed parameters' {
             $result = & $module GitTabExpansionInternal 'git push -u origin --follow-tags ma'
             $result | Should BeExactly 'master'
             $result = & $module GitTabExpansionInternal 'git push  -u  origin  --follow-tags   ma'
             $result | Should BeExactly 'master'
+        }
+        It 'Tab completes matching ref:branch with intermixed parameters' {
+            $result = & $module GitTabExpansionInternal 'git push -u origin --follow-tags /refs/heads/master:ma'
+            $result | Should BeExactly '/refs/heads/master:master'
+            $result = & $module GitTabExpansionInternal 'git push  -u  origin  --follow-tags   +/refs/heads/master:ma'
+            $result | Should BeExactly '+/refs/heads/master:master'
         }
         It 'Tab complete returns empty result for missing remote' {
             $result = & $module GitTabExpansionInternal 'git push zy'

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -4,7 +4,7 @@ Describe 'TabExpansion Tests' {
     Context 'Fetch/Push/Pull TabExpansion Tests' {
         It 'Tab completes all remotes' {
             $result = & $module GitTabExpansionInternal 'git push '
-            $result | Should BeExactly 'origin'
+            $result | Should BeExactly (git remote)
         }
         It 'Tab completes all branches' {
             $result = & $module GitTabExpansionInternal 'git push origin '
@@ -66,14 +66,23 @@ Describe 'TabExpansion Tests' {
             $result = & $module GitTabExpansionInternal 'git push  -u  origin  --follow-tags   +HEAD:ma'
             $result | Should BeExactly '+HEAD:master'
         }
-        It 'Tab completes matching multiple ref:branch with intermixed parameters' {
-            $result = & $module GitTabExpansionInternal 'git push -u origin --follow-tags :master HEAD:ma'
+        It 'Tab completes matching multiple push ref specs with intermixed parameters' {
+            $result = & $module GitTabExpansionInternal 'git push -u origin --follow-tags one :two three:four  ma'
+            $result | Should BeExactly 'master'
+            $result = & $module GitTabExpansionInternal 'git push -u origin --follow-tags one :two three:four  --crazy-param ma'
+            $result | Should BeExactly 'master'
+            $result = & $module GitTabExpansionInternal 'git push -u origin --follow-tags one :two three:four  HEAD:ma'
             $result | Should BeExactly 'HEAD:master'
-            $result = & $module GitTabExpansionInternal 'git push -u origin --follow-tags :master --crazy-param HEAD:ma'
+            $result = & $module GitTabExpansionInternal 'git push -u origin --follow-tags one :two three:four  --crazy-param HEAD:ma'
             $result | Should BeExactly 'HEAD:master'
-            $result = & $module GitTabExpansionInternal 'git push  -u  origin  --follow-tags :master  +HEAD:ma'
+
+            $result = & $module GitTabExpansionInternal 'git push -u origin --follow-tags one :two three:four  +ma'
+            $result | Should BeExactly '+master'
+            $result = & $module GitTabExpansionInternal 'git push -u origin --follow-tags one :two three:four  --crazy-param +ma'
+            $result | Should BeExactly '+master'
+            $result = & $module GitTabExpansionInternal 'git push  -u  origin  --follow-tags one :two three:four  +HEAD:ma'
             $result | Should BeExactly '+HEAD:master'
-            $result = & $module GitTabExpansionInternal 'git push  -u  origin  --follow-tags  :master  --crazy-param  +HEAD:ma'
+            $result = & $module GitTabExpansionInternal 'git push  -u  origin  --follow-tags  one :two three:four  --crazy-param  +HEAD:ma'
             $result | Should BeExactly '+HEAD:master'
         }
         It 'Tab complete returns empty result for missing remote' {

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -15,8 +15,6 @@ Describe 'TabExpansion Tests' {
         It 'Tab completes all :branches' {
             $result = & $module GitTabExpansionInternal 'git push origin :'
             $result -contains ':master' | Should Be $true
-            # Is the following a valid branch name in a refspec?
-            $result -contains ':HEAD -> origin/master' | Should Be $true
         }
         It 'Tab completes matching remotes' {
             $result = & $module GitTabExpansionInternal 'git push or'
@@ -68,6 +66,16 @@ Describe 'TabExpansion Tests' {
             $result = & $module GitTabExpansionInternal 'git push  -u  origin  --follow-tags   +HEAD:ma'
             $result | Should BeExactly '+HEAD:master'
         }
+        It 'Tab completes matching multiple ref:branch with intermixed parameters' {
+            $result = & $module GitTabExpansionInternal 'git push -u origin --follow-tags :master HEAD:ma'
+            $result | Should BeExactly 'HEAD:master'
+            $result = & $module GitTabExpansionInternal 'git push -u origin --follow-tags :master --crazy-param HEAD:ma'
+            $result | Should BeExactly 'HEAD:master'
+            $result = & $module GitTabExpansionInternal 'git push  -u  origin  --follow-tags :master  +HEAD:ma'
+            $result | Should BeExactly '+HEAD:master'
+            $result = & $module GitTabExpansionInternal 'git push  -u  origin  --follow-tags  :master  --crazy-param  +HEAD:ma'
+            $result | Should BeExactly '+HEAD:master'
+        }
         It 'Tab complete returns empty result for missing remote' {
             $result = & $module GitTabExpansionInternal 'git push zy'
             $result | Should BeNullOrEmpty
@@ -80,6 +88,7 @@ Describe 'TabExpansion Tests' {
             $result = & $module GitTabExpansionInternal 'git fetch origin/zy'
             $result | Should BeNullOrEmpty
         }
+
         It 'Tab completes branch names with - and -- in them' {
             $branchName = 'branch--for-Pester-tests'
             if (git branch --list -q $branchName) {

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -35,12 +35,12 @@ Describe 'TabExpansion Tests' {
             $result | Should BeExactly ':master'
         }
         It 'Tab completes matching ref:branches' {
-            $result = & $module GitTabExpansionInternal 'git push origin /refs/heads/master:ma'
-            $result | Should BeExactly '/refs/heads/master:master'
+            $result = & $module GitTabExpansionInternal 'git push origin HEAD:ma'
+            $result | Should BeExactly 'HEAD:master'
         }
         It 'Tab completes matching +ref:branches' {
-            $result = & $module GitTabExpansionInternal 'git push origin +/refs/heads/master:ma'
-            $result | Should BeExactly '+/refs/heads/master:master'
+            $result = & $module GitTabExpansionInternal 'git push origin +HEAD:ma'
+            $result | Should BeExactly '+HEAD:master'
         }
         It 'Tab completes matching remote with preceding parameters' {
             $result = & $module GitTabExpansionInternal 'git push --follow-tags  -u   or'
@@ -63,10 +63,10 @@ Describe 'TabExpansion Tests' {
             $result | Should BeExactly 'master'
         }
         It 'Tab completes matching ref:branch with intermixed parameters' {
-            $result = & $module GitTabExpansionInternal 'git push -u origin --follow-tags /refs/heads/master:ma'
-            $result | Should BeExactly '/refs/heads/master:master'
-            $result = & $module GitTabExpansionInternal 'git push  -u  origin  --follow-tags   +/refs/heads/master:ma'
-            $result | Should BeExactly '+/refs/heads/master:master'
+            $result = & $module GitTabExpansionInternal 'git push -u origin --follow-tags HEAD:ma'
+            $result | Should BeExactly 'HEAD:master'
+            $result = & $module GitTabExpansionInternal 'git push  -u  origin  --follow-tags   +HEAD:ma'
+            $result | Should BeExactly '+HEAD:master'
         }
         It 'Tab complete returns empty result for missing remote' {
             $result = & $module GitTabExpansionInternal 'git push zy'

--- a/test/testDebugHarness.ps1
+++ b/test/testDebugHarness.ps1
@@ -1,2 +1,2 @@
 
-Invoke-Pester $PSScriptRoot\Utils.Tests.ps1
+Invoke-Pester $PSScriptRoot


### PR DESCRIPTION
Fix #234  BTW if we decide this is an OK fix (need another set of eyes on my $gitParams regex), I'd like to review the fact that all these switch regex case statements fallthrough to the next (observed while debugging tab expansion).  I don't believe that is necessary.  I'm thinking that most (all) of these should have a break statement.

Started a minimum set of Pester tests for tab completion.  Would be good to flesh these out over time.

BTW the latest PowerShell extension for VS Code release supports "attach to PS host process" which makes debugging tab expansion a breeze.  VS Code FTW!  :-)