### PR TITLE
Default Prompt Colors

### DIFF
--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -206,6 +206,9 @@ class GitPromptSettings {
     [PoshGitTextSpan]$DefaultPromptDebugSuffix  = ' [DBG]$(''>'' * ($nestedPromptLevel + 1)) '
 
     [bool]$DefaultPromptEnableTiming            = $false
+    [PoshGitCellColor]$DefaultPromptTimingColor = [PoshGitCellColor]::new()
+
+    [PoshGitCellColor]$DefaultPromptPathColor   = [PoshGitCellColor]::new()
     [bool]$DefaultPromptAbbreviateHomeDirectory = $false
 
     [int]$BranchNameLimit = 0

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -201,9 +201,10 @@ class GitPromptSettings {
     [string]$DescribeStyle       = ''
     [psobject]$EnableWindowTitle = 'posh~git ~ '
 
-    [string]$DefaultPromptPrefix                = ''
-    [string]$DefaultPromptSuffix                = '$(''>'' * ($nestedPromptLevel + 1)) '
-    [string]$DefaultPromptDebugSuffix           = ' [DBG]$(''>'' * ($nestedPromptLevel + 1)) '
+    [PoshGitTextSpan]$DefaultPromptPrefix       = ''
+    [PoshGitTextSpan]$DefaultPromptSuffix       = '$(''>'' * ($nestedPromptLevel + 1)) '
+    [PoshGitTextSpan]$DefaultPromptDebugSuffix  = ' [DBG]$(''>'' * ($nestedPromptLevel + 1)) '
+
     [bool]$DefaultPromptEnableTiming            = $false
     [bool]$DefaultPromptAbbreviateHomeDirectory = $false
 

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -208,7 +208,7 @@ class GitPromptSettings {
     [bool]$DefaultPromptEnableTiming            = $false
     [PoshGitCellColor]$DefaultPromptTimingColor = [PoshGitCellColor]::new()
 
-    [PoshGitCellColor]$DefaultPromptPathColor   = [PoshGitCellColor]::new()
+    [PoshGitTextSpan]$DefaultPromptPath         = '$(Get-PromptPath)'
     [bool]$DefaultPromptAbbreviateHomeDirectory = $false
 
     [int]$BranchNameLimit = 0

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -28,6 +28,7 @@ FunctionsToExport = @(
     'Get-GitBranchStatusColor',
     'Get-GitStatus',
     'Get-GitDirectory',
+    'Get-PromptPath',
     'Update-AllBranches',
     'Write-GitStatus',
     'Write-GitBranchName',

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -72,7 +72,7 @@ $GitPromptScriptBlock = {
     }
 
     # Write the abbreviated current path
-    $prompt += Write-Prompt $currentPath
+    $prompt += Write-Prompt $currentPath -Color $settings.DefaultPromptPathColor
 
     # Write the Git status summary information
     $prompt += Write-VcsStatus
@@ -95,7 +95,7 @@ $GitPromptScriptBlock = {
     if ($settings.DefaultPromptEnableTiming) {
         $sw.Stop()
         $elapsed = $sw.ElapsedMilliseconds
-        $prompt += Write-Prompt " ${elapsed}ms"
+        $prompt += Write-Prompt " ${elapsed}ms" -Color $settings.DefaultPromptTimingColor
     }
 
     $global:LASTEXITCODE = $origLastExitCode


### PR DESCRIPTION
Much easier to close #474 with the changes from #513.

- `DefaultPromptPrefix`, `DefaultPromptSuffix` and `DefaultPromptDebugSuffix` are now `PoshGitTextSpan`s that understand colors
- <del>`DefaultPromptPathColor`</del> and `DefaultPromptTimingColor` are supported, too

**Update:** Also closes #469 by:

- Exporting `Get-PromptPath` with our default (`$GitPromptSettings`-based) path behavior
- Supporting `DefaultPromptPath` (also a `PoshGitTextSpan`) to control colors and the string to expand when `prompt` executes (`'$(Get-PromptPath)'` by default)

To customize how the path is displayed, the user would do something like...

```powershell
function Get-FancyPromptPath {
  (Get-PromptPath).ToUpper()
}
$GitPromptSettings.DefaultPromptPath.Text = '$(Get-FancyPromptPath)'
```