### PR TITLE
Quote remotes with special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   ([PR #425](https://github.com/dahlbyk/posh-git/pull/425))
 - Fix Chocolatey deprecation warning with dependency on 0.9.10
   ([PR #426](https://github.com/dahlbyk/posh-git/pull/426))
+- Quote tab completion for remote names containing special characters
+  ([PR #446](https://github.com/dahlbyk/posh-git/pull/446))
 
 ## 0.7.0 - February 14, 2017
 This release has focused on improving the "getting started" experience by adding an `Add-PoshGitToProfile` command that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,12 @@ Work was begun to eliminate some obvious crashes on PowerShell on .NET Core but 
 - Add support for tab-completion of Git parameters, long and short
   ([PR #395](https://github.com/dahlbyk/posh-git/pull/395))
 - Switch `$GitPromptSettings` type from `PSObject` to `PSCustomObject`. On PowerShell v5 and higher, this preserves the definition order of properties in `$GitPromptSettings` making it easier to find properties.
+- Fix prompt status in worktree
+  ([#407](https://github.com/dahlbyk/posh-git/issues/407))
+  ([PR #408](https://github.com/dahlbyk/posh-git/pull/408))
+- Quote tab completion for items containing special characters
+  ([#293](https://github.com/dahlbyk/posh-git/issues/293))
+  ([PR #413](https://github.com/dahlbyk/posh-git/pull/413))
 
 ## Thank You:
 Thank you to the following folks who contributed their time and scripting skills to make posh-git better:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   ([PR #425](https://github.com/dahlbyk/posh-git/pull/425))
 - Fix Chocolatey deprecation warning with dependency on 0.9.10
   ([PR #426](https://github.com/dahlbyk/posh-git/pull/426))
+- Don't rerun Pageant if there are no keys to add
+  ([PR #441](https://github.com/dahlbyk/posh-git/pull/441))
+- Improve (and hide for Chocolatey) profile.example.ps1 deprecation messaging
+  ([#442](https://github.com/dahlbyk/posh-git/issues/442))
+  ([PR #444](https://github.com/dahlbyk/posh-git/pull/444))
 - Quote tab completion for remote names containing special characters
   ([PR #446](https://github.com/dahlbyk/posh-git/pull/446))
 

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -81,7 +81,9 @@ function script:gitCommands($filter, $includeAliases) {
 }
 
 function script:gitRemotes($filter) {
-    git remote | Where-Object { $_ -like "$filter*" }
+    git remote |
+        Where-Object { $_ -like "$filter*" } |
+        quoteStringWithSpecialChars
 }
 
 function script:gitBranches($filter, $includeHEAD = $false, $prefix = '') {

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -207,6 +207,12 @@ Describe 'TabExpansion Tests' {
         AfterEach {
             ResetGitTempRepoWorkingDir $repoPath
         }
+        It 'Tab completes remote name with special char as quoted' {
+            git.exe remote add '#test' https://github.com/dahlbyk/posh-git.git 2> $null
+
+            $result = & $module GitTabExpansionInternal 'git push #'
+            $result | Should BeExactly "'#test'"
+        }
         It 'Tab completes branch name with special char as quoted' {
             git.exe branch '#develop' 2>$null
 

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -10,8 +10,10 @@ Describe 'TabExpansion Tests' {
             git branch -q master origin/master 2>$null
         }
         It 'Tab completes all remotes' {
+            (git remote) -contains 'origin' | Should Be $true
+
             $result = & $module GitTabExpansionInternal 'git push '
-            $result | Should BeExactly (git remote)
+            $result -contains 'origin' | Should Be $true
         }
         It 'Tab completes all branches' {
             $result = & $module GitTabExpansionInternal 'git push origin '


### PR DESCRIPTION
Missed this one in #413, and we missed that fix in the 0.7.0 changelog!

Also: other changelog fixes for 0.7.0 and 0.7.1.