### PR TITLE
DefaultRunspace.Debugger.Inbreakpoint check

### DIFF
--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -87,7 +87,7 @@ if ($ForcePoshGitPrompt -or !$currentPromptDef -or ($currentPromptDef -eq $defau
         Write-VcsStatus
 
         # If stopped in the debugger, the prompt needs to indicate that in some fashion
-        $hasInBreakpoint = [runspace]::DefaultRunspace.Debugger | Get-member -Name InBreakPoint -MemberType property
+        $hasInBreakpoint = [runspace]::DefaultRunspace.Debugger | Get-Member -Name InBreakPoint -MemberType property
         $debugMode = (Test-Path Variable:/PSDebugContext) -or ($hasInBreakPoint -and [runspace]::DefaultRunspace.Debugger.InBreakpoint)
         $promptSuffix = if ($debugMode) { $GitPromptSettings.DefaultPromptDebugSuffix } else { $GitPromptSettings.DefaultPromptSuffix }
 

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -87,7 +87,8 @@ if ($ForcePoshGitPrompt -or !$currentPromptDef -or ($currentPromptDef -eq $defau
         Write-VcsStatus
 
         # If stopped in the debugger, the prompt needs to indicate that in some fashion
-        $debugMode = (Test-Path Variable:/PSDebugContext) -or [runspace]::DefaultRunspace.Debugger.InBreakpoint
+        $hasInBreakpoint = [runspace]::DefaultRunspace.Debugger | Get-member -Name InBreakPoint -MemberType property
+        $debugMode = (Test-Path Variable:/PSDebugContext) -or ($hasInBreakPoint -and [runspace]::DefaultRunspace.Debugger.InBreakpoint)
         $promptSuffix = if ($debugMode) { $GitPromptSettings.DefaultPromptDebugSuffix } else { $GitPromptSettings.DefaultPromptSuffix }
 
         # If user specifies $null or empty string, set to ' ' to avoid "PS>" unexpectedly being displayed

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -87,8 +87,8 @@ if ($ForcePoshGitPrompt -or !$currentPromptDef -or ($currentPromptDef -eq $defau
         Write-VcsStatus
 
         # If stopped in the debugger, the prompt needs to indicate that in some fashion
-        $hasInBreakpoint = [runspace]::DefaultRunspace.Debugger | Get-Member -Name InBreakPoint -MemberType property
-        $debugMode = (Test-Path Variable:/PSDebugContext) -or ($hasInBreakPoint -and [runspace]::DefaultRunspace.Debugger.InBreakpoint)
+        $hasInBreakpoint = [runspace]::DefaultRunspace.Debugger | Get-Member -Name InBreakpoint -MemberType property
+        $debugMode = (Test-Path Variable:/PSDebugContext) -or ($hasInBreakpoint -and [runspace]::DefaultRunspace.Debugger.InBreakpoint)
         $promptSuffix = if ($debugMode) { $GitPromptSettings.DefaultPromptDebugSuffix } else { $GitPromptSettings.DefaultPromptSuffix }
 
         # If user specifies $null or empty string, set to ' ' to avoid "PS>" unexpectedly being displayed


### PR DESCRIPTION
If I don't add that check, my prompt will always end in PS> which is quite annoying.

If I check which properties are available I get:
C:\opt [master]> [runspace]::DefaultRunspace.Debugger | fl *


IsActive  : False
DebugMode : LocalScript, RemoteScript

So it doesn't include InBreakpoint. Maybe it is only enabled when IsActive is true?