### PR TITLE
Remove SuppressMessage attr used by PSSA.

### DIFF
--- a/src/GitParamTabExpansion.ps1
+++ b/src/GitParamTabExpansion.ps1
@@ -1,5 +1,4 @@
 # Variable is used in GitTabExpansion.ps1
-[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
 $shortGitParams = @{
     add = 'n v f i p e u A N'
     bisect = ''
@@ -40,7 +39,6 @@ $shortGitParams = @{
 }
 
 # Variable is used in GitTabExpansion.ps1
-[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
 $longGitParams = @{
     add = 'dry-run verbose force interactive patch edit update all no-ignore-removal no-all ignore-removal intent-to-add refresh ignore-errors ignore-missing'
     bisect = 'no-checkout term-old term-new'
@@ -84,7 +82,6 @@ $longGitParams = @{
 }
 
 # Variable is used in GitTabExpansion.ps1
-[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
 $gitParamValues = @{
     blame = @{
         encoding = 'utf-8 none'


### PR DESCRIPTION
I'm leaving these attributes in for the Pester tests as I don't care if folks can't run the Pester tests on PS v2.  In fact, I'm not even sure Pester runs on v2.