### PR TITLE
Pass "git.exe" instead of "git" to Get-Command

### DIFF
--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -430,7 +430,7 @@ function Find-Pageant() {
 # Attempt to guess $program's location. For ssh-agent/ssh-add.
 function Find-Ssh($program = 'ssh-agent') {
     Write-Verbose "$program not in path. Trying to guess location."
-    $gitItem = Get-Command git -Erroraction SilentlyContinue | Get-Item
+    $gitItem = Get-Command git.exe -Erroraction SilentlyContinue | Get-Item
     if ($null -eq $gitItem) {
         Write-Warning 'git not in path'
         return


### PR DESCRIPTION
Passing just "git" to `get-command` causes the script to fail if you have an alias called "git". For example, I have [hub](https://github.com/github/hub) installed , which recommends aliasing git=hub. However, after doing this it breaks this posh-git script because `get-command git` returns the new alias which has no path.

Running `get-command git` returns:
CommandType     Name                                               Version    Source
```
-----------     ----                                               -------    ------
Alias           git -> hub.exe
```

But `get-command git.exe` returns:
CommandType     Name                                               Version    Source
```
-----------     ----                                               -------    ------
Application     git.exe                                            2.13.2.1   C:\Program Files\Git\cmd\git.exe
```