### PR TITLE
Fix issue with tab expansion of duplicate aliases.

### DIFF
--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -192,9 +192,9 @@ function script:gitAliases($filter) {
 }
 
 function script:expandGitAlias($cmd, $rest) {
-    $gitAliases = @(git config --get-regexp "^alias\.$cmd`$")
-    if ($gitAliases[0] -match "^alias\.$cmd (?<cmd>[^!].*)`$") {
-        return "git $($Matches['cmd'])$rest"
+    $alias = git config "alias.$cmd"
+    if ($alias) {
+        return "git $alias$rest"
     }
     else {
         return "git $cmd$rest"

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -192,7 +192,8 @@ function script:gitAliases($filter) {
 }
 
 function script:expandGitAlias($cmd, $rest) {
-    if ((git config --get-regexp "^alias\.$cmd`$") -match "^alias\.$cmd (?<cmd>[^!].*)`$") {
+    $gitAliases = @(git config --get-regexp "^alias\.$cmd`$")
+    if ($gitAliases[0] -match "^alias\.$cmd (?<cmd>[^!].*)`$") {
         return "git $($Matches['cmd'])$rest"
     }
     else {

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -188,7 +188,7 @@ function script:gitAliases($filter) {
                 $alias
             }
         }
-    } | Get-Unique | Sort-Object
+    } | Sort-Object -Unique
 }
 
 function script:expandGitAlias($cmd, $rest) {

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -188,7 +188,7 @@ function script:gitAliases($filter) {
                 $alias
             }
         }
-    } | Sort-Object
+    } | Get-Unique | Sort-Object
 }
 
 function script:expandGitAlias($cmd, $rest) {

--- a/test/Shared.ps1
+++ b/test/Shared.ps1
@@ -23,12 +23,19 @@ function MakeGitPath([string]$Path) {
     $Path -replace '\\', '/'
 }
 
-function NewGitTempRepo {
+function NewGitTempRepo([switch]$MakeInitialCommit) {
     Push-Location
     $temp = [System.IO.Path]::GetTempPath()
     $repoPath = Join-Path $temp ([IO.Path]::GetRandomFileName())
     git.exe init $repoPath *>$null
     Set-Location $repoPath
+
+    if ($MakeInitialCommit) {
+        'readme' | Out-File .\README.md -Encoding ascii
+        git.exe add .\README.md *>$null
+        git.exe commit -m "initial commit." *>$null
+    }
+
     $repoPath
 }
 

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -161,6 +161,17 @@ Describe 'TabExpansion Tests' {
 
             RemoveGitTempRepo $repoPath
         }
+        It 'Command completion includes unique list of aliases' {
+            $alias = "test-$(New-Guid)"
+
+            Add-GlobalTestAlias $alias config
+            git.exe config alias.$alias help
+            (git.exe config --get-all alias.$alias).Count | Should Be 2
+
+            $result = @(& $module GitTabExpansionInternal "git $alias")
+            $result.Count | Should Be 1
+            $result[0] | Should BeExactly $alias
+        }
         It 'Tab completes when there is one alias of a given name' {
             $alias = "test-$(New-Guid)"
 

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -159,7 +159,7 @@ Describe 'TabExpansion Tests' {
 
             try {
                 git.exe config alias.co checkout
-                (git.exe config --get-all alias.co).Count | Should Be 2
+                (git.exe config --get-all alias.co).Count | Should BeGreaterThan 1
 
                 $result = & $module GitTabExpansionInternal 'git co ma'
                 $result | Should BeExactly 'master'

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -161,6 +161,15 @@ Describe 'TabExpansion Tests' {
 
             RemoveGitTempRepo $repoPath
         }
+        It 'Tab completes when there is one alias of a given name' {
+            $alias = "test-$(New-Guid)"
+
+            git.exe config alias.$alias checkout
+            (git.exe config --get-all alias.$alias).Count | Should Be 1
+
+            $result = & $module GitTabExpansionInternal "git $alias ma"
+            $result | Should BeExactly 'master'
+        }
         It 'Tab completes when there are multiple aliases of the same name' {
             Add-GlobalTestAlias co checkout
 

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -159,7 +159,7 @@ Describe 'TabExpansion Tests' {
 
             try {
                 git.exe config alias.co checkout
-                (git.exe config --get-regexp alias\.).Count | Should Be 2
+                (git.exe config --get-all alias.co).Count | Should Be 2
 
                 $result = & $module GitTabExpansionInternal 'git co ma'
                 $result | Should BeExactly 'master'

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -142,14 +142,40 @@ Describe 'TabExpansion Tests' {
         }
     }
 
+    Context 'Alias TabExpansion Tests' {
+        BeforeAll {
+            [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
+            $repoPath = NewGitTempRepo -MakeInitialCommit
+        }
+        AfterAll {
+            RemoveGitTempRepo $repoPath
+        }
+        It 'Tab completes when there are multiple aliases of the same name' {
+            $addedAlias = $false
+            if (!(git config --global --get alias.co)) {
+                git.exe config --global alias.co checkout
+                $addedAlias = $true
+            }
+
+            try {
+                git.exe config alias.co checkout
+                (git.exe config --get-regexp alias\.).Count | Should Be 2
+
+                $result = & $module GitTabExpansionInternal 'git co ma'
+                $result | Should BeExactly 'master'
+            }
+            finally {
+                if ($addedAlias) {
+                    git config --global --unset alias.co
+                }
+            }
+        }
+    }
+
     Context 'PowerShell Special Chars Tests' {
         BeforeAll {
             [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-            $repoPath = NewGitTempRepo
-
-            'readme' | Out-File .\README.md -Encoding ascii
-            git.exe add .\README.md
-            git.exe commit -m "initial commit."
+            $repoPath = NewGitTempRepo -MakeInitialCommit
         }
         AfterAll {
             RemoveGitTempRepo $repoPath


### PR DESCRIPTION
Add Pester test for bug.  Fix #421.

Also, fix that duplicate aliases would appear in the command tab expansion list.