### PR TITLE
Remove Mandatory from Test-PoshGitImportedInScript -Path

### DIFF
--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -205,7 +205,7 @@ function Test-InPSModulePath {
 
 function Test-PoshGitImportedInScript {
     param (
-        [Parameter(Position=0, Mandatory=$true)]
+        [Parameter(Position=0)]
         [string]
         $Path
     )

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -84,7 +84,8 @@ function Add-PoshGitToProfile([switch]$AllHosts, [switch]$Force, [switch]$WhatIf
     $profilePath = if ($AllHosts) { $PROFILE.CurrentUserAllHosts } else { $PROFILE.CurrentUserCurrentHost }
 
     # Under test, we override some variables using $args as a backdoor.
-    if ($args.Count -gt 0) {
+    # TODO: Can we just turn these into optional parameters with well-defined behavior?
+    if (($args.Count -gt 0) -and ($args[0] -is [string])) {
         $profilePath = [string]$args[0]
         $underTest = $true
         if ($args.Count -gt 1) {


### PR DESCRIPTION
Fix #381 

> full error trace is available here: https://gist.github.com/choco-bot/8fd09f341ed80aa5cf6ae01f39b49763

```
2017-01-30 18:46:34,436 [ERROR] - ERROR: Cannot bind argument to parameter 'Path' because it is an empty string.
 at Add-PoshGitToProfile, C:\tools\poshgit\dahlbyk-posh-git-9f6b256\src\Utils.ps1: line 98
at <ScriptBlock>, C:\tools\poshgit\dahlbyk-posh-git-9f6b256\install.ps1: line 6
at <ScriptBlock>, C:\ProgramData\chocolatey\lib\poshgit\tools\chocolateyInstall.ps1: line 42
at <ScriptBlock>, C:\ProgramData\chocolatey\helpers\chocolateyScriptRunner.ps1: line 48
at <ScriptBlock>, <No file>: line 1
```

As of https://github.com/dahlbyk/posh-git/pull/376, `install.ps1` passes `$WhatIf` on to `Add-PoshGitToProfile`, which matches a hack added to let tests override `$profilePath`. Ultimately this causes `$profilePath` to be empty when passed as a `Mandatory` parameter to `Test-PoshGitImportedInScript`. Two-part fix:

1. `Test-PoshGitImportedInScript` can correctly handle a `$null`/empty `$Path`, so it's safer to remove `Mandatory`.
2. We can skip the test argument hack by checking the argument type.