### PR TITLE
Add test for update to Add-PoshGitToProfile

### DIFF
--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -178,9 +178,9 @@ function Add-PoshGitToProfile {
 
     # Make sure the PowerShell profile directory exists
     $profileDir = Split-Path $profilePath -Parent
-    if (!(Test-Path -LiteralPath $profileDir)) { 
+    if (!(Test-Path -LiteralPath $profileDir)) {
         if ($PSCmdlet.ShouldProcess($profileDir, "Create current user PowerShell profile directory")) {
-            New-Item $profileDir -ItemType Directory -Verbose:$VerbosePreference > $null
+            New-Item $profileDir -ItemType Directory -Force -Verbose:$VerbosePreference > $null
         }
     }
 

--- a/test/Utils.Tests.ps1
+++ b/test/Utils.Tests.ps1
@@ -60,7 +60,6 @@ Describe 'Utils Function Tests' {
             Test-Path -LiteralPath $childProfilePath | Should Be $true
             $childProfilePath | Should Contain "^Import-Module .*posh-git"
         }
-
         It 'Does not modify profile that already refers to posh-git' {
             $profileContent = @'
 Import-Module PSCX


### PR DESCRIPTION
This test checks that the command creates the profile parent dir (or any in the path) if they don't exist.  The command was modified to create any dir in the path by the addition of the -Force parameter on New-Item.

Follow-up on #449 