### PR TITLE
Auto fix PSScriptAnalyzer warnings (aliases)

### DIFF
--- a/chocolatey/packAndLocalInstall.ps1
+++ b/chocolatey/packAndLocalInstall.ps1
@@ -1,5 +1,5 @@
 param ($Remote = 'origin', [switch]$Force)
-pushd $PSScriptRoot
+Push-Location $PSScriptRoot
 
 $nuspec = [xml](Get-Content poshgit.nuspec)
 $version = $nuspec.package.metadata.version
@@ -17,4 +17,4 @@ elseif (!$(git ls-remote $Remote $tag)) {
 choco pack poshgit.nuspec
 choco install -f -y poshgit -pre --version=$version -s .
 
-popd
+Pop-Location

--- a/chocolatey/tests/InstallChocolatey.Tests.ps1
+++ b/chocolatey/tests/InstallChocolatey.Tests.ps1
@@ -39,7 +39,7 @@ Describe "Install-Posh-Git" {
             RunInstall
 
             $newProfile = (Get-Content $Profile)
-            $pgitDir = [Array](Dir "$poshgitPath\*posh-git*\" | Sort-Object -Property LastWriteTime)[-1]
+            $pgitDir = [Array](Get-ChildItem "$poshgitPath\*posh-git*\" | Sort-Object -Property LastWriteTime)[-1]
             ($newProfile -like ". '$poshgitPath\posh-git\profile.example.ps1'").Count.should.be(0)
             ($newProfile -like ". '$pgitDir\profile.example.ps1'").Count.should.be(1)
         }
@@ -59,7 +59,7 @@ Describe "Install-Posh-Git" {
             RunInstall
 
             $newProfile = (Get-Content $Profile)
-            $pgitDir = [Array](Dir "$poshgitPath\*posh-git*\" | Sort-Object -Property LastWriteTime)[-1]
+            $pgitDir = [Array](Get-ChildItem "$poshgitPath\*posh-git*\" | Sort-Object -Property LastWriteTime)[-1]
             ($newProfile -like ". '$pgitDir\profile.example.ps1'").Count.should.be(1)
         }
         catch {
@@ -94,7 +94,7 @@ Describe "Install-Posh-Git" {
         try{
             RunInstall
             mkdir PoshTest
-            Pushd PoshTest
+            Push-Location PoshTest
             git init
             . $Profile
             $global:wh=""
@@ -102,7 +102,7 @@ Describe "Install-Posh-Git" {
 
             Prompt
 
-            Popd
+            Pop-Location
             $wh.should.be("$pwd\PoshTest [master]")
         }
         catch {
@@ -122,7 +122,7 @@ Describe "Install-Posh-Git" {
             Remove-Item $Profile -Force
             RunInstall
             mkdir PoshTest
-            Pushd PoshTest
+            Push-Location PoshTest
             git init
             . $Profile
             $global:wh=""
@@ -130,7 +130,7 @@ Describe "Install-Posh-Git" {
 
             Prompt
 
-            Popd
+            Pop-Location
             $wh.should.be("$pwd\PoshTest [master]")
         }
         catch {
@@ -152,7 +152,7 @@ Describe "Install-Posh-Git" {
             Add-Content $profile -value "function prompt {Write-Host 'Hi'}" -Force
             RunInstall
             mkdir PoshTest
-            Pushd PoshTest
+            Push-Location PoshTest
             git init
             . $Profile
             $global:wh=""
@@ -161,7 +161,7 @@ Describe "Install-Posh-Git" {
             Prompt
 
             Remove-Item function:\global:Write-Host
-            Popd
+            Pop-Location
             $wh.should.be("$pwd\PoshTest [master]")
         }
         catch {
@@ -183,7 +183,7 @@ Describe "Install-Posh-Git" {
             Add-Content $profile -value ". 'C:\tools\poshgit\dahlbyk-posh-git-60be436\profile.example.ps1'" -Force
             RunInstall
             mkdir PoshTest
-            Pushd PoshTest
+            Push-Location PoshTest
             git init
             write-output (Get-Content function:\prompt)
             . $Profile
@@ -193,7 +193,7 @@ Describe "Install-Posh-Git" {
             Prompt
 
             Remove-Item function:\global:Write-Host
-            Popd
+            Pop-Location
             $wh.should.be("$pwd\PoshTest [master]")
         }
         catch {


### PR DESCRIPTION
I recently submitted a PR to [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) to auto-fix warnings. I have applied this to this repo to replace aliases and make sure that the encoding gets preserved. 