### PR TITLE
Hide profile.example.ps1 warning for Chocolatey

### DIFF
--- a/chocolatey/tools/chocolateyInstall.ps1
+++ b/chocolatey/tools/chocolateyInstall.ps1
@@ -27,7 +27,7 @@
             if ($line -like '*PoshGitPrompt*') { continue; }
 
             if($line -like '. *posh-git*profile.example.ps1*') {
-                $line = ". '$currentVersionPath\profile.example.ps1'"
+                $line = ". '$currentVersionPath\profile.example.ps1' choco"
             }
             if($line -like 'Import-Module *\src\posh-git.psd1*') {
                 $line = "Import-Module '$currentVersionPath\src\posh-git.psd1'"

--- a/chocolatey/tools/chocolateyUninstall.ps1
+++ b/chocolatey/tools/chocolateyUninstall.ps1
@@ -13,6 +13,7 @@
         foreach($line in $oldProfile) {
             if ($line -like '*PoshGitPrompt*') { continue; }
             if ($line -like '*Load posh-git example profile*') { continue; }
+            if ($line -like '*Start-SshAgent*') { continue; }
 
             if($line -like '. *posh-git*profile.example.ps1*') {
                 continue;

--- a/profile.example.ps1
+++ b/profile.example.ps1
@@ -18,5 +18,6 @@ else {
 Start-SshAgent -Quiet
 
 if ($args[0] -ne 'choco') {
-    Write-Warning "posh-git's profile.example.ps1 will be removed in a future version. To avoid a change in behavior, copy its contents into your $PROFILE."
+    Write-Warning "posh-git's profile.example.ps1 will be removed in a future version."
+    Write-Warning "Consider using `Add-PoshGitToProfile -StartSshAgent` instead."
 }

--- a/profile.example.ps1
+++ b/profile.example.ps1
@@ -17,4 +17,6 @@ else {
 
 Start-SshAgent -Quiet
 
-Write-Warning "posh-git's profile.example.ps1 will be removed in a future version. To avoid a change in behavior, copy its contents into your $PROFILE."
+if ($args[0] -ne 'choco') {
+    Write-Warning "posh-git's profile.example.ps1 will be removed in a future version. To avoid a change in behavior, copy its contents into your $PROFILE."
+}

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -69,6 +69,8 @@ function Invoke-Utf8ConsoleCommand([ScriptBlock]$cmd) {
 .PARAMETER Force
     Do not check if the specified profile script is already importing
     posh-git. Just add Import-Module posh-git command.
+.PARAMETER StartSshAgent
+    Also add `Start-SshAgent -Quiet` to the specified profile script.
 .EXAMPLE
     PS C:\> Add-PoshGitToProfile
     Updates your profile script for the current PowerShell host to import the
@@ -92,6 +94,10 @@ function Add-PoshGitToProfile {
         [Parameter()]
         [switch]
         $Force,
+
+        [Parameter()]
+        [switch]
+        $StartSshAgent,
 
         [Parameter(ValueFromRemainingArguments)]
         [psobject[]]
@@ -172,6 +178,9 @@ function Add-PoshGitToProfile {
 
     if ($PSCmdlet.ShouldProcess($profilePath, "Add 'Import-Module posh-git' to profile")) {
         Add-Content -LiteralPath $profilePath -Value $profileContent -Encoding UTF8
+    }
+    if ($StartSshAgent -and $PSCmdlet.ShouldProcess($profilePath, "Add 'Start-SshAgent -Quiet' to profile")) {
+        Add-Content -LiteralPath $profilePath -Value 'Start-SshAgent -Quiet' -Encoding UTF8
     }
 }
 

--- a/test/Utils.Tests.ps1
+++ b/test/Utils.Tests.ps1
@@ -80,6 +80,23 @@ New-Alias pscore C:\Users\Keith\GitHub\rkeithhill\PowerShell\src\powershell-win-
             $profileContent += "${newLine}${newLine}Import-Module posh-git"
             $content -join $newLine | Should BeExactly $profileContent
         }
+        It 'Adds Start-SshAgent if posh-git is not installed' {
+            Add-PoshGitToProfile $profilePath -StartSshAgent
+
+            Test-Path -LiteralPath $profilePath | Should Be $true
+            $last = Get-Content $profilePath | Select-Object -Last 1
+            $last | Should BeExactly "Start-SshAgent -Quiet"
+        }
+        It 'Does not add Start-SshAgent if posh-git is installed' {
+            $profileContent = 'Import-Module posh-git'
+            Set-Content $profilePath -Value $profileContent
+
+            Add-PoshGitToProfile $profilePath -StartSshAgent
+
+            Test-Path -LiteralPath $profilePath | Should Be $true
+            $content = Get-Content $profilePath
+            $content | Should BeExactly $profileContent
+        }
     }
 
     Context 'Test-PoshGitImportedInScript Tests' {


### PR DESCRIPTION
Fixes #442 with two changes:

1. Hides the warning if posh-git is managed by Chocolatey, since we can largely control use of `profile.example.ps1` with the installer
2. Replaces the "copy its contents into your $PROFILE" suggestion with a better recommendation

#338 notwithstanding, one useful thing `profile.example.ps1` does is call `Start-SshAgent`, so I've also added `Add-PoshGitToProfile -StartSshAgent` to add the same.