### PR TITLE
Fix  duplicated branch completion for git checkout issue 505

### DIFF
--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -359,9 +359,11 @@ function GitTabExpansionInternal($lastBlock, $GitStatus = $null) {
 
         # Handles git checkout <ref>
         "^(?:checkout).* (?<ref>\S*)$" {
-            gitBranches $matches['ref'] $true
-            gitRemoteUniqueBranches $matches['ref']
-            gitTags $matches['ref']
+            $script:gitBranches = @(gitBranches $matches['ref'] $true)
+            $script:gitRemoteUniqueBranches = @(gitRemoteUniqueBranches $matches['ref'])
+            $script:gitTags = @(gitTags $matches['ref'])
+            # return only unique branches (to eliminate duplicates where the branch exists locally and on the remote)
+            $script:gitBranches + $script:gitRemoteUniqueBranches + $script:gitTags | Sort-Object -Unique
         }
 
         # Handles git worktree add <path> <ref>

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -362,7 +362,7 @@ function GitTabExpansionInternal($lastBlock, $GitStatus = $null) {
             $script:gitBranches = @(gitBranches $matches['ref'] $true)
             $script:gitRemoteUniqueBranches = @(gitRemoteUniqueBranches $matches['ref'])
             $script:gitTags = @(gitTags $matches['ref'])
-            # return only unique branches (to eliminate duplicates where the branch exists locally and on the remote)
+            # Return only unique branches (to eliminate duplicates where the branch exists locally and on the remote)
             $script:gitBranches + $script:gitRemoteUniqueBranches + $script:gitTags | Select-Object -Unique
         }
 

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -359,11 +359,12 @@ function GitTabExpansionInternal($lastBlock, $GitStatus = $null) {
 
         # Handles git checkout <ref>
         "^(?:checkout).* (?<ref>\S*)$" {
-            $script:gitBranches = @(gitBranches $matches['ref'] $true)
-            $script:gitRemoteUniqueBranches = @(gitRemoteUniqueBranches $matches['ref'])
-            $script:gitTags = @(gitTags $matches['ref'])
-            # Return only unique branches (to eliminate duplicates where the branch exists locally and on the remote)
-            $script:gitBranches + $script:gitRemoteUniqueBranches + $script:gitTags | Select-Object -Unique
+            & {
+                @(gitBranches $matches['ref'] $true)
+                @(gitRemoteUniqueBranches $matches['ref'])
+                @(gitTags $matches['ref']) 
+                # Return only unique branches (to eliminate duplicates where the branch exists locally and on the remote)
+            } | Select-Object -Unique
         }
 
         # Handles git worktree add <path> <ref>

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -363,7 +363,7 @@ function GitTabExpansionInternal($lastBlock, $GitStatus = $null) {
             $script:gitRemoteUniqueBranches = @(gitRemoteUniqueBranches $matches['ref'])
             $script:gitTags = @(gitTags $matches['ref'])
             # return only unique branches (to eliminate duplicates where the branch exists locally and on the remote)
-            $script:gitBranches + $script:gitRemoteUniqueBranches + $script:gitTags | Sort-Object -Unique
+            $script:gitBranches + $script:gitRemoteUniqueBranches + $script:gitTags | Select-Object -Unique
         }
 
         # Handles git worktree add <path> <ref>

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -360,9 +360,9 @@ function GitTabExpansionInternal($lastBlock, $GitStatus = $null) {
         # Handles git checkout <ref>
         "^(?:checkout).* (?<ref>\S*)$" {
             & {
-                @(gitBranches $matches['ref'] $true)
-                @(gitRemoteUniqueBranches $matches['ref'])
-                @(gitTags $matches['ref']) 
+                gitBranches $matches['ref'] $true
+                gitRemoteUniqueBranches $matches['ref']
+                gitTags $matches['ref']
                 # Return only unique branches (to eliminate duplicates where the branch exists locally and on the remote)
             } | Select-Object -Unique
         }


### PR DESCRIPTION
Fixes #505 by outputting only unique branches.
Instead of the proposed `Sort-Object -Unique`, I used `Select-Object -Unique` because:
- the 3 arrays for local branches, remote branches and tags are already sorted by themselves
- in order to not break existing behaviour and only fix the bug
- most user are less interested in tags and remote branches when using `git checkout`, therefore keeping the order as it was before makes sense
- better performance