### PR TITLE
Fix #448 SignatureType enum not available on PS v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   ([PR #444](https://github.com/dahlbyk/posh-git/pull/444))
 - Quote tab completion for remote names containing special characters
   ([PR #446](https://github.com/dahlbyk/posh-git/pull/446))
+- Install throws an exception due to missing SignatureType on PowerShell v2
+  ([PR #450](https://github.com/dahlbyk/posh-git/pull/450))
 
 ## 0.7.0 - February 14, 2017
 This release has focused on improving the "getting started" experience by adding an `Add-PoshGitToProfile` command that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@
   ([PR #444](https://github.com/dahlbyk/posh-git/pull/444))
 - Quote tab completion for remote names containing special characters
   ([PR #446](https://github.com/dahlbyk/posh-git/pull/446))
-- Install throws an exception due to missing SignatureType on PowerShell v2
-  ([PR #450](https://github.com/dahlbyk/posh-git/pull/450))
 
 ## 0.7.0 - February 14, 2017
 This release has focused on improving the "getting started" experience by adding an `Add-PoshGitToProfile` command that

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -161,7 +161,7 @@ function Add-PoshGitToProfile {
     # If the profile script exists and is signed, then we should not modify it
     if (Test-Path -LiteralPath $profilePath) {
         $sig = Get-AuthenticodeSignature $profilePath
-        if ($sig.SignatureType -eq [System.Management.Automation.SignatureType]::Authenticode) {
+        if ($null -ne $sig.SignerCertificate) {
             Write-Warning "Skipping add of posh-git import to profile; '$profilePath' appears to be signed."
             Write-Warning "Add the command 'Import-Module posh-git' to your profile and resign it."
             return


### PR DESCRIPTION
We now rely on the SignerCertificate field to be $null.  If it isn't $null, then we assume the profile is signed and we don't modify it.  Note that this field is not $null when the file is signed but there is a hash mismatch (which is the desired behavior).  Fix #448 