### PR TITLE
Use pscustomobject cast for sorted output of $GitPromptSettings

### DIFF
--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -1,7 +1,7 @@
 ﻿# Inspired by Mark Embling
 # http://www.markembling.info/view/my-ideal-powershell-prompt-with-git-integration
 
-$global:GitPromptSettings = New-Object PSObject -Property @{
+$global:GitPromptSettings = [pscustomobject]@{
     DefaultForegroundColor                      = $Host.UI.RawUI.ForegroundColor
 
     BeforeText                                  = ' ['


### PR DESCRIPTION
To get output sorted like the original source for `$GitPromptSettings`,
we can use a cast instead of `New-Object`.

This does change the type of the object in V2 from `PSObject` to
`hashtable`, but it doesn't appear to cause any problems because
property syntax works either way.