### PR TITLE
squash ssh agent warnings if `-Quiet`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ init:
 install:
   - ps: |
       Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
-      Install-Module Pester -MinimumVersion 3.4.0 -Scope CurrentUser -Force | Out-Null
+      Install-Module Pester -MinimumVersion 3.4.0 -MaximumVersion 3.99.99 -Scope CurrentUser -Force | Out-Null
       "Git version: $(git.exe --version)"
       "PSVersion:   $($PSVersionTable.PSVersion), build: $($PSVersionTable.BuildVersion), clr version: $($PSVersionTable.ClrVersion)"
       "Host name:   $($Host.Name)"

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -522,7 +522,9 @@ function Add-SshKey() {
         $pageant = Get-Command pageant -Erroraction SilentlyContinue | Select-Object -First 1 -ExpandProperty Name
         $pageant = if ($pageant) { $pageant } else { Find-Pageant }
         if (!$pageant) {
-            Write-Warning 'Could not find Pageant'
+            if (!$Quiet) {
+                Write-Warning 'Could not find Pageant'
+            }
             return
         }
 
@@ -543,7 +545,9 @@ function Add-SshKey() {
         $sshAdd = Get-Command ssh-add -TotalCount 1 -ErrorAction SilentlyContinue
         $sshAdd = if ($sshAdd) { $sshAdd } else { Find-Ssh('ssh-add') }
         if (!$sshAdd) {
-            Write-Warning 'Could not find ssh-add'
+            if (!$Quiet) {
+                Write-Warning 'Could not find ssh-add'
+            }
             return
         }
 

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -469,7 +469,9 @@ function Start-SshAgent([switch]$Quiet) {
         $pageant = Get-Command pageant -TotalCount 1 -Erroraction SilentlyContinue
         $pageant = if ($pageant) { $pageant } else { Find-Pageant }
         if (!$pageant) {
-            Write-Warning "Could not find Pageant."
+            if (!$Quiet) {
+                Write-Warning 'Could not find Pageant'
+            }
             return
         }
 
@@ -479,7 +481,9 @@ function Start-SshAgent([switch]$Quiet) {
         $sshAgent = Get-Command ssh-agent -TotalCount 1 -ErrorAction SilentlyContinue
         $sshAgent = if ($sshAgent) { $sshAgent } else { Find-Ssh('ssh-agent') }
         if (!$sshAgent) {
-            Write-Warning 'Could not find ssh-agent'
+            if (!$Quiet) {
+                Write-Warning 'Could not find ssh-add'
+            }
             return
         }
 
@@ -490,7 +494,7 @@ function Start-SshAgent([switch]$Quiet) {
         }
     }
 
-    Add-SshKey
+    Add-SshKey -Quiet:$Quiet
 }
 
 function Get-SshPath($File = 'id_rsa') {
@@ -517,7 +521,7 @@ function Get-SshPath($File = 'id_rsa') {
     None.
     You cannot pipe input to this cmdlet.
 #>
-function Add-SshKey() {
+function Add-SshKey([switch]$Quiet) {
     if ($env:GIT_SSH -imatch 'plink') {
         $pageant = Get-Command pageant -Erroraction SilentlyContinue | Select-Object -First 1 -ExpandProperty Name
         $pageant = if ($pageant) { $pageant } else { Find-Pageant }

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -482,7 +482,7 @@ function Start-SshAgent([switch]$Quiet) {
         $sshAgent = if ($sshAgent) { $sshAgent } else { Find-Ssh('ssh-agent') }
         if (!$sshAgent) {
             if (!$Quiet) {
-                Write-Warning 'Could not find ssh-add'
+                Write-Warning 'Could not find ssh-agent'
             }
             return
         }


### PR DESCRIPTION
Maps better to stdout/stderr, so cases where PS is run as CLI tool
Refs: https://github.com/nodejs/node-gyp/issues/1195#issuecomment-329574067