### PR TITLE
Fix tab expansion for non-ASCII file paths

### DIFF
--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -224,7 +224,7 @@ function Get-GitStatus($gitDir = (Get-GitDirectory)) {
                 if ($cacheResponse.State) { $branch += "|" + $cacheResponse.State }
             } else {
                 dbg 'Getting status' $sw
-                $status = Invoke-Utf8ConsoleCommand { git -c color.status=false status --short --branch 2>$null }
+                $status = Invoke-Utf8ConsoleCommand { git -c core.quotepath=false -c color.status=false status --short --branch 2>$null }
                 if($settings.EnableStashStatus) {
                     dbg 'Getting stash count' $sw
                     $stashCount = $null | git stash list 2>$null | measure-object | Select-Object -expand Count

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -117,4 +117,32 @@ Describe 'TabExpansion Tests' {
             }
         }
     }
+    Context 'Add/Reset/Checkout TabExpansion Tests' {
+        BeforeEach {
+            $origPath = Get-Location
+            $temp = [System.IO.Path]::GetTempPath()
+            $repoPath = Join-Path $temp ([IO.Path]::GetRandomFileName())
+
+            git init $repoPath
+            Set-Location $repoPath
+        }
+        AfterEach {
+            Set-Location $origPath
+            if (Test-Path $repoPath) {
+                Remove-Item $repoPath -Recurse -Force
+            }
+        }
+        It 'Tab completes non-ASCII file name' {
+            git config core.quotepath true # Problematic (default) config
+
+            $fileName = "posh$([char]8226)git.txt"
+            New-Item $fileName
+
+            $GitStatus = & $module Get-GitStatus
+
+            $result = & $module GitTabExpansionInternal 'git add ' $GitStatus
+
+            $result | Should BeExactly $fileName
+        }
+    }
 }


### PR DESCRIPTION
Fix #64 now that #359 and #397 have fixed the [encoding issue I encountered at the time](https://github.com/dahlbyk/posh-git/issues/64#issuecomment-7152220).

![non-ascii-paths](https://cloud.githubusercontent.com/assets/133987/22661436/012a29de-ec6b-11e6-9725-d016d347894b.gif)

cc @Haacked