### PR TITLE
Verbose install parameter

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
-param([switch]$WhatIf = $false, [switch]$Force = $false)
+param([switch]$WhatIf = $false, [switch]$Force = $false, [switch]$Verbose = $false)
 
 $installDir = Split-Path $MyInvocation.MyCommand.Path -Parent
 
 Import-Module $installDir\src\posh-git.psd1
-Add-PoshGitToProfile -WhatIf:$WhatIf -Force:$Force
+Add-PoshGitToProfile -WhatIf:$WhatIf -Force:$Force -Verbose:$Verbose


### PR DESCRIPTION
When troubleshooting install issues, it would be nice to be able to call:
`.\install.ps1 -Verbose`

Alternative for seeing verbose output from install.ps1 is:
```
$VerbosePreference = "Continue"
.\install.ps1
```

Another option would be to add SupportsShouldProcess binding, but then Import-Module also displays verbose output and it is pretty chatty.  I am assuming that is why WhatIf was also added separately.

I wasn't sure though the order you would like the Verbose parameter declared in and then later used when calling Add-PoshGitToProfile.  Let me know if you would like for me to change the orders.