### PR TITLE
During install create the profile dir if it does not already exist

### DIFF
--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -176,6 +176,14 @@ function Add-PoshGitToProfile {
         $profileContent = "`nImport-Module '$ModuleBasePath\posh-git.psd1'"
     }
 
+    # Make sure the PowerShell profile directory exists
+    $profileDir = Split-Path $profilePath -Parent
+    if (!(Test-Path -LiteralPath $profileDir)) { 
+        if ($PSCmdlet.ShouldProcess($profileDir, "Create current user PowerShell profile directory")) {
+            New-Item $profileDir -ItemType Directory -Verbose:$VerbosePreference > $null
+        }
+    }
+
     if ($PSCmdlet.ShouldProcess($profilePath, "Add 'Import-Module posh-git' to profile")) {
         Add-Content -LiteralPath $profilePath -Value $profileContent -Encoding UTF8
     }


### PR DESCRIPTION
While installing posh-git using install.ps1 on Windows 7 Enterprise SP1 laptops for users running Powershell 4.0 or 5.0 had some users receive this error:

    PS C:\tools\posh-git> .\install.ps1
    Add-Content : Could not find a part of the path
    'C:\Users\*username*\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1'.
    At C:\tools\posh-git\src\Utils.ps1:180 char:9
    +         Add-Content -LiteralPath $profilePath -Value $profileContent -Encoding U ...

Nothing had previously been added to the user's Profile scripts AND the folder "WindowsPowerShell" did not exists under the user's documents.  This caused Add-Content to fail.

The pull request is to create the Powershell profile directory for the current user if it does not already exists.

Tested both with and without -WhatIf and it works good.