### PR TITLE
Add `Add-PoshGitToProfile -AllUsers` support

### DIFF
--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -112,16 +112,7 @@ $global:GitPromptSettings = [pscustomobject]@{
     TruncatedBranchSuffix                       = '...'
 }
 
-# PowerShell 5.x only runs on Windows so use .NET types to determine isAdminProcess
-# Or if we are on v6 or higher, check the $IsWindows pre-defined variable.
-if (($PSVersionTable.PSVersion.Major -le 5) -or $IsWindows) {
-    $currentUser = [Security.Principal.WindowsPrincipal]([Security.Principal.WindowsIdentity]::GetCurrent())
-    $isAdminProcess = $currentUser.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-}
-else {
-    # Must be Linux or OSX, so use the id util. Root has userid of 0.
-    $isAdminProcess = 0 -eq (id -u)
-}
+$isAdminProcess = Test-Administrator
 
 $adminHeader = if ($isAdminProcess) { 'Administrator: ' } else { '' }
 

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -125,6 +125,10 @@ function Add-PoshGitToProfile {
         $TestParams
     )
 
+    if ($AllUsers -and !(Test-Administrator)) {
+        throw 'Installing posh-git for all users requires an elevated host.'
+    }
+
     $underTest = $false
 
     $profileName = $(if ($AllUsers) { 'AllUsers' } else { 'CurrentUser' }) `

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -126,7 +126,7 @@ function Add-PoshGitToProfile {
     )
 
     if ($AllUsers -and !(Test-Administrator)) {
-        throw 'Installing posh-git for all users requires an elevated host.'
+        throw 'Adding posh-git to an AllUsers profile requires an elevated host.'
     }
 
     $underTest = $false

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -65,7 +65,12 @@ function Invoke-Utf8ConsoleCommand([ScriptBlock]$cmd) {
 .PARAMETER AllHosts
     By default, this command modifies the CurrentUserCurrentHost profile
     script.  By specifying the AllHosts switch, the command updates the
-    CurrentUserAllHosts profile.
+    CurrentUserAllHosts profile (or AllUsersAllHosts, given -AllUsers).
+.PARAMETER AllUsers
+    By default, this command modifies the CurrentUserCurrentHost profile
+    script.  By specifying the AllUsers switch, the command updates the
+    AllUsersCurrentHost profile (or AllUsersAllHosts, given -AllHosts).
+    Requires elevated permissions.
 .PARAMETER Force
     Do not check if the specified profile script is already importing
     posh-git. Just add Import-Module posh-git command.
@@ -76,7 +81,7 @@ function Invoke-Utf8ConsoleCommand([ScriptBlock]$cmd) {
     Updates your profile script for the current PowerShell host to import the
     posh-git module when the current PowerShell host starts.
 .EXAMPLE
-    PS C:\> Add-PoshGitToProfile -AllHost
+    PS C:\> Add-PoshGitToProfile -AllHosts
     Updates your profile script for all PowerShell hosts to import the posh-git
     module whenever any PowerShell host starts.
 .INPUTS
@@ -93,6 +98,10 @@ function Add-PoshGitToProfile {
 
         [Parameter()]
         [switch]
+        $AllUsers,
+
+        [Parameter()]
+        [switch]
         $Force,
 
         [Parameter()]
@@ -106,7 +115,12 @@ function Add-PoshGitToProfile {
 
     $underTest = $false
 
-    $profilePath = if ($AllHosts) { $PROFILE.CurrentUserAllHosts } else { $PROFILE.CurrentUserCurrentHost }
+    $profileName = $(if ($AllUsers) { 'AllUsers' } else { 'CurrentUser' }) `
+                 + $(if ($AllHosts) { 'AllHosts' } else { 'CurrentHost' })
+    Write-Verbose "`$profileName = '$profileName'"
+
+    $profilePath = $PROFILE.$profileName
+    Write-Verbose "`$profilePath = '$profilePath'"
 
     # Under test, we override some variables using $args as a backdoor.
     if (($TestParams.Count -gt 0) -and ($TestParams[0] -is [string])) {
@@ -149,7 +163,6 @@ function Add-PoshGitToProfile {
 
     if (!$profilePath) {
         Write-Warning "Skipping add of posh-git import to profile; no profile found."
-        Write-Verbose "`$profilePath          = '$profilePath'"
         Write-Verbose "`$PROFILE              = '$PROFILE'"
         Write-Verbose "CurrentUserCurrentHost = '$($PROFILE.CurrentUserCurrentHost)'"
         Write-Verbose "CurrentUserAllHosts    = '$($PROFILE.CurrentUserAllHosts)'"

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -54,6 +54,18 @@ function Invoke-Utf8ConsoleCommand([ScriptBlock]$cmd) {
     }
 }
 
+function Test-Administrator {
+    # PowerShell 5.x only runs on Windows so use .NET types to determine isAdminProcess
+    # Or if we are on v6 or higher, check the $IsWindows pre-defined variable.
+    if (($PSVersionTable.PSVersion.Major -le 5) -or $IsWindows) {
+        $currentUser = [Security.Principal.WindowsPrincipal]([Security.Principal.WindowsIdentity]::GetCurrent())
+        return $currentUser.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    }
+
+    # Must be Linux or OSX, so use the id util. Root has userid of 0.
+    return 0 -eq (id -u)
+}
+
 <#
 .SYNOPSIS
     Configures your PowerShell profile (startup) script to import the posh-git


### PR DESCRIPTION
Toward including an option to install posh-git with Git for Windows (https://github.com/git-for-windows/git/issues/1384), this adds an option to add to profile for all users.

Note that, as expected, `-AllUsers` from a non-elevated shell fails:

```
Add-Content : Access to the path
'C:\Windows\System32\WindowsPowerShell\v1.0\Microsoft.PowerShell_profile.ps1' is denied.
```
or
```
Add-Content : Access to the path
'C:\Windows\System32\WindowsPowerShell\v1.0\profile.ps1' is denied.
```

Running PowerShell as Administrator allows the global install.