### PR TITLE
VSCode 1.10 broke the attach confg apparently.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
             "type": "PowerShell",
             "request": "attach",
             "name": "PowerShell Attach to Host Process",
-            "processId": "${command.PickPSHostProcess}",
+            "processId": "${command:PickPSHostProcess}",
             "runspaceId": 1
         }
     ]


### PR DESCRIPTION
This is a minor change to the .vscode\launch.json file to make it work correctly with VSCode 1.10.  Merge this to `develop` as soon as is convenient.