### PR TITLE
Only override OutputEncoding if single-byte

### DIFF
--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -32,11 +32,15 @@ function Invoke-Utf8ConsoleCommand([ScriptBlock]$cmd) {
         # A native executable that writes to stderr AND has its stderr redirected will generate non-terminating
         # error records if the user has set $ErrorActionPreference to Stop. Override that value in this scope.
         $ErrorActionPreference = 'Continue'
-        [Console]::OutputEncoding = [Text.Encoding]::UTF8
+        if ($currentEncoding.IsSingleByte) {
+            [Console]::OutputEncoding = [Text.Encoding]::UTF8
+        }
         & $cmd
     }
     finally {
-        [Console]::OutputEncoding = $currentEncoding
+        if ($currentEncoding.IsSingleByte) {
+            [Console]::OutputEncoding = $currentEncoding
+        }
 
         # Clear out stderr output that was added to the $Error collection, putting those errors in a module variable
         if ($global:Error.Count -gt $errorCount) {


### PR DESCRIPTION
Hack to fix #389 due to apparent [bug in .NET](http://stackoverflow.com/a/22363632/54249). Changes code added in #359.

My hypothesis is that the `[Console]::OutputEncoding` override is only necessary if we're not already using a multi-byte encoding.

I tested this locally by adding `chcp 65001` at the start of my `$PROFILE`. This causes the `OutputEncoding` override to be skipped, and posh-git still handles a UTF8 branch name as expected. Not sure what/how else to test, other than users with a variety of natural console/encoding settings.