### PR TITLE
Warn if posh-git working directory is in PSModulePath

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
-param([switch]$WhatIf = $false)
+param([switch]$WhatIf = $false, [switch]$Force = $false)
 
 $installDir = Split-Path $MyInvocation.MyCommand.Path -Parent
 
 Import-Module $installDir\src\posh-git.psd1
-Add-PoshGitToProfile -WhatIf:$WhatIf
+Add-PoshGitToProfile -WhatIf:$WhatIf -Force:$Force

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -216,6 +216,7 @@ function Test-InPSModulePath {
     if (!$modulePaths) { return $false }
 
     $pathStringComparison = Get-PathStringComparison
+    $Path = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
     $inModulePath = @($modulePaths | Where-Object { $Path.StartsWith($_.TrimEnd([System.IO.Path]::DirectorySeparatorChar), $pathStringComparison) }).Count -gt 0
 
     if ($inModulePath -and ('src' -eq (Split-Path $Path -Leaf))) {

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -217,6 +217,13 @@ function Test-InPSModulePath {
 
     $pathStringComparison = Get-PathStringComparison
     $inModulePath = @($modulePaths | Where-Object { $Path.StartsWith($_, $pathStringComparison) }).Count -gt 0
+
+    if ($inModulePath -and ('src' -eq (Split-Path $Path -Leaf))) {
+        Write-Warning 'posh-git repository structure is incompatible with %PSModulePath%.'
+        Write-Warning 'Importing with absolute path instead.'
+        return $false
+    }
+
     $inModulePath
 }
 

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -216,7 +216,7 @@ function Test-InPSModulePath {
     if (!$modulePaths) { return $false }
 
     $pathStringComparison = Get-PathStringComparison
-    $inModulePath = @($modulePaths | Where-Object { $Path.StartsWith($_, $pathStringComparison) }).Count -gt 0
+    $inModulePath = @($modulePaths | Where-Object { $Path.StartsWith($_.TrimEnd([System.IO.Path]::DirectorySeparatorChar), $pathStringComparison) }).Count -gt 0
 
     if ($inModulePath -and ('src' -eq (Split-Path $Path -Leaf))) {
         Write-Warning 'posh-git repository structure is incompatible with %PSModulePath%.'

--- a/test/Utils.Tests.ps1
+++ b/test/Utils.Tests.ps1
@@ -114,13 +114,13 @@ New-Alias pscore C:\Users\Keith\GitHub\rkeithhill\PowerShell\src\powershell-win-
     Context 'Test-InPSModulePath Tests' {
         It 'Returns false for install not under any PSModulePaths' {
             Mock Get-PSModulePath { }
-            $path = "C:\Users\Keith\Documents\WindowsPowerShell\Modules\posh-git\0.7.0"
+            $path = "C:\Users\Keith\Documents\WindowsPowerShell\Modules\posh-git\0.7.0\"
             Test-InPSModulePath $path | Should Be $false
             Assert-MockCalled Get-PSModulePath
         }
         It 'Returns true for install under single PSModulePath' {
             Mock Get-PSModulePath {
-                return 'C:\Users\Keith\Documents\WindowsPowerShell\Modules\posh-git\0.7.0'
+                return 'C:\Users\Keith\Documents\WindowsPowerShell\Modules\posh-git\'
             }
             $path = "C:\Users\Keith\Documents\WindowsPowerShell\Modules\posh-git\0.7.0"
             Test-InPSModulePath $path | Should Be $true
@@ -128,8 +128,8 @@ New-Alias pscore C:\Users\Keith\GitHub\rkeithhill\PowerShell\src\powershell-win-
         }
         It 'Returns true for install under multiple PSModulePaths' {
             Mock Get-PSModulePath {
-                return 'C:\Users\Keith\Documents\WindowsPowerShell\Modules\posh-git\0.7.0',
-                       'C:\Users\Keith\Documents\WindowsPowerShell\Modules\posh-git\0.6.1.20160330'
+                return 'C:\Users\Keith\Documents\WindowsPowerShell\Modules\posh-git\0.7.0\',
+                       'C:\Users\Keith\Documents\WindowsPowerShell\Modules\posh-git\0.6.1.20160330\'
             }
             $path = "C:\Users\Keith\Documents\WindowsPowerShell\Modules\posh-git\0.7.0"
             Test-InPSModulePath $path | Should Be $true
@@ -137,8 +137,8 @@ New-Alias pscore C:\Users\Keith\GitHub\rkeithhill\PowerShell\src\powershell-win-
         }
         It 'Returns false when current posh-git module location is not under PSModulePaths' {
             Mock Get-PSModulePath {
-                return 'C:\Users\Keith\Documents\WindowsPowerShell\Modules\posh-git\0.7.0',
-                       'C:\Users\Keith\Documents\WindowsPowerShell\Modules\posh-git\0.6.1.20160330'
+                return 'C:\Users\Keith\Documents\WindowsPowerShell\Modules\posh-git\0.7.0\',
+                       'C:\Users\Keith\Documents\WindowsPowerShell\Modules\posh-git\0.6.1.20160330\'
             }
             $path = "C:\tools\posh-git\dahlbyk-posh-git-18d600a"
             Test-InPSModulePath $path | Should Be $false

--- a/test/Utils.Tests.ps1
+++ b/test/Utils.Tests.ps1
@@ -144,5 +144,13 @@ New-Alias pscore C:\Users\Keith\GitHub\rkeithhill\PowerShell\src\powershell-win-
             Test-InPSModulePath $path | Should Be $false
             Assert-MockCalled Get-PSModulePath
         }
+        It 'Returns false when current posh-git module location is under PSModulePath, but in a src directory' {
+            Mock Get-PSModulePath {
+                return 'C:\GitHub'
+            }
+            $path = "C:\GitHub\posh-git\src"
+            Test-InPSModulePath $path | Should Be $false
+            Assert-MockCalled Get-PSModulePath
+        }
     }
 }


### PR DESCRIPTION
Closes #391 with a warning that there was a `PSModulePath` match that we're ignoring:

```
WARNING: posh-git repository structure is incompatible with %PSModulePath%.
WARNING: Importing with absolute path instead.
```

Also:

- `PSModulePath`, for me at least, contains `C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\` and other paths with a trailing slash that we can now match directly. Not that this pattern will be common, but it bit me in local testing.
- `./install.ps1` delegates to `Add-PoshGitToProfile`, which will potentially warn "If you want to force the add, use the -Force parameter." but not specify where `-Force` is valid. So now it's also valid on `install.ps1`.