### PR TITLE
Update CHANGELOG for 1.0.0-beta1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,75 @@
 # posh-git Release History
 
-## 1.0.0 - TBD
-This release introduces breaking changes with 0.x to both drop support for PowerShell 2.0 and support writing prompt strings using ANSI sequences.
-The ANSI sequence support will help with cross-platform PowerShell support, which is another goal of this release.
+## 1.0.0-beta1 - January 10, 2018
+
+The 1.0.0 release is targeted specifically at Windows PowerShell 5.x and (cross-platform) PowerShell Core 6.x, both of
+which support writing prompt strings using [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code).
+On Windows, support for [Console Virtual Terminal Sequences](https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences)
+was added in Windows 10 version 1511.
+Consequently this release introduces BREAKING changes with 0.7.x by:
+
+- Dropping support for Windows PowerShell versions 2.0, 3.0 and 4.0.
+- Changing the $GitPromptSettings hashtable to a more structured and stongly typed object.
+  Here is one example of the changed settings structure:
+  ```powershell
+  $GitPromptSettings.LocalWorkingStatusSymbol = '#'
+  $GitPromptSettings.LocalWorkingStatusForegroundColor = [ConsoleColor]::DarkRed
+  ```
+  Changes to:
+  ```powershell
+  $GitPromptSettings.LocalWorkingStatusSymbol.Text = '#'
+  $GitPromptSettings.LocalWorkingStatusSymbol.ForegroundColor = [ConsoleColor]::DarkRed
+  ```
+- Changing `Write-VcsStatus`, `Write-GitStatus` and `Write-Prompt` to return a string rather than write to host when
+  the host supports ANSI escape sequences.
+
+If you are still on Windows PowerShell 2.0, 3.0 or 4.0, please continue to use the 0.7.x version of posh-git.
+
+### Removed
 
 - Drop support for PowerShell 2.0
   ([#163](https://github.com/dahlbyk/posh-git/issues/163))
   ([PR #427](https://github.com/dahlbyk/posh-git/pull/427))
-- Remove public `Enable-GitColors`, `Get-AliasPattern` and `Get-GitBranch`; plus `Invoke-NullCoalescing` and its `??` alias
+- Drop support for PowerShell 3.0 and 4.0
+  ([#328](https://github.com/dahlbyk/posh-git/issues/328))
+  ([PR #513](https://github.com/dahlbyk/posh-git/pull/513))
+- Remove public `Enable-GitColors`, `Get-AliasPattern`, `Get-GitBranch` and `Invoke-NullCoalescing` and its `??` alias
   ([#93](https://github.com/dahlbyk/posh-git/issues/93))
   ([PR #427](https://github.com/dahlbyk/posh-git/pull/427))
+
+### Added
+
+- Implement support for ANSI escape sequences for colored output - support System.ConsoleColor, System.Drawing.HtmlColor
+  (if available on the platform) and 24-bit color.  NOTE: this is a breaking change since `Write-VcsStatus`,
+  `Write-GitStatus` and `Write-Prompt` will now return a string rather than write to the host when the host supports
+  ANSI escape sequences.
+  ([#304](https://github.com/dahlbyk/posh-git/pull/304))
+  ([#447](https://github.com/dahlbyk/posh-git/pull/447))
+  ([#455](https://github.com/dahlbyk/posh-git/pull/455))
+- $GitPromptSettings is now a strongly typed object using PS classes
+  ([#344](https://github.com/dahlbyk/posh-git/issues/344))
+  ([PR #513](https://github.com/dahlbyk/posh-git/pull/513))
+- Provide more granular commands than just `Write-GitStatus`.
+  ([#345](https://github.com/dahlbyk/posh-git/issues/345))
+  ([PR #513](https://github.com/dahlbyk/posh-git/pull/513))
+  We now export the commands that `Write-GitStatus` uses internally which are:
+  * Write-GitBranchName
+  * Write-GitBranchStatus
+  * Write-GitIndexStatus
+  * Write-GitStashCount
+  * Write-GitWorkingDirStatus
+  * Write-GitWorkingDirStatusSummary
+
+### Fixed
+
+- Fixed Get-AuthenticodeSignature not on PS Core.
+  ([PR #487](https://github.com/dahlbyk/posh-git/pull/487))
+- Provide DefaultPromptPrefixColor and DefaultPromptSuffixColor options
+  ([#474](https://github.com/dahlbyk/posh-git/issues/474))
+  ([PR #520](https://github.com/dahlbyk/posh-git/pull/520))
+- Fixed posh-git prompt makes PowerShell transcripts less readable
+  ([#282](https://github.com/dahlbyk/posh-git/issues/282))
+  ([PR #447](https://github.com/dahlbyk/posh-git/pull/447))
 
 ## 0.7.2 - January 10, 2018
 

--- a/chocolatey/poshgit.nuspec
+++ b/chocolatey/poshgit.nuspec
@@ -27,7 +27,7 @@ Note on performance: displaying file status in the git prompt for a very large r
     <summary>Provides prompt with Git status summary information and tab completion for Git commands, parameters, remotes and branch names.</summary>
     <tags>poshgit posh-git powershell git</tags>
     <projectUrl>https://github.com/dahlbyk/posh-git</projectUrl>
-    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta1/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/develop/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
       <dependency id="chocolatey" version="0.9.10" />

--- a/chocolatey/poshgit.nuspec
+++ b/chocolatey/poshgit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>poshgit</id>
     <title>posh-git</title>
-    <version>1.0.0-pre00</version>
+    <version>1.0.0-beta1</version>
     <authors>Keith Dahlby, Mark Embling, Jeremy Skinner, Keith Hill</authors>
     <owners>Keith Dahlby</owners>
     <description>### posh-git
@@ -27,7 +27,7 @@ Note on performance: displaying file status in the git prompt for a very large r
     <summary>Provides prompt with Git status summary information and tab completion for Git commands, parameters, remotes and branch names.</summary>
     <tags>poshgit posh-git powershell git</tags>
     <projectUrl>https://github.com/dahlbyk/posh-git</projectUrl>
-    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/develop/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta1/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
       <dependency id="chocolatey" version="0.9.10" />

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -65,16 +65,16 @@ PrivateData = @{
         Tags = @('git', 'prompt', 'tab', 'tab-completion', 'tab-expansion', 'tabexpansion')
 
         # A URL to the license for this module.
-        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta1/LICENSE.txt'
+        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/develop/LICENSE.txt'
 
         # A URL to the main website for this project.
         ProjectUri = 'https://github.com/dahlbyk/posh-git'
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta1/CHANGELOG.md'
+        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/develop/CHANGELOG.md'
 
         # OVERRIDE THIS FIELD FOR PUBLISHED RELEASES - LEAVE AT 'alpha' FOR CLONED/LOCAL REPO USAGE
-        Prerelease = 'beta1'
+        Prerelease = 'beta1x'
     }
 }
 

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -65,16 +65,16 @@ PrivateData = @{
         Tags = @('git', 'prompt', 'tab', 'tab-completion', 'tab-expansion', 'tabexpansion')
 
         # A URL to the license for this module.
-        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/develop/LICENSE.txt'
+        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta1/LICENSE.txt'
 
         # A URL to the main website for this project.
         ProjectUri = 'https://github.com/dahlbyk/posh-git'
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/develop/CHANGELOG.md'
+        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta1/CHANGELOG.md'
 
         # OVERRIDE THIS FIELD FOR PUBLISHED RELEASES - LEAVE AT 'alpha' FOR CLONED/LOCAL REPO USAGE
-        Prerelease = 'alpha'
+        Prerelease = 'beta1'
     }
 }
 


### PR DESCRIPTION
I'm presuming beta1 but I think that is the appropriate moniker.  I think we're further along than an alpha.

I guess the README.md update will come later.  Question is, should I update the `master` readme since that is the default readme folks will see?  Or should we rely on folks to switch to the develop branch.  For sure, the README on develop should be updated. 