### PR TITLE
Turn on autocrlf in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,9 @@ branches:
   only:
     - master
 
+init:
+  - git config --global core.autocrlf true
+
 install:
   - ps: |
       Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null


### PR DESCRIPTION
Fix test regression from #336 due to AppVeyor defaulting to `core.autocrlf = input` (which is a very strange choice, IMHO).

Related reading:
- https://www.appveyor.com/docs/appveyor-yml/
- http://help.appveyor.com/discussions/problems/671-coreautocrlf
- http://help.appveyor.com/discussions/problems/948-tests-fail-on-appveyor-but-not-locally
- http://help.appveyor.com/discussions/problems/1119-allow-changing-git-autocrlf-setting