### PR TITLE
Remove PowerShell v2 support.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,10 +4,10 @@
         {
             "type": "PowerShell",
             "request": "launch",
-            "name": "PowerShell Launch Pester Tests",
-            "script": "${workspaceRoot}/test/testDebugHarness.ps1",
+            "name": "PowerShell Pester Tests",
+            "script": "Invoke-Pester",
             "args": [],
-            "cwd": "${file}"
+            "cwd": "${workspaceRoot}/test"
         },
         {
             "type": "PowerShell",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # posh-git Release History
 
+## 1.0.0 - TBD
+This release introduces breaking changes with 0.x to both drop support for PowerShell 2.0 and support writing prompt strings using ANSI sequences.
+The ANSI sequence support will help with cross-platform PowerShell support which is another goal of this release.
+
+- Drop support for PowerShell 2.0
+- Remove Invoke-NullCoalescing command
+  ([#93](https://github.com/dahlbyk/posh-git/issues/93))
+  ([PR #426](https://github.com/dahlbyk/posh-git/pull/426))
+
 ## 0.7.0 - February 14, 2017
 This release has focused on improving the "getting started" experience by adding an `Add-PoshGitToProfile` command that
 modifies the user's PowerShell profile script to import the posh-git module whenever PowerShell starts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The ANSI sequence support will help with cross-platform PowerShell support, whic
 - Drop support for PowerShell 2.0
   ([#163](https://github.com/dahlbyk/posh-git/issues/163))
   ([PR #427](https://github.com/dahlbyk/posh-git/pull/427))
-- Remove `Invoke-NullCoalescing` command
+- Remove public `Enable-GitColors`, `Get-AliasPattern` and `Get-GitBranch`; plus `Invoke-NullCoalescing` and its `??` alias
   ([#93](https://github.com/dahlbyk/posh-git/issues/93))
   ([PR #427](https://github.com/dahlbyk/posh-git/pull/427))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## 1.0.0 - TBD
 This release introduces breaking changes with 0.x to both drop support for PowerShell 2.0 and support writing prompt strings using ANSI sequences.
-The ANSI sequence support will help with cross-platform PowerShell support which is another goal of this release.
+The ANSI sequence support will help with cross-platform PowerShell support, which is another goal of this release.
 
 - Drop support for PowerShell 2.0
-- Remove Invoke-NullCoalescing command
+  ([#163](https://github.com/dahlbyk/posh-git/issues/163))
+  ([PR #427](https://github.com/dahlbyk/posh-git/pull/427))
+- Remove `Invoke-NullCoalescing` command
   ([#93](https://github.com/dahlbyk/posh-git/issues/93))
-  ([PR #426](https://github.com/dahlbyk/posh-git/pull/426))
+  ([PR #427](https://github.com/dahlbyk/posh-git/pull/427))
 
 ## 0.7.0 - February 14, 2017
 This release has focused on improving the "getting started" experience by adding an `Add-PoshGitToProfile` command that

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Rather than turn off file status entirely (`$GitPromptSettings.EnableFileStatus 
 ### Prerequisites
 Before installing posh-git make sure the following prerequisites have been met.
 
-1. PowerShell 2.0 or higher. Check your PowerShell version by executing `$PSVersionTable.PSVersion`.
+1. PowerShell 3.0 or higher. Check your PowerShell version by executing `$PSVersionTable.PSVersion`.
 
 2. Script execution policy must be set to either `RemoteSigned` or `Unrestricted`.
    Check the script execution policy setting by executing `Get-ExecutionPolicy`.
@@ -58,7 +58,7 @@ Update-Module posh-git
 ```
 
 ### Installing posh-git via Chocolatey
-If you have PowerShell version 2 or are having issues using Install-Module with PowerShell version 3 or 4, you can use [Chocolatey](https://chocolatey.org) to install posh-git.
+If you are having issues using Install-Module with PowerShell version 3 or 4, you can use [Chocolatey](https://chocolatey.org) to install posh-git.
 If you don't have Chocolatey, you can install it from the [Chocolately Install page](https://chocolatey.org/install).
 With Chocolatey installed, execute the following command to install posh-git:
 ```

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ You may be asked if you trust packages coming from the PowerShell Gallery. Answe
 
 If you are on PowerShell version 3 or 4, you will need to install the [Package Management Preview for PowerShell 3 & 4](https://www.microsoft.com/en-us/download/details.aspx?id=51451) in order to run the command above.
 
-Note: If you get an error message from Install-Module about NuGet being required to interact with NuGet-based repositories, execute the following commands to bootstrap the NuGet provider:
+Note: If you get an error message from `Install-Module` about NuGet being required to interact with NuGet-based repositories, execute the following commands to bootstrap the NuGet provider:
 ```
 Install-PackageProvider NuGet -Force
 Import-PackageProvider NuGet -Force
 ```
-Then retry the Install-Module command above.
+Then retry the `Install-Module` command above.
 
 After you have successfully installed the posh-git module from the PowerShell Gallery, you will be able to update to a newer version by executing the command:
 ```
@@ -58,7 +58,7 @@ Update-Module posh-git
 ```
 
 ### Installing posh-git via Chocolatey
-If you are having issues using Install-Module with PowerShell version 3 or 4, you can use [Chocolatey](https://chocolatey.org) to install posh-git.
+If you are having issues using `Install-Module` with PowerShell version 3 or 4, you can use [Chocolatey](https://chocolatey.org) to install posh-git.
 If you don't have Chocolatey, you can install it from the [Chocolately Install page](https://chocolatey.org/install).
 With Chocolatey installed, execute the following command to install posh-git:
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ os:
 
 branches:
   only:
-    - master
+    - develop
 
 init:
   - git config --global core.autocrlf true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ os:
 branches:
   only:
     - develop
+    - master
 
 init:
   - git config --global core.autocrlf true

--- a/chocolatey/poshgit.nuspec
+++ b/chocolatey/poshgit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>poshgit</id>
     <title>posh-git</title>
-    <version>0.7.0</version>
+    <version>1.0.0-pre00</version>
     <authors>Keith Dahlby, Mark Embling, Jeremy Skinner, Keith Hill</authors>
     <owners>Keith Dahlby</owners>
     <description>### posh-git

--- a/src/CheckRequirements.ps1
+++ b/src/CheckRequirements.ps1
@@ -7,12 +7,14 @@ if (!(Get-Command git -TotalCount 1 -ErrorAction SilentlyContinue)) {
 }
 
 $requiredVersion = [Version]'1.7.2'
-if ([String](git --version 2> $null) -match '(?<ver>\d+(?:\.\d+)+)') {
+if ([string](git --version 2> $null) -match '(?<ver>\d+(?:\.\d+)+)') {
     $version = [Version]$Matches['ver']
 }
+
 if ($version -lt $requiredVersion) {
     Write-Warning "posh-git requires Git $requiredVersion or better. You have $version."
     $false
-} else {
+}
+else {
     $true
 }

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -4,7 +4,7 @@
 RootModule = 'posh-git.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.0'
+ModuleVersion = '1.0.0.0'
 
 # ID used to uniquely identify this module
 GUID = '74c9fd30-734b-4c89-a8ae-7727ad21d1d5'
@@ -24,9 +24,6 @@ PowerShellVersion = '3.0'
 # Functions to export from this module
 FunctionsToExport = @(
     'Add-PoshGitToProfile',
-    'Enable-GitColors',
-    'Get-AliasPattern',
-    'Get-GitBranch',
     'Get-GitStatus',
     'Get-GitDirectory',
     'Update-AllBranches',

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -69,7 +69,7 @@ PrivateData = @{
         ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/develop/CHANGELOG.md'
 
         # TODO: REMOVE BEFOE RELEASE
-        PrereleaseVersion = 'pre00'
+        PreReleaseVersion = 'pre00'
     }
 
 }

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -1,10 +1,10 @@
 @{
 
 # Script module or binary module file associated with this manifest.
-ModuleToProcess = 'posh-git.psm1'
+RootModule = 'posh-git.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.7.0'
+ModuleVersion = '1.0.0'
 
 # ID used to uniquely identify this module
 GUID = '74c9fd30-734b-4c89-a8ae-7727ad21d1d5'
@@ -19,27 +19,26 @@ Copyright = '(c) 2010-2017 Keith Dahlby and contributors'
 Description = 'Provides prompt with Git status summary information and tab completion for Git commands, parameters, remotes and branch names.'
 
 # Minimum version of the Windows PowerShell engine required by this module
-PowerShellVersion = '2.0'
+PowerShellVersion = '3.0'
 
 # Functions to export from this module
 FunctionsToExport = @(
-    'Invoke-NullCoalescing',
     'Add-PoshGitToProfile',
+    'Enable-GitColors',
+    'Get-AliasPattern',
+    'Get-GitBranch',
+    'Get-GitStatus',
+    'Get-GitDirectory',
+    'Update-AllBranches',
     'Write-GitStatus',
     'Write-Prompt',
     'Write-VcsStatus',
-    'Get-GitBranch',
-    'Get-GitStatus',
-    'Enable-GitColors',
-    'Get-GitDirectory',
-    'TabExpansion',
-    'Get-AliasPattern',
     'Get-SshAgent',
     'Start-SshAgent',
     'Stop-SshAgent',
     'Add-SshKey',
     'Get-SshPath',
-    'Update-AllBranches',
+    'TabExpansion',
     'tgit'
 )
 
@@ -50,7 +49,7 @@ CmdletsToExport = @()
 VariablesToExport = @()
 
 # Aliases to export from this module
-AliasesToExport = @('??')
+AliasesToExport = @()
 
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{
@@ -61,13 +60,13 @@ PrivateData = @{
         Tags = @('git', 'prompt', 'tab', 'tab-completion', 'tab-expansion', 'tabexpansion')
 
         # A URL to the license for this module.
-        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/v0.7.0/LICENSE.txt'
+        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/develop/LICENSE.txt'
 
         # A URL to the main website for this project.
         ProjectUri = 'https://github.com/dahlbyk/posh-git'
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/v0.7.0/CHANGELOG.md'
+        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/develop/CHANGELOG.md'
 
     } # End of PSData hashtable
 

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -51,11 +51,11 @@ VariablesToExport = @()
 # Aliases to export from this module
 AliasesToExport = @()
 
-# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+# Private data to pass to the module specified in RootModule/ModuleToProcess.
+# This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{
 
     PSData = @{
-
         # Tags applied to this module. These help with module discovery in online galleries.
         Tags = @('git', 'prompt', 'tab', 'tab-completion', 'tab-expansion', 'tabexpansion')
 
@@ -68,8 +68,10 @@ PrivateData = @{
         # ReleaseNotes of this module
         ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/develop/CHANGELOG.md'
 
-    } # End of PSData hashtable
+        # TODO: REMOVE BEFOE RELEASE
+        PrereleaseVersion = 'pre00'
+    }
 
-} # End of PrivateData hashtable
+}
 
 }

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -1,17 +1,6 @@
-param([switch]$NoVersionWarn,[switch]$ForcePoshGitPrompt)
+param([switch]$NoVersionWarn, [switch]$ForcePoshGitPrompt)
 
-if (Get-Module posh-git) { return }
-
-$psv = $PSVersionTable.PSVersion
-
-if ($psv.Major -lt 3 -and !$NoVersionWarn) {
-    Write-Warning ("posh-git support for PowerShell 2.0 is deprecated; you have version $($psv).`n" +
-    "To download version 5.0, please visit https://www.microsoft.com/en-us/download/details.aspx?id=50395`n" +
-    "For more information and to discuss this, please visit https://github.com/dahlbyk/posh-git/issues/163`n" +
-    "To suppress this warning, change your profile to include 'Import-Module posh-git -Args `$true'.")
-}
-
-& $PSScriptRoot\CheckVersion.ps1 > $null
+& $PSScriptRoot\CheckRequirements.ps1 > $null
 
 . $PSScriptRoot\Utils.ps1
 . $PSScriptRoot\GitUtils.ps1
@@ -27,11 +16,12 @@ Get-TempEnv 'SSH_AGENT_PID'
 Get-TempEnv 'SSH_AUTH_SOCK'
 
 # Get the default prompt definition.
-if (($psv.Major -eq 2) -or ![Runspace]::DefaultRunspace.InitialSessionState.Commands) {
+$initialSessionState = [Runspace]::DefaultRunspace.InitialSessionState
+if (!$initialSessionState.Commands -or !$initialSessionState.Commands['prompt']) {
     $defaultPromptDef = "`$(if (test-path variable:/PSDebugContext) { '[DBG]: ' } else { '' }) + 'PS ' + `$(Get-Location) + `$(if (`$nestedpromptlevel -ge 1) { '>>' }) + '> '"
 }
 else {
-    $defaultPromptDef = [Runspace]::DefaultRunspace.InitialSessionState.Commands['prompt'].Definition
+    $defaultPromptDef = $initialSessionState.Commands['prompt'].Definition
 }
 
 # If there is no prompt function or the prompt function is the default, replace the current prompt function definition
@@ -44,8 +34,7 @@ if (!$currentPromptDef) {
 }
 
 if ($ForcePoshGitPrompt -or !$currentPromptDef -or ($currentPromptDef -eq $defaultPromptDef)) {
-    # Have to use [scriptblock]::Create() to get debugger detection to work in PS v2
-    $poshGitPromptScriptBlock = [scriptblock]::Create(@'
+    $poshGitPromptScriptBlock = {
         if ($GitPromptSettings.DefaultPromptEnableTiming) {
             $sw = [System.Diagnostics.Stopwatch]::StartNew()
         }
@@ -107,7 +96,7 @@ if ($ForcePoshGitPrompt -or !$currentPromptDef -or ($currentPromptDef -eq $defau
 
         $global:LASTEXITCODE = $origLastExitCode
         $expandedPromptSuffix
-'@)
+    }
 
     # Set the posh-git prompt as the default prompt
     Set-Item Function:\prompt -Value $poshGitPromptScriptBlock
@@ -128,25 +117,23 @@ $ExecutionContext.SessionState.Module.OnRemove = {
 }
 
 $exportModuleMemberParams = @{
-    Alias = @('??') # TODO: Remove in 1.0.0
     Function = @(
-        'Invoke-NullCoalescing',
         'Add-PoshGitToProfile',
+        'Enable-GitColors',
+        'Get-AliasPattern',
+        'Get-GitBranch',
+        'Get-GitDirectory',
+        'Get-GitStatus',
+        'Update-AllBranches',
         'Write-GitStatus',
         'Write-Prompt',
         'Write-VcsStatus',
-        'Get-GitBranch',
-        'Get-GitStatus',
-        'Enable-GitColors',
-        'Get-GitDirectory',
-        'TabExpansion',
-        'Get-AliasPattern',
         'Get-SshAgent',
         'Start-SshAgent',
         'Stop-SshAgent',
         'Add-SshKey',
         'Get-SshPath',
-        'Update-AllBranches',
+        'TabExpansion',
         'tgit'
     )
 }

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -119,9 +119,6 @@ $ExecutionContext.SessionState.Module.OnRemove = {
 $exportModuleMemberParams = @{
     Function = @(
         'Add-PoshGitToProfile',
-        'Enable-GitColors',
-        'Get-AliasPattern',
-        'Get-GitBranch',
         'Get-GitDirectory',
         'Get-GitStatus',
         'Update-AllBranches',

--- a/test/Get-GitBranch.Tests.ps1
+++ b/test/Get-GitBranch.Tests.ps1
@@ -1,16 +1,18 @@
 . $PSScriptRoot\Shared.ps1
 
-Describe 'Get-GitBranch Tests' {
-    Context 'Get-GitBranch GIT_DIR Tests' {
-        It 'Returns GIT_DIR! when in .git dir of the repo' {
-            $repoRoot = (Resolve-Path $PSScriptRoot\..).Path
-            Set-Location $repoRoot\.git -ErrorAction Stop
-            Get-GitBranch | Should BeExactly 'GIT_DIR!'
-        }
-        It 'Returns correct path when in a child folder of the .git dir of the repo' {
-            $repoRoot = (Resolve-Path $PSScriptRoot\..).Path
-            Set-Location $repoRoot\.git\hooks -ErrorAction Stop
-            Get-GitBranch | Should BeExactly 'GIT_DIR!'
+InModuleScope posh-git {
+    Describe 'Get-GitBranch Tests' {
+        Context 'Get-GitBranch GIT_DIR Tests' {
+            It 'Returns GIT_DIR! when in .git dir of the repo' {
+                $repoRoot = (Resolve-Path $PSScriptRoot\..).Path
+                Set-Location $repoRoot\.git -ErrorAction Stop
+                Get-GitBranch | Should BeExactly 'GIT_DIR!'
+            }
+            It 'Returns correct path when in a child folder of the .git dir of the repo' {
+                $repoRoot = (Resolve-Path $PSScriptRoot\..).Path
+                Set-Location $repoRoot\.git\hooks -ErrorAction Stop
+                Get-GitBranch | Should BeExactly 'GIT_DIR!'
+            }
         }
     }
 }

--- a/test/Utils.Tests.ps1
+++ b/test/Utils.Tests.ps1
@@ -4,9 +4,11 @@
 Describe 'Utils Function Tests' {
     Context 'Add-PoshGitToProfile Tests' {
         BeforeAll {
-           $newLine = [System.Environment]::NewLine
+            [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
+            $newLine = [System.Environment]::NewLine
         }
         BeforeEach {
+            [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
             $profilePath = [System.IO.Path]::GetTempFileName()
         }
         AfterEach {
@@ -84,6 +86,7 @@ New-Alias pscore C:\Users\Keith\GitHub\rkeithhill\PowerShell\src\powershell-win-
 
     Context 'Test-PoshGitImportedInScript Tests' {
         BeforeEach {
+            [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
             $profilePath = [System.IO.Path]::GetTempFileName()
         }
         AfterEach {

--- a/test/testDebugHarness.ps1
+++ b/test/testDebugHarness.ps1
@@ -1,2 +1,0 @@
-
-Invoke-Pester $PSScriptRoot


### PR DESCRIPTION
Also doing some miscellaneous cleanup (remove Invoke-NullCoalescing, remove testDebugHarness.ps1 in favor of using the Pester Tests debug configuration, rename CheckVersion.ps1 to CheckRequirements.ps1).

Checkout the version number (1.0.0-pre00) in the chocolatey/poshgit.nuspec file.  Not sure which version of NuGet is being used but if v2, I think the prelease string uses a simple lexicographic sort so that pre10 would sort below pre9.  I suspect 1.0 could have more than 10 prerelease choco drops.  I hope not more than 100 though.  :-)

cc https://github.com/dahlbyk/posh-git/issues/163