### PR TITLE
Add AbbreviateHomeDirectory setting

### DIFF
--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -100,7 +100,7 @@ $global:GitPromptSettings = [pscustomobject]@{
     DefaultPromptSuffix                         = '$(''>'' * ($nestedPromptLevel + 1)) '
     DefaultPromptDebugSuffix                    = ' [DBG]$(''>'' * ($nestedPromptLevel + 1)) '
     DefaultPromptEnableTiming                   = $false
-    DefaultPromptAbbreviateHomeDirectory        = $true
+    DefaultPromptAbbreviateHomeDirectory        = $false
 
     Debug                                       = $false
 

--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -101,6 +101,8 @@ $global:GitPromptSettings = [pscustomobject]@{
     DefaultPromptDebugSuffix                    = ' [DBG]$(''>'' * ($nestedPromptLevel + 1)) '
     DefaultPromptEnableTiming                   = $false
 
+    AbbreviateHomeDirectory                     = $true
+
     Debug                                       = $false
 
     BranchNameLimit                             = 0

--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -100,8 +100,7 @@ $global:GitPromptSettings = [pscustomobject]@{
     DefaultPromptSuffix                         = '$(''>'' * ($nestedPromptLevel + 1)) '
     DefaultPromptDebugSuffix                    = ' [DBG]$(''>'' * ($nestedPromptLevel + 1)) '
     DefaultPromptEnableTiming                   = $false
-
-    AbbreviateHomeDirectory                     = $true
+    DefaultPromptAbbreviateHomeDirectory        = $true
 
     Debug                                       = $false
 

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -66,7 +66,7 @@ if (!$currentPromptDef -or ($currentPromptDef -eq $defaultPromptDef)) {
         }
 
         # Abbreviate path by replacing beginning of path with ~ *iff* the path is in the user's home dir
-        if ($currentPath -and $currentPath.StartsWith($Home, $stringComparison))
+        if ($GitPromptSettings.AbbreviateHomeDirectory -and $currentPath -and $currentPath.StartsWith($Home, $stringComparison))
         {
             $currentPath = "~" + $currentPath.SubString($Home.Length)
         }

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -66,7 +66,7 @@ if (!$currentPromptDef -or ($currentPromptDef -eq $defaultPromptDef)) {
         }
 
         # Abbreviate path by replacing beginning of path with ~ *iff* the path is in the user's home dir
-        if ($GitPromptSettings.AbbreviateHomeDirectory -and $currentPath -and $currentPath.StartsWith($Home, $stringComparison))
+        if ($GitPromptSettings.DefaultPromptAbbreviateHomeDirectory -and $currentPath -and $currentPath.StartsWith($Home, $stringComparison))
         {
             $currentPath = "~" + $currentPath.SubString($Home.Length)
         }


### PR DESCRIPTION
Adds a setting to optionally disable the home directory abbreviation in
the prompt. By default, this is set to true, preserving the existing
behavior.

Closes #386 