### PR TITLE
Write-Prompt with $null colors, plus respecting DefaultForegroundColor

### DIFF
--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -2,19 +2,19 @@
 # http://www.markembling.info/view/my-ideal-powershell-prompt-with-git-integration
 
 $global:GitPromptSettings = [pscustomobject]@{
-    DefaultForegroundColor                      = $Host.UI.RawUI.ForegroundColor
+    DefaultForegroundColor                      = $null
 
     BeforeText                                  = ' ['
     BeforeForegroundColor                       = [ConsoleColor]::Yellow
-    BeforeBackgroundColor                       = $Host.UI.RawUI.BackgroundColor
+    BeforeBackgroundColor                       = $null
 
     DelimText                                   = ' |'
     DelimForegroundColor                        = [ConsoleColor]::Yellow
-    DelimBackgroundColor                        = $Host.UI.RawUI.BackgroundColor
+    DelimBackgroundColor                        = $null
 
     AfterText                                   = ']'
     AfterForegroundColor                        = [ConsoleColor]::Yellow
-    AfterBackgroundColor                        = $Host.UI.RawUI.BackgroundColor
+    AfterBackgroundColor                        = $null
 
     FileAddedText                               = '+'
     FileModifiedText                            = '~'
@@ -24,62 +24,62 @@ $global:GitPromptSettings = [pscustomobject]@{
     LocalDefaultStatusSymbol                    = $null
     LocalDefaultStatusForegroundColor           = [ConsoleColor]::DarkGreen
     LocalDefaultStatusForegroundBrightColor     = [ConsoleColor]::Green
-    LocalDefaultStatusBackgroundColor           = $Host.UI.RawUI.BackgroundColor
+    LocalDefaultStatusBackgroundColor           = $null
 
     LocalWorkingStatusSymbol                    = '!'
     LocalWorkingStatusForegroundColor           = [ConsoleColor]::DarkRed
     LocalWorkingStatusForegroundBrightColor     = [ConsoleColor]::Red
-    LocalWorkingStatusBackgroundColor           = $Host.UI.RawUI.BackgroundColor
+    LocalWorkingStatusBackgroundColor           = $null
 
     LocalStagedStatusSymbol                     = '~'
     LocalStagedStatusForegroundColor            = [ConsoleColor]::Cyan
-    LocalStagedStatusBackgroundColor            = $Host.UI.RawUI.BackgroundColor
+    LocalStagedStatusBackgroundColor            = $null
 
     BranchUntrackedSymbol                       = $null
     BranchForegroundColor                       = [ConsoleColor]::Cyan
-    BranchBackgroundColor                       = $Host.UI.RawUI.BackgroundColor
+    BranchBackgroundColor                       = $null
 
     BranchGoneStatusSymbol                      = [char]0x00D7 # × Multiplication sign
     BranchGoneStatusForegroundColor             = [ConsoleColor]::DarkCyan
-    BranchGoneStatusBackgroundColor             = $Host.UI.RawUI.BackgroundColor
+    BranchGoneStatusBackgroundColor             = $null
 
     BranchIdenticalStatusToSymbol               = [char]0x2261 # ≡ Three horizontal lines
     BranchIdenticalStatusToForegroundColor      = [ConsoleColor]::Cyan
-    BranchIdenticalStatusToBackgroundColor      = $Host.UI.RawUI.BackgroundColor
+    BranchIdenticalStatusToBackgroundColor      = $null
 
     BranchAheadStatusSymbol                     = [char]0x2191 # ↑ Up arrow
     BranchAheadStatusForegroundColor            = [ConsoleColor]::Green
-    BranchAheadStatusBackgroundColor            = $Host.UI.RawUI.BackgroundColor
+    BranchAheadStatusBackgroundColor            = $null
 
     BranchBehindStatusSymbol                    = [char]0x2193 # ↓ Down arrow
     BranchBehindStatusForegroundColor           = [ConsoleColor]::Red
-    BranchBehindStatusBackgroundColor           = $Host.UI.RawUI.BackgroundColor
+    BranchBehindStatusBackgroundColor           = $null
 
     BranchBehindAndAheadStatusSymbol            = [char]0x2195 # ↕ Up & Down arrow
     BranchBehindAndAheadStatusForegroundColor   = [ConsoleColor]::Yellow
-    BranchBehindAndAheadStatusBackgroundColor   = $Host.UI.RawUI.BackgroundColor
+    BranchBehindAndAheadStatusBackgroundColor   = $null
 
     BeforeIndexText                             = ""
     BeforeIndexForegroundColor                  = [ConsoleColor]::DarkGreen
     BeforeIndexForegroundBrightColor            = [ConsoleColor]::Green
-    BeforeIndexBackgroundColor                  = $Host.UI.RawUI.BackgroundColor
+    BeforeIndexBackgroundColor                  = $null
 
     IndexForegroundColor                        = [ConsoleColor]::DarkGreen
     IndexForegroundBrightColor                  = [ConsoleColor]::Green
-    IndexBackgroundColor                        = $Host.UI.RawUI.BackgroundColor
+    IndexBackgroundColor                        = $null
 
     WorkingForegroundColor                      = [ConsoleColor]::DarkRed
     WorkingForegroundBrightColor                = [ConsoleColor]::Red
-    WorkingBackgroundColor                      = $Host.UI.RawUI.BackgroundColor
+    WorkingBackgroundColor                      = $null
 
     EnableStashStatus                           = $false
     BeforeStashText                             = ' ('
-    BeforeStashBackgroundColor                  = $Host.UI.RawUI.BackgroundColor
+    BeforeStashBackgroundColor                  = $null
     BeforeStashForegroundColor                  = [ConsoleColor]::Red
     AfterStashText                              = ')'
-    AfterStashBackgroundColor                   = $Host.UI.RawUI.BackgroundColor
+    AfterStashBackgroundColor                   = $null
     AfterStashForegroundColor                   = [ConsoleColor]::Red
-    StashBackgroundColor                        = $Host.UI.RawUI.BackgroundColor
+    StashBackgroundColor                        = $null
     StashForegroundColor                        = [ConsoleColor]::Red
 
     ShowStatusWhenZero                          = $true

--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -128,6 +128,11 @@ if (Get-Module NuGet) {
 }
 
 function Write-Prompt($Object, $ForegroundColor = $null, $BackgroundColor = $null) {
+    $s = $global:GitPromptSettings
+    if ($s -and !$ForegroundColor) {
+        $ForegroundColor = $s.DefaultForegroundColor
+    }
+
     if ($BackgroundColor -is [string]) {
         $BackgroundColor = [ConsoleColor]$BackgroundColor
     }

--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -127,12 +127,25 @@ if (Get-Module NuGet) {
     $WindowTitleSupported = $false
 }
 
-function Write-Prompt($Object, $ForegroundColor, $BackgroundColor = -1) {
-    if ($BackgroundColor -lt 0) {
-        Write-Host $Object -NoNewLine -ForegroundColor $ForegroundColor
-    } else {
-        Write-Host $Object -NoNewLine -ForegroundColor $ForegroundColor -BackgroundColor $BackgroundColor
+function Write-Prompt($Object, $ForegroundColor = $null, $BackgroundColor = $null) {
+    if ($BackgroundColor -is [string]) {
+        $BackgroundColor = [ConsoleColor]$BackgroundColor
     }
+    if ($ForegroundColor -is [string]) {
+        $ForegroundColor = [ConsoleColor]$ForegroundColor
+    }
+
+    $writeHostParams = @{
+        Object = $Object;
+        NoNewLine = $true;
+    }
+    if (($BackgroundColor -ge 0) -and ($BackgroundColor -le 15)) {
+        $writeHostParams.BackgroundColor = $BackgroundColor
+    }
+    if (($ForegroundColor -ge 0) -and ($ForegroundColor -le 15)) {
+        $writeHostParams.ForegroundColor = $ForegroundColor
+    }
+    Write-Host @writeHostParams
 }
 
 function Format-BranchName($branchName){

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -85,11 +85,11 @@ if ($ForcePoshGitPrompt -or !$currentPromptDef -or ($currentPromptDef -eq $defau
         $defaultPromptPrefix = [string]$GitPromptSettings.DefaultPromptPrefix
         if ($defaultPromptPrefix) {
             $expandedDefaultPromptPrefix = $ExecutionContext.SessionState.InvokeCommand.ExpandString($defaultPromptPrefix)
-            Write-Host $expandedDefaultPromptPrefix -NoNewline
+            Write-Prompt $expandedDefaultPromptPrefix
         }
 
         # Write the abbreviated current path
-        Write-Host $currentPath -NoNewline
+        Write-Prompt $currentPath
 
         # Write the Git status summary information
         Write-VcsStatus
@@ -110,7 +110,7 @@ if ($ForcePoshGitPrompt -or !$currentPromptDef -or ($currentPromptDef -eq $defau
         if ($GitPromptSettings.DefaultPromptEnableTiming) {
             $sw.Stop()
             $elapsed = $sw.ElapsedMilliseconds
-            Write-Host " ${elapsed}ms" -NoNewline
+            Write-Prompt " ${elapsed}ms"
         }
 
         $global:LASTEXITCODE = $origLastExitCode


### PR DESCRIPTION
`Write-Prompt -ForgroundColor` being required has frustrated me for a while, as has capturing the `$Host.UI.RawUI` color values when `$GitPromptSettings` is initialized (meaning posh-git looks wrong if those values are changed after the module is loaded. So I've made `-ForegroundColor` optional, and defaulted the appropriate settings to `$null`.

I've also started respecting `DefaultForegroundColor` again, to align with what I did kind of by accident in #447 (because `-ForegroundColor` was required). The setting was introduced as a hack for colored Git commands messing with `$Host.UI.RawUI.ForegroundColor` (02956e1177ae0c348f22927bc4440352172f2a32). More recently, it was removed in #202 and restored in #209 to avoid a breaking change. However, since we have it, I suppose we might as well support using it to control the default prompt text color.

<img width="994" alt="powershell_2017-03-04_10-59-00" src="https://cloud.githubusercontent.com/assets/133987/23580549/99933162-00c9-11e7-9ec1-55708789d587.png">
