### PR TITLE
Directory names that contain [brackets] cause GitPrompt to fail

### DIFF
--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -24,7 +24,7 @@ function Get-GitDirectory {
         $Env:GIT_DIR -replace '\\|/', [System.IO.Path]::DirectorySeparatorChar
     }
     else {
-        $currentDir = Get-Item $pathInfo -Force
+        $currentDir = Get-Item -LiteralPath $pathInfo -Force
         while ($currentDir) {
             $gitDirPath = Join-Path $currentDir.FullName .git
             if (Test-Path -LiteralPath $gitDirPath -PathType Container) {


### PR DESCRIPTION
Using `Get-Item -LiteralPath` means that "[brackets]" don't get interpreted as wildcards. 

Repro: 
- rename the directory in you have a git repo using square brackets e.g. `C:\code\foo[bar]`
- Open a posh-git enabled Powershell prompt in the directory
- The following error appears:  ``` C:\code\foo[bar] [Error: Cannot retrieve the dynamic parameters for the cmdlet. The specified wildcard character pattern is not valid: foo[bar]]```

