### PR TITLE
WIP: Reorgs settings using PS v5 classes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,12 @@
         {
             "type": "PowerShell",
             "request": "launch",
+            "name": "PowerShell Interactive Session",
+            "cwd": "${workspaceRoot}"
+        },
+        {
+            "type": "PowerShell",
+            "request": "launch",
             "name": "PowerShell Pester Tests",
             "script": "Invoke-Pester",
             "args": [],

--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -1,101 +1,169 @@
 ﻿# Inspired by Mark Embling
 # http://www.markembling.info/view/my-ideal-powershell-prompt-with-git-integration
 
+enum BranchBehindAndAheadDisplayOptions { Full; Compact; Minimal }
+
+class PoshGitCellColor {
+    [psobject]$BackgroundColor
+    [psobject]$ForegroundColor
+
+    PoshGitCellColor() {
+        $this.ForegroundColor = $null
+        $this.BackgroundColor = $null
+    }
+
+    PoshGitCellColor([psobject]$ForegroundColor) {
+        $this.ForegroundColor = $ForegroundColor
+        $this.BackgroundColor = $null
+    }
+
+    PoshGitCellColor([psobject]$ForegroundColor, [psobject]$BackgroundColor) {
+        $this.ForegroundColor = $ForegroundColor
+        $this.BackgroundColor = $BackgroundColor
+    }
+
+    hidden [string] ToString($color) {
+        $ansiTerm = "$([char]0x1b)[0m"
+
+        if (!$color) {
+            $str = "<default>"
+        }
+        elseif (Test-VirtualTerminalSequece $color) {
+            $txt = EscapseAnsiString $color
+            $str = "${color} # ${ansiTerm} $txt"
+        }
+        else {
+            $str = ""
+
+            if ($global:GitPromptSettings.AnsiConsole) {
+                $bg = Get-BackgroundVirtualTerminalSequence $color
+                $str += "${bg} ${ansiTerm} "
+            }
+
+            $str += $color.ToString()
+        }
+
+        return $str
+    }
+
+    [string] ToString() {
+        $str = "ForegroundColor: "
+        $str += $this.ToString($this.ForegroundColor) + ", "
+        $str += "BackgroundColor: "
+        $str += $this.ToString($this.BackgroundColor)
+        return $str
+    }
+}
+
+class PoshGitTextSpan {
+    [string]$Text
+    [psobject]$BackgroundColor
+    [psobject]$ForegroundColor
+
+    PoshGitTextSpan() {
+        $this.Text = ""
+        $this.ForegroundColor = $null
+        $this.BackgroundColor = $null
+    }
+
+    PoshGitTextSpan([string]$Text) {
+        $this.Text = $Text
+        $this.ForegroundColor = $null
+        $this.BackgroundColor = $null
+    }
+
+    PoshGitTextSpan([string]$Text, [psobject]$ForegroundColor) {
+        $this.Text = $Text
+        $this.ForegroundColor = $ForegroundColor
+        $this.BackgroundColor = $null
+    }
+
+    PoshGitTextSpan([string]$Text, [psobject]$ForegroundColor, [psobject]$BackgroundColor) {
+        $this.Text = $Text
+        $this.ForegroundColor = $ForegroundColor
+        $this.BackgroundColor = $BackgroundColor
+    }
+
+    PoshGitTextSpan([PoshGitTextSpan]$PoshGitTextSpan) {
+        $this.Text = $PoshGitTextSpan.Text
+        $this.ForegroundColor = $PoshGitTextSpan.ForegroundColor
+        $this.BackgroundColor = $PoshGitTextSpan.BackgroundColor
+    }
+
+    PoshGitTextSpan([PoshGitCellColor]$PoshGitCellColor) {
+        $this.Text = ''
+        $this.ForegroundColor = $PoshGitCellColor.ForegroundColor
+        $this.BackgroundColor = $PoshGitCellColor.BackgroundColor
+    }
+
+    [string] ToString() {
+        $color = [PoshGitCellColor]::new($this.ForegroundColor, $this.BackgroundColor)
+        $txt = $this.RenderAnsi()
+        $str = "Text: '$txt',`t $($color.ToString())"
+        return $str
+    }
+
+    [string] RenderAnsi() {
+        $e = [char]27 + "["
+        $txt = $this.Text
+
+        $bg = $this.BackgroundColor
+        if ($bg -and !(Test-VirtualTerminalSequece $bg)) {
+            $bg = Get-BackgroundVirtualTerminalSequence $bg
+        }
+
+        $fg = $this.ForegroundColor
+        if (!(Test-VirtualTerminalSequece $fg)) {
+            $fg = Get-ForegroundVirtualTerminalSequence $fg
+        }
+
+        return "${fg}${bg}${txt}${e}0m"
+    }
+}
+
 $global:GitPromptSettings = [pscustomobject]@{
-    DefaultForegroundColor                      = $null
-
-    BeforeText                                  = ' ['
-    BeforeForegroundColor                       = [ConsoleColor]::Yellow
-    BeforeBackgroundColor                       = $null
-
-    DelimText                                   = ' |'
-    DelimForegroundColor                        = [ConsoleColor]::Yellow
-    DelimBackgroundColor                        = $null
-
-    AfterText                                   = ']'
-    AfterForegroundColor                        = [ConsoleColor]::Yellow
-    AfterBackgroundColor                        = $null
-
     FileAddedText                               = '+'
     FileModifiedText                            = '~'
     FileRemovedText                             = '-'
     FileConflictedText                          = '!'
 
-    LocalDefaultStatusSymbol                    = $null
-    LocalDefaultStatusForegroundColor           = [ConsoleColor]::DarkGreen
-    LocalDefaultStatusForegroundBrightColor     = [ConsoleColor]::Green
-    LocalDefaultStatusBackgroundColor           = $null
+    DefaultColor                                = [PoshGitCellColor]::new()
+    BranchColor                                 = [PoshGitCellColor]::new([ConsoleColor]::Cyan)
+    IndexColor                                  = [PoshGitCellColor]::new([ConsoleColor]::DarkGreen)
+    WorkingColor                                = [PoshGitCellColor]::new([ConsoleColor]::DarkRed)
+    StashColor                                  = [PoshGitCellColor]::new([ConsoleColor]::Red)
+    ErrorColor                                  = [PoshGitCellColor]::new([ConsoleColor]::Red)
 
-    LocalWorkingStatusSymbol                    = '!'
-    LocalWorkingStatusForegroundColor           = [ConsoleColor]::DarkRed
-    LocalWorkingStatusForegroundBrightColor     = [ConsoleColor]::Red
-    LocalWorkingStatusBackgroundColor           = $null
+    BeforeText                                  = [PoshGitTextSpan]::new(' [', [ConsoleColor]::Yellow)
+    DelimText                                   = [PoshGitTextSpan]::new(' |', [ConsoleColor]::Yellow)
+    AfterText                                   = [PoshGitTextSpan]::new(']',  [ConsoleColor]::Yellow)
 
-    LocalStagedStatusSymbol                     = '~'
-    LocalStagedStatusForegroundColor            = [ConsoleColor]::Cyan
-    LocalStagedStatusBackgroundColor            = $null
+    LocalDefaultStatusSymbol                    = [PoshGitTextSpan]::new('',  [ConsoleColor]::DarkGreen)
+    LocalWorkingStatusSymbol                    = [PoshGitTextSpan]::new('!', [ConsoleColor]::DarkRed)
+    LocalStagedStatusSymbol                     = [PoshGitTextSpan]::new('~', [ConsoleColor]::DarkCyan)
 
-    BranchUntrackedSymbol                       = $null
-    BranchForegroundColor                       = [ConsoleColor]::Cyan
-    BranchBackgroundColor                       = $null
+    BranchUntrackedSymbol                       = [PoshGitTextSpan]::new('',  [ConsoleColor]::DarkCyan)
 
-    BranchGoneStatusSymbol                      = [char]0x00D7 # × Multiplication sign
-    BranchGoneStatusForegroundColor             = [ConsoleColor]::DarkCyan
-    BranchGoneStatusBackgroundColor             = $null
+    BranchGoneStatusSymbol                      = [PoshGitTextSpan]::new([char]0x00D7, [ConsoleColor]::DarkCyan) # × Multiplication sign
+    BranchIdenticalStatusSymbol                 = [PoshGitTextSpan]::new([char]0x2261, [ConsoleColor]::Cyan)     # ≡ Three horizontal lines
+    BranchAheadStatusSymbol                     = [PoshGitTextSpan]::new([char]0x2191, [ConsoleColor]::Green)    # ↑ Up arrow
+    BranchBehindStatusSymbol                    = [PoshGitTextSpan]::new([char]0x2193, [ConsoleColor]::Red)      # ↓ Down arrow
+    BranchBehindAndAheadStatusSymbol            = [PoshGitTextSpan]::new([char]0x2195, [ConsoleColor]::Yellow)   # ↕ Up & Down arrow
+    BranchBehindAndAheadDisplay                 = [BranchBehindAndAheadDisplayOptions]"Full"
 
-    BranchIdenticalStatusToSymbol               = [char]0x2261 # ≡ Three horizontal lines
-    BranchIdenticalStatusToForegroundColor      = [ConsoleColor]::Cyan
-    BranchIdenticalStatusToBackgroundColor      = $null
+    BeforeIndexText                             = [PoshGitTextSpan]::new('',  [ConsoleColor]::DarkGreen)
 
-    BranchAheadStatusSymbol                     = [char]0x2191 # ↑ Up arrow
-    BranchAheadStatusForegroundColor            = [ConsoleColor]::Green
-    BranchAheadStatusBackgroundColor            = $null
-
-    BranchBehindStatusSymbol                    = [char]0x2193 # ↓ Down arrow
-    BranchBehindStatusForegroundColor           = [ConsoleColor]::Red
-    BranchBehindStatusBackgroundColor           = $null
-
-    BranchBehindAndAheadStatusSymbol            = [char]0x2195 # ↕ Up & Down arrow
-    BranchBehindAndAheadStatusForegroundColor   = [ConsoleColor]::Yellow
-    BranchBehindAndAheadStatusBackgroundColor   = $null
-
-    BeforeIndexText                             = ""
-    BeforeIndexForegroundColor                  = [ConsoleColor]::DarkGreen
-    BeforeIndexForegroundBrightColor            = [ConsoleColor]::Green
-    BeforeIndexBackgroundColor                  = $null
-
-    IndexForegroundColor                        = [ConsoleColor]::DarkGreen
-    IndexForegroundBrightColor                  = [ConsoleColor]::Green
-    IndexBackgroundColor                        = $null
-
-    WorkingForegroundColor                      = [ConsoleColor]::DarkRed
-    WorkingForegroundBrightColor                = [ConsoleColor]::Red
-    WorkingBackgroundColor                      = $null
+    BeforeStashText                             = [PoshGitTextSpan]::new(' (', [ConsoleColor]::Red)
+    AfterStashText                              = [PoshGitTextSpan]::new(')',  [ConsoleColor]::Red)
 
     EnableStashStatus                           = $false
-    BeforeStashText                             = ' ('
-    BeforeStashBackgroundColor                  = $null
-    BeforeStashForegroundColor                  = [ConsoleColor]::Red
-    AfterStashText                              = ')'
-    AfterStashBackgroundColor                   = $null
-    AfterStashForegroundColor                   = [ConsoleColor]::Red
-    StashBackgroundColor                        = $null
-    StashForegroundColor                        = [ConsoleColor]::Red
-
-    ErrorForegroundColor                        = [ConsoleColor]::Red
-    ErrorBackgroundColor                        = $null
-
     ShowStatusWhenZero                          = $true
-
     AutoRefreshIndex                            = $true
-
-    # Valid values are "Full", "Compact", and "Minimal"
-    BranchBehindAndAheadDisplay                 = "Full"
 
     EnablePromptStatus                          = !$Global:GitMissing
     EnableFileStatus                            = $true
     EnableFileStatusFromCache                   = $null
-    RepositoriesInWhichToDisableFileStatus      = @( ) # Array of repository paths
+    RepositoriesInWhichToDisableFileStatus      = @() # Array of repository paths
     DescribeStyle                               = ''
 
     EnableWindowTitle                           = 'posh~git ~ '
@@ -114,6 +182,16 @@ $global:GitPromptSettings = [pscustomobject]@{
     TruncatedBranchSuffix                       = '...'
 }
 
+# Override some of the normal colors if the background color is set to the default DarkMagenta.
+$s = $global:GitPromptSettings
+if ($Host.UI.RawUI.BackgroundColor -eq [ConsoleColor]::DarkMagenta) {
+    $s.LocalDefaultStatusSymbol.ForegroundColor = 'Green'
+    $s.LocalWorkingStatusSymbol.ForegroundColor = 'Red'
+    $s.BeforeIndexText.ForegroundColor          = 'Green'
+    $s.IndexColor.ForegroundColor               = 'Green'
+    $s.WorkingColor.ForegroundColor             = 'Red'
+}
+
 # PowerShell 5.x only runs on Windows so use .NET types to determine isAdminProcess
 # Or if we are on v6 or higher, check the $IsWindows pre-defined variable.
 if (($PSVersionTable.PSVersion.Major -le 5) -or $IsWindows) {
@@ -128,6 +206,7 @@ else {
 $adminHeader = if ($isAdminProcess) { 'Administrator: ' } else { '' }
 
 $WindowTitleSupported = $true
+# TODO: Hmm, this is a curious way to detemine window title supported
 if (Get-Module NuGet) {
     $WindowTitleSupported = $false
 }
@@ -142,42 +221,72 @@ function Write-Prompt {
         $BackgroundColor = $null,
         [parameter(ValueFromPipeline = $true)]
         [Text.StringBuilder]
-        $Builder)
+        $Builder
+    )
+
     $s = $global:GitPromptSettings
-    if ($s -and ($null -eq $ForegroundColor)) {
-        $ForegroundColor = $s.DefaultForegroundColor
+    if ($s) {
+        if ($null -eq $ForegroundColor) {
+            $ForegroundColor = $s.DefaultColor.ForegroundColor
+        }
+
+        if ($null -eq $BackgroundColor) {
+            $BackgroundColor = $s.DefaultColor.BackgroundColor
+        }
+    }
+
+    if ($Object -is [PoshGitCellColor]) {
+        Write-Warning "Unexpected PoshGitCellColor passed to Write-Prompt"
     }
 
     if ($GitPromptSettings.AnsiConsole) {
-        $e = [char]27 + "["
-        $f = Get-ForegroundVirtualTerminalSequence $ForegroundColor
-        $b = Get-BackgroundVirtualTerminalSequence $BackgroundColor
-        if ($Builder) {
-            return $Builder.Append($f).Append($b).Append($Object).Append($e).Append("0m")
+        if ($Object -is [PoshGitTextSpan]) {
+            $str = $Object.RenderAnsi()
         }
-        return "${f}${b}${Object}${e}0m"
+        else {
+            $e = [char]27 + "["
+            $f = Get-ForegroundVirtualTerminalSequence $ForegroundColor
+            $b = Get-BackgroundVirtualTerminalSequence $BackgroundColor
+            $str = "${f}${b}${Object}${e}0m"
+        }
+
+        if ($Builder) {
+            return $Builder.Append($str)
+        }
+
+        return $str
     }
+
+    if ($Object -is [PoshGitTextSpan]) {
+        $BackgroundColor = $Object.BackgroundColor
+        $ForegroundColor = $Object.ForegroundColor
+        $Object = $Object.Text
+    }
+
     $writeHostParams = @{
         Object = $Object;
         NoNewLine = $true;
     }
+
     if (($BackgroundColor -ge 0) -and ($BackgroundColor -le 15)) {
         $writeHostParams.BackgroundColor = $BackgroundColor
     }
+
     if (($ForegroundColor -ge 0) -and ($ForegroundColor -le 15)) {
         $writeHostParams.ForegroundColor = $ForegroundColor
     }
+
     Write-Host @writeHostParams
     if ($Builder) {
         return $Builder
     }
+
     return ""
 }
 
 function Format-BranchName($branchName){
     $s = $global:GitPromptSettings
-
-    if($s.BranchNameLimit -gt 0 -and $branchName.Length -gt $s.BranchNameLimit)
+    if (($s.BranchNameLimit -gt 0) -and ($branchName.Length -gt $s.BranchNameLimit))
     {
         $branchName = "{0}{1}" -f $branchName.Substring(0,$s.BranchNameLimit), $s.TruncatedBranchSuffix
     }
@@ -187,163 +296,181 @@ function Format-BranchName($branchName){
 
 function Write-GitStatus($status) {
     $s = $global:GitPromptSettings
-    $sb = New-Object System.Text.StringBuilder
-    if ($status -and $s) {
-        $sb | Write-Prompt $s.BeforeText -BackgroundColor $s.BeforeBackgroundColor -ForegroundColor $s.BeforeForegroundColor | Out-Null
+    $sb = [System.Text.StringBuilder]::new(150)
 
-        $branchStatusText            = $null
-        $branchStatusBackgroundColor = $s.BranchBackgroundColor
-        $branchStatusForegroundColor = $s.BranchForegroundColor
+    if (!$s) {
+        Write-Warning "`$global:GitPromptSettings is not defined. Posh-git prompt information will be limited."
+    }
+
+    if ($status -and $s) {
+        $sb | Write-Prompt $s.BeforeText > $null
+
+        $branchStatusTextSpan = [PoshGitTextSpan]::new($s.BranchColor)
 
         if (!$status.Upstream) {
-            $branchStatusText            = $s.BranchUntrackedSymbol
-        } elseif ($status.UpstreamGone -eq $true) {
+            $branchStatusTextSpan = $s.BranchUntrackedSymbol
+        }
+        elseif ($status.UpstreamGone -eq $true) {
             # Upstream branch is gone
-            $branchStatusText            = $s.BranchGoneStatusSymbol
-            $branchStatusBackgroundColor = $s.BranchGoneStatusBackgroundColor
-            $branchStatusForegroundColor = $s.BranchGoneStatusForegroundColor
-        } elseif ($status.BehindBy -eq 0 -and $status.AheadBy -eq 0) {
+            $branchStatusTextSpan = $s.BranchGoneStatusSymbol
+        }
+        elseif (($status.BehindBy -eq 0) -and ($status.AheadBy -eq 0)) {
             # We are aligned with remote
-            $branchStatusText            = $s.BranchIdenticalStatusToSymbol
-            $branchStatusBackgroundColor = $s.BranchIdenticalStatusToBackgroundColor
-            $branchStatusForegroundColor = $s.BranchIdenticalStatusToForegroundColor
-        } elseif ($status.BehindBy -ge 1 -and $status.AheadBy -ge 1) {
+            $branchStatusTextSpan = $s.BranchIdenticalStatusSymbol
+        }
+        elseif (($status.BehindBy -ge 1) -and ($status.AheadBy -ge 1)) {
+            $branchStatusTextSpan.ForegroundColor = $s.BranchBehindAndAheadStatusSymbol.ForegroundColor
+            $branchStatusTextSpan.BackgroundColor = $s.BranchBehindAndAheadStatusSymbol.BackgroundColor
+
             # We are both behind and ahead of remote
             if ($s.BranchBehindAndAheadDisplay -eq "Full") {
-                $branchStatusText        = ("{0}{1} {2}{3}" -f $s.BranchBehindStatusSymbol, $status.BehindBy, $s.BranchAheadStatusSymbol, $status.AheadBy)
-            } elseif ($s.BranchBehindAndAheadDisplay -eq "Compact") {
-                $branchStatusText        = ("{0}{1}{2}" -f $status.BehindBy, $s.BranchBehindAndAheadStatusSymbol, $status.AheadBy)
-            } else {
-                $branchStatusText        = $s.BranchBehindAndAheadStatusSymbol
+                $branchStatusTextSpan.Text = ("{0}{1} {2}{3}" -f $s.BranchBehindStatusSymbol.Text, $status.BehindBy, $s.BranchAheadStatusSymbol.Text, $status.AheadBy)
             }
-            $branchStatusBackgroundColor = $s.BranchBehindAndAheadStatusBackgroundColor
-            $branchStatusForegroundColor = $s.BranchBehindAndAheadStatusForegroundColor
-        } elseif ($status.BehindBy -ge 1) {
+            elseif ($s.BranchBehindAndAheadDisplay -eq "Compact") {
+                $branchStatusTextSpan.Text = ("{0}{1}{2}" -f $status.BehindBy, $s.BranchBehindAndAheadStatusSymbol.Text, $status.AheadBy)
+            }
+            else {
+                $branchStatusTextSpan.Text = $s.BranchBehindAndAheadStatusSymbol.Text
+            }
+        }
+        elseif ($status.BehindBy -ge 1) {
+            $branchStatusTextSpan.ForegroundColor = $s.BranchBehindStatusSymbol.ForegroundColor
+            $branchStatusTextSpan.BackgroundColor = $s.BranchBehindStatusSymbol.BackgroundColor
+
             # We are behind remote
-            if ($s.BranchBehindAndAheadDisplay -eq "Full" -Or $s.BranchBehindAndAheadDisplay -eq "Compact") {
-                $branchStatusText        = ("{0}{1}" -f $s.BranchBehindStatusSymbol, $status.BehindBy)
-            } else {
-                $branchStatusText        = $s.BranchBehindStatusSymbol
+            if (($s.BranchBehindAndAheadDisplay -eq "Full") -Or ($s.BranchBehindAndAheadDisplay -eq "Compact")) {
+                $branchStatusTextSpan.Text = ("{0}{1}" -f $s.BranchBehindStatusSymbol.Text, $status.BehindBy)
             }
-            $branchStatusBackgroundColor = $s.BranchBehindStatusBackgroundColor
-            $branchStatusForegroundColor = $s.BranchBehindStatusForegroundColor
-        } elseif ($status.AheadBy -ge 1) {
+            else {
+                $branchStatusTextSpan.Text = $s.BranchBehindStatusSymbol.Text
+            }
+        }
+        elseif ($status.AheadBy -ge 1) {
+            $branchStatusTextSpan.ForegroundColor = $s.BranchAheadStatusSymbol.ForegroundColor
+            $branchStatusTextSpan.BackgroundColor = $s.BranchAheadStatusSymbol.BackgroundColor
+
             # We are ahead of remote
-            if ($s.BranchBehindAndAheadDisplay -eq "Full" -Or $s.BranchBehindAndAheadDisplay -eq "Compact") {
-                $branchStatusText        = ("{0}{1}" -f $s.BranchAheadStatusSymbol, $status.AheadBy)
+            if (($s.BranchBehindAndAheadDisplay -eq "Full") -or ($s.BranchBehindAndAheadDisplay -eq "Compact")) {
+                $branchStatusTextSpan.Text = ("{0}{1}" -f $s.BranchAheadStatusSymbol.Text, $status.AheadBy)
             } else {
-                $branchStatusText        = $s.BranchAheadStatusSymbol
+                $branchStatusTextSpan.Text = $s.BranchAheadStatusSymbol.Text
             }
-            $branchStatusBackgroundColor = $s.BranchAheadStatusBackgroundColor
-            $branchStatusForegroundColor = $s.BranchAheadStatusForegroundColor
-        } else {
+        }
+        else {
             # This condition should not be possible but defaulting the variables to be safe
-            $branchStatusText            = "?"
+            $branchStatusTextSpan.Text = "?"
         }
 
-        $sb | Write-Prompt (Format-BranchName($status.Branch)) -BackgroundColor $branchStatusBackgroundColor -ForegroundColor $branchStatusForegroundColor | Out-Null
+        $branchNameTextSpan = [PoshGitTextSpan]::new($branchStatusTextSpan)
+        $branchNameTextSpan.Text = Format-BranchName $status.Branch
+        $sb | Write-Prompt $branchNameTextSpan > $null
 
-        if ($branchStatusText) {
-            $sb | Write-Prompt  (" {0}" -f $branchStatusText) -BackgroundColor $branchStatusBackgroundColor -ForegroundColor $branchStatusForegroundColor | Out-Null
+        if ($branchStatusTextSpan.Text) {
+            $sb.Append(' ') > $null
+            $sb | Write-Prompt $branchStatusTextSpan > $null
         }
 
-        if($s.EnableFileStatus -and $status.HasIndex) {
-            $sb | Write-Prompt $s.BeforeIndexText -BackgroundColor $s.BeforeIndexBackgroundColor -ForegroundColor $s.BeforeIndexForegroundColor | Out-Null
+        if ($s.EnableFileStatus -and $status.HasIndex) {
+            $sb | Write-Prompt $s.BeforeIndexText > $null
 
-            if($s.ShowStatusWhenZero -or $status.Index.Added) {
-                $sb | Write-Prompt (" $($s.FileAddedText)$($status.Index.Added.Count)") -BackgroundColor $s.IndexBackgroundColor -ForegroundColor $s.IndexForegroundColor | Out-Null
+            $statusTextSpan = [PoshGitTextSpan]::new($s.IndexColor)
+            if ($s.ShowStatusWhenZero -or $status.Index.Added) {
+                $statusTextSpan.Text = " $($s.FileAddedText)$($status.Index.Added.Count)"
+                $sb | Write-Prompt $statusTextSpan > $null
             }
-            if($s.ShowStatusWhenZero -or $status.Index.Modified) {
-                $sb | Write-Prompt (" $($s.FileModifiedText)$($status.Index.Modified.Count)") -BackgroundColor $s.IndexBackgroundColor -ForegroundColor $s.IndexForegroundColor | Out-Null
+
+            if ($s.ShowStatusWhenZero -or $status.Index.Modified) {
+                $statusTextSpan.Text = " $($s.FileModifiedText)$($status.Index.Modified.Count)"
+                $sb | Write-Prompt $statusTextSpan > $null
             }
-            if($s.ShowStatusWhenZero -or $status.Index.Deleted) {
-                $sb | Write-Prompt (" $($s.FileRemovedText)$($status.Index.Deleted.Count)") -BackgroundColor $s.IndexBackgroundColor -ForegroundColor $s.IndexForegroundColor | Out-Null
+
+            if ($s.ShowStatusWhenZero -or $status.Index.Deleted) {
+                $statusTextSpan.Text = " $($s.FileRemovedText)$($status.Index.Deleted.Count)"
+                $sb | Write-Prompt $statusTextSpan > $null
             }
 
             if ($status.Index.Unmerged) {
-                $sb | Write-Prompt (" $($s.FileConflictedText)$($status.Index.Unmerged.Count)") -BackgroundColor $s.IndexBackgroundColor -ForegroundColor $s.IndexForegroundColor | Out-Null
+                $statusTextSpan.Text = " $($s.FileConflictedText)$($status.Index.Unmerged.Count)"
+                $sb | Write-Prompt $statusTextSpan > $null
             }
 
             if($status.HasWorking) {
-                $sb | Write-Prompt $s.DelimText -BackgroundColor $s.DelimBackgroundColor -ForegroundColor $s.DelimForegroundColor | Out-Null
+                $sb | Write-Prompt $s.DelimText > $null
             }
         }
 
-        if($s.EnableFileStatus -and $status.HasWorking) {
-            if($s.ShowStatusWhenZero -or $status.Working.Added) {
-                $sb | Write-Prompt (" $($s.FileAddedText)$($status.Working.Added.Count)") -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor | Out-Null
+        if ($s.EnableFileStatus -and $status.HasWorking) {
+            $workingTextSpan = [PoshGitTextSpan]::new($s.WorkingColor)
+
+            if ($s.ShowStatusWhenZero -or $status.Working.Added) {
+                $workingTextSpan.Text = " $($s.FileAddedText)$($status.Working.Added.Count)"
+                $sb | Write-Prompt $workingTextSpan > $null
             }
-            if($s.ShowStatusWhenZero -or $status.Working.Modified) {
-                $sb | Write-Prompt (" $($s.FileModifiedText)$($status.Working.Modified.Count)") -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor | Out-Null
+
+            if ($s.ShowStatusWhenZero -or $status.Working.Modified) {
+                $workingTextSpan.Text = " $($s.FileModifiedText)$($status.Working.Modified.Count)"
+                $sb | Write-Prompt $workingTextSpan > $null
             }
-            if($s.ShowStatusWhenZero -or $status.Working.Deleted) {
-                $sb | Write-Prompt (" $($s.FileRemovedText)$($status.Working.Deleted.Count)") -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor | Out-Null
+
+            if ($s.ShowStatusWhenZero -or $status.Working.Deleted) {
+                $workingTextSpan.Text = " $($s.FileRemovedText)$($status.Working.Deleted.Count)"
+                $sb | Write-Prompt $workingTextSpan > $null
             }
 
             if ($status.Working.Unmerged) {
-                $sb | Write-Prompt (" $($s.FileConflictedText)$($status.Working.Unmerged.Count)") -BackgroundColor $s.WorkingBackgroundColor -ForegroundColor $s.WorkingForegroundColor | Out-Null
+                $workingTextSpan.Text = " $($s.FileConflictedText)$($status.Working.Unmerged.Count)"
+                $sb | Write-Prompt $workingTextSpan > $null
             }
         }
 
         if ($status.HasWorking) {
             # We have un-staged files in the working tree
-            $localStatusSymbol          = $s.LocalWorkingStatusSymbol
-            $localStatusBackgroundColor = $s.LocalWorkingStatusBackgroundColor
-            $localStatusForegroundColor = $s.LocalWorkingStatusForegroundColor
-        } elseif ($status.HasIndex) {
+            $localStatusSymbol = $s.LocalWorkingStatusSymbol
+        }
+        elseif ($status.HasIndex) {
             # We have staged but uncommited files
-            $localStatusSymbol          = $s.LocalStagedStatusSymbol
-            $localStatusBackgroundColor = $s.LocalStagedStatusBackgroundColor
-            $localStatusForegroundColor = $s.LocalStagedStatusForegroundColor
-        } else {
+            $localStatusSymbol = $s.LocalStagedStatusSymbol
+        }
+        else {
             # No uncommited changes
-            $localStatusSymbol          = $s.LocalDefaultStatusSymbol
-            $localStatusBackgroundColor = $s.LocalDefaultStatusBackgroundColor
-            $localStatusForegroundColor = $s.LocalDefaultStatusForegroundColor
+            $localStatusSymbol = $s.LocalDefaultStatusSymbol
         }
 
         if ($localStatusSymbol) {
-            $sb | Write-Prompt (" {0}" -f $localStatusSymbol) -BackgroundColor $localStatusBackgroundColor -ForegroundColor $localStatusForegroundColor | Out-Null
+            $sb.Append(' ') > $null
+            $sb | Write-Prompt $localStatusSymbol > $null
         }
 
         if ($s.EnableStashStatus -and ($status.StashCount -gt 0)) {
-             $sb | Write-Prompt $s.BeforeStashText -BackgroundColor $s.BeforeStashBackgroundColor -ForegroundColor $s.BeforeStashForegroundColor | Out-Null
-             $sb | Write-Prompt $status.StashCount -BackgroundColor $s.StashBackgroundColor -ForegroundColor $s.StashForegroundColor | Out-Null
-             $sb | Write-Prompt $s.AfterStashText -BackgroundColor $s.AfterStashBackgroundColor -ForegroundColor $s.AfterStashForegroundColor | Out-Null
+            $stashTextSpan = [PoshGitTextSpan]::new("$($status.StashCount)", $s.StashColor)
+
+            $sb | Write-Prompt $s.BeforeStashText > $null
+            $sb | Write-Prompt $stashTextSpan > $null
+            $sb | Write-Prompt $s.AfterStashText > $null
         }
 
-        $sb | Write-Prompt $s.AfterText -BackgroundColor $s.AfterBackgroundColor -ForegroundColor $s.AfterForegroundColor | Out-Null
+        $sb | Write-Prompt $s.AfterText > $null
 
         if ($WindowTitleSupported -and $s.EnableWindowTitle) {
-            if( -not $Global:PreviousWindowTitle ) {
+            if (!$Global:PreviousWindowTitle) {
                 $Global:PreviousWindowTitle = $Host.UI.RawUI.WindowTitle
             }
+
             $repoName = Split-Path -Leaf (Split-Path $status.GitDir)
             $prefix = if ($s.EnableWindowTitle -is [string]) { $s.EnableWindowTitle } else { '' }
             $Host.UI.RawUI.WindowTitle = "$script:adminHeader$prefix$repoName [$($status.Branch)]"
         }
 
         return $sb.ToString()
-    } elseif ( $Global:PreviousWindowTitle ) {
+    }
+    elseif ($Global:PreviousWindowTitle) {
         $Host.UI.RawUI.WindowTitle = $Global:PreviousWindowTitle
         return ""
     }
 }
 
-if(!(Test-Path Variable:Global:VcsPromptStatuses)) {
+if (!(Test-Path Variable:Global:VcsPromptStatuses)) {
     $Global:VcsPromptStatuses = @()
-}
-$s = $global:GitPromptSettings
-
-# Override some of the normal colors if the background color is set to the default DarkMagenta.
-if ($Host.UI.RawUI.BackgroundColor -eq [ConsoleColor]::DarkMagenta) {
-    $s.LocalDefaultStatusForegroundColor    = $s.LocalDefaultStatusForegroundBrightColor
-    $s.LocalWorkingStatusForegroundColor    = $s.LocalWorkingStatusForegroundBrightColor
-
-    $s.BeforeIndexForegroundColor           = $s.BeforeIndexForegroundBrightColor
-    $s.IndexForegroundColor                 = $s.IndexForegroundBrightColor
-
-    $s.WorkingForegroundColor               = $s.WorkingForegroundBrightColor
 }
 
 function Global:Write-VcsStatus {
@@ -360,9 +487,9 @@ $PoshGitVcsPrompt = {
     catch {
         $s = $Global:GitPromptSettings
         if ($s) {
-            Write-Prompt $s.BeforeText -BackgroundColor $s.BeforeBackgroundColor -ForegroundColor $s.BeforeForegroundColor
-            Write-Prompt "Error: $_" -BackgroundColor $s.ErrorBackgroundColor -ForegroundColor $s.ErrorForegroundColor
-            Write-Prompt $s.AfterText -BackgroundColor $s.AfterBackgroundColor -ForegroundColor $s.AfterForegroundColor
+            Write-Prompt $s.BeforeText
+            Write-Prompt "Error: $_" -BackgroundColor $s.ErrorColor.BackgroundColor -ForegroundColor $s.ErrorColor.ForegroundColor
+            Write-Prompt $s.AfterText
         }
     }
 }

--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -30,14 +30,14 @@ class PoshGitCellColor {
         }
         elseif (Test-VirtualTerminalSequece $color) {
             $txt = EscapseAnsiString $color
-            $str = "${color} # ${ansiTerm} $txt"
+            $str = "${color} #${ansiTerm} $txt"
         }
         else {
             $str = ""
 
             if ($global:GitPromptSettings.AnsiConsole) {
                 $bg = Get-BackgroundVirtualTerminalSequence $color
-                $str += "${bg}   ${ansiTerm} "
+                $str += "${bg}  ${ansiTerm} "
             }
 
             $str += $color.ToString()
@@ -113,7 +113,7 @@ class PoshGitTextSpan {
         }
 
         $fg = $this.ForegroundColor
-        if (!(Test-VirtualTerminalSequece $fg)) {
+        if ($fg -and !(Test-VirtualTerminalSequece $fg)) {
             $fg = Get-ForegroundVirtualTerminalSequence $fg
         }
 
@@ -360,8 +360,9 @@ function Write-GitStatus($status) {
         $sb | Write-Prompt $branchNameTextSpan > $null
 
         if ($branchStatusTextSpan.Text) {
-            $branchStatusTextSpan.Text = " " + $branchStatusTextSpan.Text
-            $sb | Write-Prompt $branchStatusTextSpan > $null
+            $textSpan = [PoshGitTextSpan]::new($branchStatusTextSpan)
+            $textSpan.Text = " " + $branchStatusTextSpan.Text
+            $sb | Write-Prompt $textSpan > $null
         }
 
         if ($s.EnableFileStatus -and $status.HasIndex) {
@@ -431,8 +432,9 @@ function Write-GitStatus($status) {
         }
 
         if ($localStatusSymbol.Text) {
-            $localStatusSymbol.Text = " " + $localStatusSymbol.Text
-            $sb | Write-Prompt $localStatusSymbol > $null
+            $textSpan = [PoshGitTextSpan]::new($localStatusSymbol)
+            $textSpan.Text = " " + $localStatusSymbol.Text
+            $sb | Write-Prompt $textSpan > $null
         }
 
         if ($s.EnableStashStatus -and ($status.StashCount -gt 0)) {

--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -37,7 +37,7 @@ class PoshGitCellColor {
 
             if ($global:GitPromptSettings.AnsiConsole) {
                 $bg = Get-BackgroundVirtualTerminalSequence $color
-                $str += "${bg} ${ansiTerm} "
+                $str += "${bg}   ${ansiTerm} "
             }
 
             $str += $color.ToString()
@@ -122,64 +122,63 @@ class PoshGitTextSpan {
 }
 
 $global:GitPromptSettings = [pscustomobject]@{
-    FileAddedText                               = '+'
-    FileModifiedText                            = '~'
-    FileRemovedText                             = '-'
-    FileConflictedText                          = '!'
+    DefaultColor                           = [PoshGitCellColor]::new()
+    BranchColor                            = [PoshGitCellColor]::new([ConsoleColor]::Cyan)
+    IndexColor                             = [PoshGitCellColor]::new([ConsoleColor]::DarkGreen)
+    WorkingColor                           = [PoshGitCellColor]::new([ConsoleColor]::DarkRed)
+    StashColor                             = [PoshGitCellColor]::new([ConsoleColor]::Red)
+    ErrorColor                             = [PoshGitCellColor]::new([ConsoleColor]::Red)
 
-    DefaultColor                                = [PoshGitCellColor]::new()
-    BranchColor                                 = [PoshGitCellColor]::new([ConsoleColor]::Cyan)
-    IndexColor                                  = [PoshGitCellColor]::new([ConsoleColor]::DarkGreen)
-    WorkingColor                                = [PoshGitCellColor]::new([ConsoleColor]::DarkRed)
-    StashColor                                  = [PoshGitCellColor]::new([ConsoleColor]::Red)
-    ErrorColor                                  = [PoshGitCellColor]::new([ConsoleColor]::Red)
+    BeforeText                             = [PoshGitTextSpan]::new(' [', [ConsoleColor]::Yellow)
+    DelimText                              = [PoshGitTextSpan]::new(' |', [ConsoleColor]::Yellow)
+    AfterText                              = [PoshGitTextSpan]::new(']',  [ConsoleColor]::Yellow)
 
-    BeforeText                                  = [PoshGitTextSpan]::new(' [', [ConsoleColor]::Yellow)
-    DelimText                                   = [PoshGitTextSpan]::new(' |', [ConsoleColor]::Yellow)
-    AfterText                                   = [PoshGitTextSpan]::new(']',  [ConsoleColor]::Yellow)
+    LocalDefaultStatusSymbol               = [PoshGitTextSpan]::new('',  [ConsoleColor]::DarkGreen)
+    LocalWorkingStatusSymbol               = [PoshGitTextSpan]::new('!', [ConsoleColor]::DarkRed)
+    LocalStagedStatusSymbol                = [PoshGitTextSpan]::new('~', [ConsoleColor]::DarkCyan)
 
-    LocalDefaultStatusSymbol                    = [PoshGitTextSpan]::new('',  [ConsoleColor]::DarkGreen)
-    LocalWorkingStatusSymbol                    = [PoshGitTextSpan]::new('!', [ConsoleColor]::DarkRed)
-    LocalStagedStatusSymbol                     = [PoshGitTextSpan]::new('~', [ConsoleColor]::DarkCyan)
+    BranchGoneStatusSymbol                 = [PoshGitTextSpan]::new([char]0x00D7, [ConsoleColor]::DarkCyan) # × Multiplication sign
+    BranchIdenticalStatusSymbol            = [PoshGitTextSpan]::new([char]0x2261, [ConsoleColor]::Cyan)     # ≡ Three horizontal lines
+    BranchAheadStatusSymbol                = [PoshGitTextSpan]::new([char]0x2191, [ConsoleColor]::Green)    # ↑ Up arrow
+    BranchBehindStatusSymbol               = [PoshGitTextSpan]::new([char]0x2193, [ConsoleColor]::Red)      # ↓ Down arrow
+    BranchBehindAndAheadStatusSymbol       = [PoshGitTextSpan]::new([char]0x2195, [ConsoleColor]::Yellow)   # ↕ Up & Down arrow
 
-    BranchUntrackedSymbol                       = [PoshGitTextSpan]::new('',  [ConsoleColor]::DarkCyan)
+    BeforeIndexText                        = [PoshGitTextSpan]::new('',  [ConsoleColor]::DarkGreen)
+    BeforeStashText                        = [PoshGitTextSpan]::new(' (', [ConsoleColor]::Red)
+    AfterStashText                         = [PoshGitTextSpan]::new(')',  [ConsoleColor]::Red)
 
-    BranchGoneStatusSymbol                      = [PoshGitTextSpan]::new([char]0x00D7, [ConsoleColor]::DarkCyan) # × Multiplication sign
-    BranchIdenticalStatusSymbol                 = [PoshGitTextSpan]::new([char]0x2261, [ConsoleColor]::Cyan)     # ≡ Three horizontal lines
-    BranchAheadStatusSymbol                     = [PoshGitTextSpan]::new([char]0x2191, [ConsoleColor]::Green)    # ↑ Up arrow
-    BranchBehindStatusSymbol                    = [PoshGitTextSpan]::new([char]0x2193, [ConsoleColor]::Red)      # ↓ Down arrow
-    BranchBehindAndAheadStatusSymbol            = [PoshGitTextSpan]::new([char]0x2195, [ConsoleColor]::Yellow)   # ↕ Up & Down arrow
-    BranchBehindAndAheadDisplay                 = [BranchBehindAndAheadDisplayOptions]"Full"
+    FileAddedText                          = '+'
+    FileModifiedText                       = '~'
+    FileRemovedText                        = '-'
+    FileConflictedText                     = '!'
+    BranchUntrackedText                    = ''
 
-    BeforeIndexText                             = [PoshGitTextSpan]::new('',  [ConsoleColor]::DarkGreen)
+    BranchBehindAndAheadDisplay            = [BranchBehindAndAheadDisplayOptions]"Full"
 
-    BeforeStashText                             = [PoshGitTextSpan]::new(' (', [ConsoleColor]::Red)
-    AfterStashText                              = [PoshGitTextSpan]::new(')',  [ConsoleColor]::Red)
+    EnableStashStatus                      = $false
+    ShowStatusWhenZero                     = $true
+    AutoRefreshIndex                       = $true
 
-    EnableStashStatus                           = $false
-    ShowStatusWhenZero                          = $true
-    AutoRefreshIndex                            = $true
+    EnablePromptStatus                     = !$global:GitMissing
+    EnableFileStatus                       = $true
+    EnableFileStatusFromCache              = $null
+    RepositoriesInWhichToDisableFileStatus = @() # Array of repository paths
+    DescribeStyle                          = ''
 
-    EnablePromptStatus                          = !$Global:GitMissing
-    EnableFileStatus                            = $true
-    EnableFileStatusFromCache                   = $null
-    RepositoriesInWhichToDisableFileStatus      = @() # Array of repository paths
-    DescribeStyle                               = ''
+    EnableWindowTitle                      = 'posh~git ~ '
 
-    EnableWindowTitle                           = 'posh~git ~ '
+    AnsiConsole                            = $Host.UI.SupportsVirtualTerminal -or ($Env:ConEmuANSI -eq "ON")
 
-    AnsiConsole                                 = $Host.UI.SupportsVirtualTerminal -or ($Env:ConEmuANSI -eq "ON")
+    DefaultPromptPrefix                    = ''
+    DefaultPromptSuffix                    = '$(''>'' * ($nestedPromptLevel + 1)) '
+    DefaultPromptDebugSuffix               = ' [DBG]$(''>'' * ($nestedPromptLevel + 1)) '
+    DefaultPromptEnableTiming              = $false
+    DefaultPromptAbbreviateHomeDirectory   = $false
 
-    DefaultPromptPrefix                         = ''
-    DefaultPromptSuffix                         = '$(''>'' * ($nestedPromptLevel + 1)) '
-    DefaultPromptDebugSuffix                    = ' [DBG]$(''>'' * ($nestedPromptLevel + 1)) '
-    DefaultPromptEnableTiming                   = $false
-    DefaultPromptAbbreviateHomeDirectory        = $false
+    Debug                                  = $false
 
-    Debug                                       = $false
-
-    BranchNameLimit                             = 0
-    TruncatedBranchSuffix                       = '...'
+    BranchNameLimit                        = 0
+    TruncatedBranchSuffix                  = '...'
 }
 
 # Override some of the normal colors if the background color is set to the default DarkMagenta.
@@ -213,13 +212,16 @@ if (Get-Module NuGet) {
 
 function Write-Prompt {
     param(
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         $Object,
-        [parameter()]
+
+        [Parameter()]
         $ForegroundColor = $null,
-        [parameter()]
+
+        [Parameter()]
         $BackgroundColor = $null,
-        [parameter(ValueFromPipeline = $true)]
+
+        [Parameter(ValueFromPipeline = $true)]
         [Text.StringBuilder]
         $Builder
     )
@@ -233,10 +235,6 @@ function Write-Prompt {
         if ($null -eq $BackgroundColor) {
             $BackgroundColor = $s.DefaultColor.BackgroundColor
         }
-    }
-
-    if ($Object -is [PoshGitCellColor]) {
-        Write-Warning "Unexpected PoshGitCellColor passed to Write-Prompt"
     }
 
     if ($GitPromptSettings.AnsiConsole) {
@@ -298,17 +296,13 @@ function Write-GitStatus($status) {
     $s = $global:GitPromptSettings
     $sb = [System.Text.StringBuilder]::new(150)
 
-    if (!$s) {
-        Write-Warning "`$global:GitPromptSettings is not defined. Posh-git prompt information will be limited."
-    }
-
     if ($status -and $s) {
         $sb | Write-Prompt $s.BeforeText > $null
 
         $branchStatusTextSpan = [PoshGitTextSpan]::new($s.BranchColor)
 
         if (!$status.Upstream) {
-            $branchStatusTextSpan = $s.BranchUntrackedSymbol
+            $branchStatusTextSpan.Text = $s.BranchUntrackedText
         }
         elseif ($status.UpstreamGone -eq $true) {
             # Upstream branch is gone
@@ -366,7 +360,7 @@ function Write-GitStatus($status) {
         $sb | Write-Prompt $branchNameTextSpan > $null
 
         if ($branchStatusTextSpan.Text) {
-            $sb.Append(' ') > $null
+            $branchStatusTextSpan.Text = " " + $branchStatusTextSpan.Text
             $sb | Write-Prompt $branchStatusTextSpan > $null
         }
 
@@ -436,13 +430,14 @@ function Write-GitStatus($status) {
             $localStatusSymbol = $s.LocalDefaultStatusSymbol
         }
 
-        if ($localStatusSymbol) {
-            $sb.Append(' ') > $null
+        if ($localStatusSymbol.Text) {
+            $localStatusSymbol.Text = " " + $localStatusSymbol.Text
             $sb | Write-Prompt $localStatusSymbol > $null
         }
 
         if ($s.EnableStashStatus -and ($status.StashCount -gt 0)) {
-            $stashTextSpan = [PoshGitTextSpan]::new("$($status.StashCount)", $s.StashColor)
+            $stashTextSpan = [PoshGitTextSpan]::new($s.StashColor)
+            $stashTextSpan.Text = "$($status.StashCount)"
 
             $sb | Write-Prompt $s.BeforeStashText > $null
             $sb | Write-Prompt $stashTextSpan > $null
@@ -452,8 +447,8 @@ function Write-GitStatus($status) {
         $sb | Write-Prompt $s.AfterText > $null
 
         if ($WindowTitleSupported -and $s.EnableWindowTitle) {
-            if (!$Global:PreviousWindowTitle) {
-                $Global:PreviousWindowTitle = $Host.UI.RawUI.WindowTitle
+            if (!$global:PreviousWindowTitle) {
+                $global:PreviousWindowTitle = $Host.UI.RawUI.WindowTitle
             }
 
             $repoName = Split-Path -Leaf (Split-Path $status.GitDir)
@@ -463,29 +458,29 @@ function Write-GitStatus($status) {
 
         return $sb.ToString()
     }
-    elseif ($Global:PreviousWindowTitle) {
-        $Host.UI.RawUI.WindowTitle = $Global:PreviousWindowTitle
+    elseif ($global:PreviousWindowTitle) {
+        $Host.UI.RawUI.WindowTitle = $global:PreviousWindowTitle
         return ""
     }
 }
 
 if (!(Test-Path Variable:Global:VcsPromptStatuses)) {
-    $Global:VcsPromptStatuses = @()
+    $global:VcsPromptStatuses = @()
 }
 
 function Global:Write-VcsStatus {
     Set-ConsoleMode -ANSI
-    $Global:VcsPromptStatuses | ForEach-Object { & $_ }
+    $global:VcsPromptStatuses | ForEach-Object { & $_ }
 }
 
 # Add scriptblock that will execute for Write-VcsStatus
 $PoshGitVcsPrompt = {
     try {
-        $Global:GitStatus = Get-GitStatus
+        $global:GitStatus = Get-GitStatus
         Write-GitStatus $GitStatus
     }
     catch {
-        $s = $Global:GitPromptSettings
+        $s = $global:GitPromptSettings
         if ($s) {
             Write-Prompt $s.BeforeText
             Write-Prompt "Error: $_" -BackgroundColor $s.ErrorColor.BackgroundColor -ForegroundColor $s.ErrorColor.ForegroundColor
@@ -494,4 +489,4 @@ $PoshGitVcsPrompt = {
     }
 }
 
-$Global:VcsPromptStatuses += $PoshGitVcsPrompt
+$global:VcsPromptStatuses += $PoshGitVcsPrompt


### PR DESCRIPTION
This is based on the existing `develop` branch approach to rendering ANSI.  The other approaches I tried aren't there yet. Add-Type is too slow on PS Core.  Using C# source code is a pain to get built and working cross-platform.

This approach uses v5 classes so we would have to drop support for v3/v4.  This seems reasonable to me as the primary points of this branch are to support cross-platform PowerShell Core and ANSI.

Before this change, looking at the `$GitPromptSettings` results in:

![image](https://user-images.githubusercontent.com/5177512/32141301-798cd73a-bc42-11e7-8e14-5483cccbcd52.png)

After this change:

![image](https://user-images.githubusercontent.com/5177512/32141304-891615cc-bc42-11e7-93dc-c20c5e02adec.png)
