### PR TITLE
Fix 'Write-Prompt' to be able use Black as foreground color.

### DIFF
--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -132,7 +132,7 @@ if (Get-Module NuGet) {
 
 function Write-Prompt($Object, $ForegroundColor = $null, $BackgroundColor = $null) {
     $s = $global:GitPromptSettings
-    if ($s -and !$ForegroundColor) {
+    if ($s -and $ForegroundColor -eq $null) {
         $ForegroundColor = $s.DefaultForegroundColor
     }
 

--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -132,7 +132,7 @@ if (Get-Module NuGet) {
 
 function Write-Prompt($Object, $ForegroundColor = $null, $BackgroundColor = $null) {
     $s = $global:GitPromptSettings
-    if ($s -and $ForegroundColor -eq $null) {
+    if ($s -and ($null -eq $ForegroundColor)) {
         $ForegroundColor = $s.DefaultForegroundColor
     }
 


### PR DESCRIPTION
Current implementation replaces 'Black' color with DefaultForegroundColor. This breaks some themes from the oh-my-posh package.