### PR TITLE
Don't rerun pageant if there are no keys to add

### DIFF
--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -529,7 +529,9 @@ function Add-SshKey() {
         if ($args.Count -eq 0) {
             $keyPath = Join-Path $Env:HOME .ssh
             $keys = Get-ChildItem $keyPath/*.ppk -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName
-            & $pageant $keys
+            if ($keys) {
+                & $pageant $keys
+            }
         }
         else {
             foreach ($value in $args) {


### PR DESCRIPTION
Currently, if there is no key file, posh-git's Start-SshAgent runs pageant twice which causes pageant to show an error dialog about already running. This simple change stops that happening.