### PR TITLE
Release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # posh-git Release History
 
-## 0.7.2 - April 19, 2018
+## 0.7.3 - April 19, 2018
 
 - posh-git now exports the variable `$GitPromptScriptBlock` which contains the code for the default prompt.
   ([#501](https://github.com/dahlbyk/posh-git/issues/501))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # posh-git Release History
 
+## 0.7.2 - January 10, 2018
+
+- posh-git now exports the variable `$GitPromptScriptBlock` which contains the code for the default prompt.
+  ([#501](https://github.com/dahlbyk/posh-git/issues/501))
+  ([PR #513](https://github.com/dahlbyk/posh-git/pull/513))
+
+  If you need to execute your own logic in your own prompt function but still want to display the default posh-git
+  prompt, you can execute this scriptblock from your prompt function e.g.:
+
+  ```powershell
+  # profile.ps1
+  function prompt {
+    Set-NodeVersion
+    &$GitPromptScriptBlock
+  }
+  Import-Module posh-git
+  ```
+
+- Added `Add-PoshGitToProfile -AllUsers` support
+  ([PR #504](https://github.com/dahlbyk/posh-git/pull/504))
+- Fixed 'Write-Prompt' to be able use Black as foreground color.
+  ([#470](https://github.com/dahlbyk/posh-git/pull/470))
+  ([PR #468](https://github.com/dahlbyk/posh-git/pull/468))
+  Thanks Vladimir Poleh (@vladimir-poleh)
+- Pass "git.exe" instead of "git" to Get-Command.
+  ([PR #478](https://github.com/dahlbyk/posh-git/pull/478))
+  ([PR #479](https://github.com/dahlbyk/posh-git/pull/479))
+  Thanks Mike Sigsworth (@mikesigs)
+- Squash ssh agent warnings if `-Quiet`.
+  ([PR #484](https://github.com/dahlbyk/posh-git/pull/484))
+  Thanks Refael Ackermann (@refack)
+- Fixed directory names that contain [brackets] cause GitPrompt to fail.
+  ([PR #502](https://github.com/dahlbyk/posh-git/pull/502))
+  Thanks Duncan Smart (@duncansmart)
+- Fixed duplicated branch completion for git checkout
+  ([#505](https://github.com/dahlbyk/posh-git/issues/505))
+  ([PR #506](https://github.com/dahlbyk/posh-git/pull/506))
+  ([PR #512](https://github.com/dahlbyk/posh-git/pull/512))
+  Thanks Christoph Bergmeister (@bergmeister)
+- Fixed PSScriptAnalyzer warnings in the source
+  ([PR #509](https://github.com/dahlbyk/posh-git/pull/509))
+  Thanks Christoph Bergmeister (@bergmeister)
+- Fixed errors added to $Error collection by `Get-GitStatus` command
+  ([#500](https://github.com/dahlbyk/posh-git/issues/500))
+  ([PR #514](https://github.com/dahlbyk/posh-git/pull/514))
+- Add custom path rendering in prompt
+  ([#469](https://github.com/dahlbyk/posh-git/issues/469))
+  ([PR #520](https://github.com/dahlbyk/posh-git/pull/520))
+- Clean up wording for work dir local status in help file
+  ([PR #516](https://github.com/dahlbyk/posh-git/pull/516))
+- Add code coverage to Coveralls.io
+  ([#416](https://github.com/dahlbyk/posh-git/pull/416))
+  ([PR #461](https://github.com/dahlbyk/posh-git/pull/461))
+  Thanks Jan De Dobbeleer (@JanJoris)
+
 ## 0.7.1 - March 14, 2017
 
 - Fixed tab completion issues with duplicate aliases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # posh-git Release History
 
-## 0.7.2 - January 10, 2018
+## 0.7.2 - April 19, 2018
 
 - posh-git now exports the variable `$GitPromptScriptBlock` which contains the code for the default prompt.
   ([#501](https://github.com/dahlbyk/posh-git/issues/501))
@@ -18,8 +18,6 @@
   Import-Module posh-git
   ```
 
-- Added `Add-PoshGitToProfile -AllUsers` support
-  ([PR #504](https://github.com/dahlbyk/posh-git/pull/504))
 - Fixed 'Write-Prompt' to be able use Black as foreground color.
   ([#470](https://github.com/dahlbyk/posh-git/pull/470))
   ([PR #468](https://github.com/dahlbyk/posh-git/pull/468))
@@ -34,6 +32,8 @@
 - Fixed directory names that contain [brackets] cause GitPrompt to fail.
   ([PR #502](https://github.com/dahlbyk/posh-git/pull/502))
   Thanks Duncan Smart (@duncansmart)
+- Added `Add-PoshGitToProfile -AllUsers` support
+  ([PR #504](https://github.com/dahlbyk/posh-git/pull/504))
 - Fixed duplicated branch completion for git checkout
   ([#505](https://github.com/dahlbyk/posh-git/issues/505))
   ([PR #506](https://github.com/dahlbyk/posh-git/pull/506))
@@ -45,11 +45,25 @@
 - Fixed errors added to $Error collection by `Get-GitStatus` command
   ([#500](https://github.com/dahlbyk/posh-git/issues/500))
   ([PR #514](https://github.com/dahlbyk/posh-git/pull/514))
-- Add custom path rendering in prompt
+- Added custom path rendering in prompt
   ([#469](https://github.com/dahlbyk/posh-git/issues/469))
   ([PR #520](https://github.com/dahlbyk/posh-git/pull/520))
 - Clean up wording for work dir local status in help file
   ([PR #516](https://github.com/dahlbyk/posh-git/pull/516))
+- Added `$GitPromptSettings.AdminTitlePrefixText` (default: `'Administrator: '`)
+  ([#537](https://github.com/dahlbyk/posh-git/pull/537))
+  ([PR #538](https://github.com/dahlbyk/posh-git/pull/538))
+  Thanks Eric Jorgensen (@nebosite)
+- Added `$GitPromptSettings.UntrackedFilesMode`;
+  accepted values are `$null` (inherit `status.showUntrackedFiles`), "all", "no", and "normal"
+  ([#556](https://github.com/dahlbyk/posh-git/pull/556))
+  ([PR #557](https://github.com/dahlbyk/posh-git/pull/557))
+  Thanks David Snedecor (@TheSned)
+- `PoshGitVcsPrompt` errors now show details if `$GitPromptSettings.Debug`
+  ([PR #560](https://github.com/dahlbyk/posh-git/pull/560))
+- Exported `Expand-GitCommand` for use with custom tab expansion
+  ([#562](https://github.com/dahlbyk/posh-git/pull/562))
+  ([PR #563](https://github.com/dahlbyk/posh-git/pull/563))
 - Add code coverage to Coveralls.io
   ([#416](https://github.com/dahlbyk/posh-git/pull/416))
   ([PR #461](https://github.com/dahlbyk/posh-git/pull/461))

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -14,7 +14,7 @@ If not, PLEASE fill in the following details so that we can help you!
 To retrieve the system details, paste the following line into PowerShell, press Enter
 and then copy/paste the resulting output above.
 
-"- posh-git version/path: $($m = Get-Module posh-git; '{0} {1} {2}' -f $m.Version,$m.PrivateData.PSData.PreReleaseVersion,$m.ModuleBase.Replace($HOME,'~'))`n- PowerShell version: $($PSVersionTable.PSVersion)`n- $(
+"- posh-git version/path: $($m = Get-Module posh-git; '{0} {1} {2}' -f $m.Version,$m.PrivateData.PSData.Prerelease,$m.ModuleBase.Replace($HOME,'~'))`n- PowerShell version: $($PSVersionTable.PSVersion)`n- $(
 git --version)`n- OS: $([System.Environment]::OSVersion)"
 -->
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2016 Keith Dahlby and contributors
+Copyright (c) 2010-2018 Keith Dahlby and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ You can also tab complete remote names and branch names e.g.: `git pull or<tab> 
 - `master` avoids breaking changes, maintaining v0.x.
   ( [README](https://github.com/dahlbyk/posh-git/blob/master/README.md)
   • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/master/CHANGELOG.md) )
+  - Supports PowerShell 3+
 - `develop` includes breaking changes, toward [v1.0](https://github.com/dahlbyk/posh-git/issues/328).
   ( [README](https://github.com/dahlbyk/posh-git/blob/develop/README.md)
   • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/develop/CHANGELOG.md) )
+  - Supports PowerShell 5 and PowerShell Core 6
+  - Supports [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code) for color customization
 - Previous releases:
   - v0.7.1
     ( [README](https://github.com/dahlbyk/posh-git/blob/v0.7.1/README.md)

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ You can also tab complete remote names and branch names e.g.: `git pull or<tab> 
 
 #### Releases
 
-- v0.7.2
-  ( [README](https://github.com/dahlbyk/posh-git/blob/v0.7.2/README.md)
-  • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v0.7.2/CHANGELOG.md) )
+- v0.7.3
+  ( [README](https://github.com/dahlbyk/posh-git/blob/v0.7.3/README.md)
+  • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v0.7.3/CHANGELOG.md) )
 - v0.7.1
   ( [README](https://github.com/dahlbyk/posh-git/blob/v0.7.1/README.md)
   • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v0.7.1/CHANGELOG.md) )

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![v0 build status](https://ci.appveyor.com/api/projects/status/eb8erd5afaa01w80/branch/v0?svg=true&pendingText=v0%20%E2%80%A3%20pending&failingText=v0%20%E2%80%A3%20failing&passingText=v0%20%E2%80%A3%20passing)](https://ci.appveyor.com/project/dahlbyk/posh-git/branch/v0)
 [![v0 build coverage](https://coveralls.io/repos/github/dahlbyk/posh-git/badge.svg?branch=v0)](https://coveralls.io/github/dahlbyk/posh-git?branch=v0)
 
-[![develop build status](https://ci.appveyor.com/api/projects/status/eb8erd5afaa01w80/branch/develop?svg=true&pendingText=develop%20%E2%80%A3%20pending&failingText=develop%20%E2%80%A3%20failing&passingText=develop%20%E2%80%A3%20passing)](https://ci.appveyor.com/project/dahlbyk/posh-git/branch/develop)
-[![develop build coverage](https://coveralls.io/repos/github/dahlbyk/posh-git/badge.svg?branch=develop)](https://coveralls.io/github/dahlbyk/posh-git?branch=develop)
+[![master build status](https://ci.appveyor.com/api/projects/status/eb8erd5afaa01w80/branch/master?svg=true&pendingText=master%20%E2%80%A3%20pending&failingText=master%20%E2%80%A3%20failing&passingText=master%20%E2%80%A3%20passing)](https://ci.appveyor.com/project/dahlbyk/posh-git/branch/master)
+[![master build coverage](https://coveralls.io/repos/github/dahlbyk/posh-git/badge.svg?branch=master)](https://coveralls.io/github/dahlbyk/posh-git?branch=master)
 
 [![Join the chat at https://gitter.im/dahlbyk/posh-git](https://badges.gitter.im/dahlbyk/posh-git.svg)](https://gitter.im/dahlbyk/posh-git?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![posh-git on Chocolatey](https://img.shields.io/chocolatey/dt/poshgit.svg)](https://chocolatey.org/packages/poshgit/)
@@ -23,9 +23,9 @@ You can also tab complete remote names and branch names e.g.: `git pull or<tab> 
   ( [README](https://github.com/dahlbyk/posh-git/blob/v0/README.md)
   • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v0/CHANGELOG.md) )
   - Supports Windows PowerShell 3+
-- `develop` includes breaking changes, toward [v1.0](https://github.com/dahlbyk/posh-git/issues/328).
-  ( [README](https://github.com/dahlbyk/posh-git/blob/develop/README.md)
-  • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/develop/CHANGELOG.md) )
+- `master` includes breaking changes, toward [v1.0](https://github.com/dahlbyk/posh-git/issues/328) and beyond.
+  ( [README](https://github.com/dahlbyk/posh-git/blob/master/README.md)
+  • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/master/CHANGELOG.md) )
   - Supports Windows PowerShell 5.x and PowerShell Core 6
   - Supports [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code) for color customization
 - Releases:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,8 @@
 # posh-git
 
-[![v0 build status](https://ci.appveyor.com/api/projects/status/eb8erd5afaa01w80/branch/v0?svg=true&pendingText=v0%20%E2%80%A3%20pending&failingText=v0%20%E2%80%A3%20failing&passingText=v0%20%E2%80%A3%20passing)](https://ci.appveyor.com/project/dahlbyk/posh-git/branch/v0)
-[![v0 build coverage](https://coveralls.io/repos/github/dahlbyk/posh-git/badge.svg?branch=v0)](https://coveralls.io/github/dahlbyk/posh-git?branch=v0)
-
-[![master build status](https://ci.appveyor.com/api/projects/status/eb8erd5afaa01w80/branch/master?svg=true&pendingText=master%20%E2%80%A3%20pending&failingText=master%20%E2%80%A3%20failing&passingText=master%20%E2%80%A3%20passing)](https://ci.appveyor.com/project/dahlbyk/posh-git/branch/master)
-[![master build coverage](https://coveralls.io/repos/github/dahlbyk/posh-git/badge.svg?branch=master)](https://coveralls.io/github/dahlbyk/posh-git?branch=master)
-
 [![Join the chat at https://gitter.im/dahlbyk/posh-git](https://badges.gitter.im/dahlbyk/posh-git.svg)](https://gitter.im/dahlbyk/posh-git?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![posh-git on Chocolatey](https://img.shields.io/chocolatey/dt/poshgit.svg)](https://chocolatey.org/packages/poshgit/)
+[![posh-git on PowerShell Gallery](https://img.shields.io/powershellgallery/dt/posh-git.svg)](https://www.powershellgallery.org/packages/posh-git/)
 
 posh-git is a PowerShell module that integrates Git and PowerShell by providing Git status summary information that can be displayed in the PowerShell prompt, e.g.:
 ```powershell
@@ -19,25 +14,53 @@ That will tab complete to `git checkout` and if you keep pressing <kbd>tab</kbd>
 You can also tab complete remote names and branch names e.g.: `git pull or<tab> ma<tab>` tab completes to `git pull origin master`.
 
 ## Versions
-- `v0` avoids breaking changes, maintaining v0.x.
-  ( [README](https://github.com/dahlbyk/posh-git/blob/v0/README.md)
-  • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v0/CHANGELOG.md) )
-  - Supports Windows PowerShell 3+
-- `master` includes breaking changes, toward [v1.0](https://github.com/dahlbyk/posh-git/issues/328) and beyond.
-  ( [README](https://github.com/dahlbyk/posh-git/blob/master/README.md)
-  • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/master/CHANGELOG.md) )
-  - Supports Windows PowerShell 5.x and PowerShell Core 6
-  - Supports [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code) for color customization
-- Releases:
-  - v0.7.2
-    ( [README](https://github.com/dahlbyk/posh-git/blob/v0.7.2/README.md)
-    • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v0.7.2/CHANGELOG.md) )
-  - v0.7.1
-    ( [README](https://github.com/dahlbyk/posh-git/blob/v0.7.1/README.md)
-    • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v0.7.1/CHANGELOG.md) )
-  - v0.7.0
-    ( [README](https://github.com/dahlbyk/posh-git/blob/v0.7.0/README.md)
-    • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v0.7.0/CHANGELOG.md) )
+
+### posh-git v0.x
+
+[![v0 build status](https://ci.appveyor.com/api/projects/status/eb8erd5afaa01w80/branch/v0?svg=true&pendingText=v0%20%E2%80%A3%20pending&failingText=v0%20%E2%80%A3%20failing&passingText=v0%20%E2%80%A3%20passing)](https://ci.appveyor.com/project/dahlbyk/posh-git/branch/v0)
+[![v0 build coverage](https://coveralls.io/repos/github/dahlbyk/posh-git/badge.svg?branch=v0)](https://coveralls.io/github/dahlbyk/posh-git?branch=v0)
+( [README](https://github.com/dahlbyk/posh-git/blob/v0/README.md)
+• [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v0/CHANGELOG.md) )
+
+- Supports Windows PowerShell 3+
+- Does not support PowerShell Core
+- Avoids breaking changes, maintaining v0.x
+
+#### Releases
+
+- v0.7.2
+  ( [README](https://github.com/dahlbyk/posh-git/blob/v0.7.2/README.md)
+  • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v0.7.2/CHANGELOG.md) )
+- v0.7.1
+  ( [README](https://github.com/dahlbyk/posh-git/blob/v0.7.1/README.md)
+  • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v0.7.1/CHANGELOG.md) )
+- v0.7.0
+  ( [README](https://github.com/dahlbyk/posh-git/blob/v0.7.0/README.md)
+  • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v0.7.0/CHANGELOG.md) )
+
+### posh-git v1.0
+
+[![master build status](https://ci.appveyor.com/api/projects/status/eb8erd5afaa01w80/branch/master?svg=true&pendingText=master%20%E2%80%A3%20pending&failingText=master%20%E2%80%A3%20failing&passingText=master%20%E2%80%A3%20passing)](https://ci.appveyor.com/project/dahlbyk/posh-git/branch/master)
+[![master build coverage](https://coveralls.io/repos/github/dahlbyk/posh-git/badge.svg?branch=master)](https://coveralls.io/github/dahlbyk/posh-git?branch=master)
+( [README](https://github.com/dahlbyk/posh-git/blob/master/README.md)
+• [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/master/CHANGELOG.md) )
+
+- Supports Windows PowerShell 5.x
+- Supports PowerShell Core 6+ on all platforms
+- Supports [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code) for color customization
+- Includes breaking changes from v0.x ([roadmap](https://github.com/dahlbyk/posh-git/issues/328))
+
+#### Releases
+
+- v1.0.0
+  ( [README](https://github.com/dahlbyk/posh-git/blob/v1.0.0/README.md)
+  • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v1.0.0/CHANGELOG.md) )
+- v1.0.0-beta2
+  ( [README](https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta2/README.md)
+  • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta2/CHANGELOG.md) )
+- v1.0.0-beta1
+  ( [README](https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta1/README.md)
+  • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta1/CHANGELOG.md) )
 
 ## Notes
 posh-git adds variables to your session to let you customize it, including `$GitPromptSettings`, `$GitTabSettings`, and `$TortoiseGitSettings`.

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ You can also tab complete remote names and branch names e.g.: `git pull or<tab> 
 - `master` avoids breaking changes, maintaining v0.x.
   ( [README](https://github.com/dahlbyk/posh-git/blob/master/README.md)
   • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/master/CHANGELOG.md) )
-  - Supports PowerShell 3+
+  - Supports Windows PowerShell 3+
 - `develop` includes breaking changes, toward [v1.0](https://github.com/dahlbyk/posh-git/issues/328).
   ( [README](https://github.com/dahlbyk/posh-git/blob/develop/README.md)
   • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/develop/CHANGELOG.md) )
-  - Supports PowerShell 5 and PowerShell Core 6
+  - Supports Windows PowerShell 5.x and PowerShell Core 6
   - Supports [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code) for color customization
 - Previous releases:
   - v0.7.1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # posh-git
 
-[![master build status](https://ci.appveyor.com/api/projects/status/eb8erd5afaa01w80/branch/master?svg=true&pendingText=master%20%E2%80%A3%20pending&failingText=master%20%E2%80%A3%20failing&passingText=master%20%E2%80%A3%20passing)](https://ci.appveyor.com/project/dahlbyk/posh-git/branch/master)
-[![master build coverage](https://coveralls.io/repos/github/dahlbyk/posh-git/badge.svg?branch=master)](https://coveralls.io/github/dahlbyk/posh-git?branch=master)
+[![v0 build status](https://ci.appveyor.com/api/projects/status/eb8erd5afaa01w80/branch/v0?svg=true&pendingText=v0%20%E2%80%A3%20pending&failingText=v0%20%E2%80%A3%20failing&passingText=v0%20%E2%80%A3%20passing)](https://ci.appveyor.com/project/dahlbyk/posh-git/branch/v0)
+[![v0 build coverage](https://coveralls.io/repos/github/dahlbyk/posh-git/badge.svg?branch=v0)](https://coveralls.io/github/dahlbyk/posh-git?branch=v0)
 
 [![develop build status](https://ci.appveyor.com/api/projects/status/eb8erd5afaa01w80/branch/develop?svg=true&pendingText=develop%20%E2%80%A3%20pending&failingText=develop%20%E2%80%A3%20failing&passingText=develop%20%E2%80%A3%20passing)](https://ci.appveyor.com/project/dahlbyk/posh-git/branch/develop)
 [![develop build coverage](https://coveralls.io/repos/github/dahlbyk/posh-git/badge.svg?branch=develop)](https://coveralls.io/github/dahlbyk/posh-git?branch=develop)
@@ -19,16 +19,19 @@ That will tab complete to `git checkout` and if you keep pressing <kbd>tab</kbd>
 You can also tab complete remote names and branch names e.g.: `git pull or<tab> ma<tab>` tab completes to `git pull origin master`.
 
 ## Versions
-- `master` avoids breaking changes, maintaining v0.x.
-  ( [README](https://github.com/dahlbyk/posh-git/blob/master/README.md)
-  • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/master/CHANGELOG.md) )
+- `v0` avoids breaking changes, maintaining v0.x.
+  ( [README](https://github.com/dahlbyk/posh-git/blob/v0/README.md)
+  • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v0/CHANGELOG.md) )
   - Supports Windows PowerShell 3+
 - `develop` includes breaking changes, toward [v1.0](https://github.com/dahlbyk/posh-git/issues/328).
   ( [README](https://github.com/dahlbyk/posh-git/blob/develop/README.md)
   • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/develop/CHANGELOG.md) )
   - Supports Windows PowerShell 5.x and PowerShell Core 6
   - Supports [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code) for color customization
-- Previous releases:
+- Releases:
+  - v0.7.2
+    ( [README](https://github.com/dahlbyk/posh-git/blob/v0.7.2/README.md)
+    • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v0.7.2/CHANGELOG.md) )
   - v0.7.1
     ( [README](https://github.com/dahlbyk/posh-git/blob/v0.7.1/README.md)
     • [CHANGELOG](https://github.com/dahlbyk/posh-git/blob/v0.7.1/CHANGELOG.md) )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
 branches:
   only:
-    - master
+    - v0
 
 init:
   - git config --global core.autocrlf true

--- a/chocolatey/packAndLocalInstall.ps1
+++ b/chocolatey/packAndLocalInstall.ps1
@@ -1,5 +1,5 @@
 param ($Remote = 'origin', [switch]$Force)
-pushd $PSScriptRoot
+Push-Location $PSScriptRoot
 
 $nuspec = [xml](Get-Content poshgit.nuspec)
 $version = $nuspec.package.metadata.version
@@ -17,4 +17,4 @@ elseif (!$(git ls-remote $Remote $tag)) {
 choco pack poshgit.nuspec
 choco install -f -y poshgit -pre --version=$version -s .
 
-popd
+Pop-Location

--- a/chocolatey/poshgit.nuspec
+++ b/chocolatey/poshgit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>poshgit</id>
     <title>posh-git</title>
-    <version>0.7.3</version>
+    <version>0.7.4-pre0</version>
     <authors>Keith Dahlby, Mark Embling, Jeremy Skinner, Keith Hill</authors>
     <owners>Keith Dahlby</owners>
     <description>### posh-git
@@ -27,7 +27,7 @@ Note on performance: displaying file status in the git prompt for a very large r
     <summary>Provides prompt with Git status summary information and tab completion for Git commands, parameters, remotes and branch names.</summary>
     <tags>poshgit posh-git powershell git</tags>
     <projectUrl>https://github.com/dahlbyk/posh-git</projectUrl>
-    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/v0.7.3/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/v0/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
       <dependency id="chocolatey" version="0.9.10" />

--- a/chocolatey/poshgit.nuspec
+++ b/chocolatey/poshgit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>poshgit</id>
     <title>posh-git</title>
-    <version>0.7.2-pre0</version>
+    <version>0.7.2-pre1</version>
     <authors>Keith Dahlby, Mark Embling, Jeremy Skinner, Keith Hill</authors>
     <owners>Keith Dahlby</owners>
     <description>### posh-git
@@ -27,7 +27,7 @@ Note on performance: displaying file status in the git prompt for a very large r
     <summary>Provides prompt with Git status summary information and tab completion for Git commands, parameters, remotes and branch names.</summary>
     <tags>poshgit posh-git powershell git</tags>
     <projectUrl>https://github.com/dahlbyk/posh-git</projectUrl>
-    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/master/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/v0.7.2-pre1/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
       <dependency id="chocolatey" version="0.9.10" />

--- a/chocolatey/poshgit.nuspec
+++ b/chocolatey/poshgit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>poshgit</id>
     <title>posh-git</title>
-    <version>0.7.2</version>
+    <version>0.7.3-pre0</version>
     <authors>Keith Dahlby, Mark Embling, Jeremy Skinner, Keith Hill</authors>
     <owners>Keith Dahlby</owners>
     <description>### posh-git
@@ -27,7 +27,7 @@ Note on performance: displaying file status in the git prompt for a very large r
     <summary>Provides prompt with Git status summary information and tab completion for Git commands, parameters, remotes and branch names.</summary>
     <tags>poshgit posh-git powershell git</tags>
     <projectUrl>https://github.com/dahlbyk/posh-git</projectUrl>
-    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/v0.7.2/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/v0/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
       <dependency id="chocolatey" version="0.9.10" />

--- a/chocolatey/poshgit.nuspec
+++ b/chocolatey/poshgit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>poshgit</id>
     <title>posh-git</title>
-    <version>0.7.2-pre1</version>
+    <version>0.7.2</version>
     <authors>Keith Dahlby, Mark Embling, Jeremy Skinner, Keith Hill</authors>
     <owners>Keith Dahlby</owners>
     <description>### posh-git
@@ -27,7 +27,7 @@ Note on performance: displaying file status in the git prompt for a very large r
     <summary>Provides prompt with Git status summary information and tab completion for Git commands, parameters, remotes and branch names.</summary>
     <tags>poshgit posh-git powershell git</tags>
     <projectUrl>https://github.com/dahlbyk/posh-git</projectUrl>
-    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/v0.7.2-pre1/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/v0.7.2/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
       <dependency id="chocolatey" version="0.9.10" />

--- a/chocolatey/poshgit.nuspec
+++ b/chocolatey/poshgit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>poshgit</id>
     <title>posh-git</title>
-    <version>0.7.3-pre0</version>
+    <version>0.7.3</version>
     <authors>Keith Dahlby, Mark Embling, Jeremy Skinner, Keith Hill</authors>
     <owners>Keith Dahlby</owners>
     <description>### posh-git
@@ -27,7 +27,7 @@ Note on performance: displaying file status in the git prompt for a very large r
     <summary>Provides prompt with Git status summary information and tab completion for Git commands, parameters, remotes and branch names.</summary>
     <tags>poshgit posh-git powershell git</tags>
     <projectUrl>https://github.com/dahlbyk/posh-git</projectUrl>
-    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/v0/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/v0.7.3/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
       <dependency id="chocolatey" version="0.9.10" />

--- a/chocolatey/tests/InstallChocolatey.Tests.ps1
+++ b/chocolatey/tests/InstallChocolatey.Tests.ps1
@@ -39,7 +39,7 @@ Describe "Install-Posh-Git" {
             RunInstall
 
             $newProfile = (Get-Content $Profile)
-            $pgitDir = [Array](Dir "$poshgitPath\*posh-git*\" | Sort-Object -Property LastWriteTime)[-1]
+            $pgitDir = [Array](Get-ChildItem "$poshgitPath\*posh-git*\" | Sort-Object -Property LastWriteTime)[-1]
             ($newProfile -like ". '$poshgitPath\posh-git\profile.example.ps1'").Count.should.be(0)
             ($newProfile -like ". '$pgitDir\profile.example.ps1'").Count.should.be(1)
         }
@@ -59,7 +59,7 @@ Describe "Install-Posh-Git" {
             RunInstall
 
             $newProfile = (Get-Content $Profile)
-            $pgitDir = [Array](Dir "$poshgitPath\*posh-git*\" | Sort-Object -Property LastWriteTime)[-1]
+            $pgitDir = [Array](Get-ChildItem "$poshgitPath\*posh-git*\" | Sort-Object -Property LastWriteTime)[-1]
             ($newProfile -like ". '$pgitDir\profile.example.ps1'").Count.should.be(1)
         }
         catch {
@@ -94,7 +94,7 @@ Describe "Install-Posh-Git" {
         try{
             RunInstall
             mkdir PoshTest
-            Pushd PoshTest
+            Push-Location PoshTest
             git init
             . $Profile
             $global:wh=""
@@ -102,7 +102,7 @@ Describe "Install-Posh-Git" {
 
             Prompt
 
-            Popd
+            Pop-Location
             $wh.should.be("$pwd\PoshTest [master]")
         }
         catch {
@@ -122,7 +122,7 @@ Describe "Install-Posh-Git" {
             Remove-Item $Profile -Force
             RunInstall
             mkdir PoshTest
-            Pushd PoshTest
+            Push-Location PoshTest
             git init
             . $Profile
             $global:wh=""
@@ -130,7 +130,7 @@ Describe "Install-Posh-Git" {
 
             Prompt
 
-            Popd
+            Pop-Location
             $wh.should.be("$pwd\PoshTest [master]")
         }
         catch {
@@ -152,7 +152,7 @@ Describe "Install-Posh-Git" {
             Add-Content $profile -value "function prompt {Write-Host 'Hi'}" -Force
             RunInstall
             mkdir PoshTest
-            Pushd PoshTest
+            Push-Location PoshTest
             git init
             . $Profile
             $global:wh=""
@@ -161,7 +161,7 @@ Describe "Install-Posh-Git" {
             Prompt
 
             Remove-Item function:\global:Write-Host
-            Popd
+            Pop-Location
             $wh.should.be("$pwd\PoshTest [master]")
         }
         catch {
@@ -183,7 +183,7 @@ Describe "Install-Posh-Git" {
             Add-Content $profile -value ". 'C:\tools\poshgit\dahlbyk-posh-git-60be436\profile.example.ps1'" -Force
             RunInstall
             mkdir PoshTest
-            Pushd PoshTest
+            Push-Location PoshTest
             git init
             write-output (Get-Content function:\prompt)
             . $Profile
@@ -193,7 +193,7 @@ Describe "Install-Posh-Git" {
             Prompt
 
             Remove-Item function:\global:Write-Host
-            Popd
+            Pop-Location
             $wh.should.be("$pwd\PoshTest [master]")
         }
         catch {

--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -104,6 +104,8 @@ $global:GitPromptSettings = [pscustomobject]@{
     DefaultPromptSuffix                         = '$(''>'' * ($nestedPromptLevel + 1)) '
     DefaultPromptDebugSuffix                    = ' [DBG]$(''>'' * ($nestedPromptLevel + 1)) '
     DefaultPromptEnableTiming                   = $false
+
+    DefaultPromptPath                           = '$(Get-PromptPath)'
     DefaultPromptAbbreviateHomeDirectory        = $false
 
     Debug                                       = $false

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -434,7 +434,7 @@ function Find-Pageant() {
 # Attempt to guess $program's location. For ssh-agent/ssh-add.
 function Find-Ssh($program = 'ssh-agent') {
     Write-Verbose "$program not in path. Trying to guess location."
-    $gitItem = Get-Command git -Erroraction SilentlyContinue | Get-Item
+    $gitItem = Get-Command git -CommandType Application -Erroraction SilentlyContinue | Get-Item
     if ($null -eq $gitItem) {
         Write-Warning 'git not in path'
         return

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -275,6 +275,27 @@ function Get-PathStringComparison {
     }
 }
 
+function Get-PromptPath {
+    $settings = $global:GitPromptSettings
+    $abbrevHomeDir = $settings -and $settings.DefaultPromptAbbreviateHomeDirectory
+
+    # A UNC path has no drive so it's better to use the ProviderPath e.g. "\\server\share".
+    # However for any path with a drive defined, it's better to use the Path property.
+    # In this case, ProviderPath is "\LocalMachine\My"" whereas Path is "Cert:\LocalMachine\My".
+    # The latter is more desirable.
+    $pathInfo = $ExecutionContext.SessionState.Path.CurrentLocation
+    $currentPath = if ($pathInfo.Drive) { $pathInfo.Path } else { $pathInfo.ProviderPath }
+
+    $stringComparison = Get-PathStringComparison
+
+    # Abbreviate path by replacing beginning of path with ~ *iff* the path is in the user's home dir
+    if ($abbrevHomeDir -and $currentPath -and $currentPath.StartsWith($Home, $stringComparison)) {
+        $currentPath = "~" + $currentPath.SubString($Home.Length)
+    }
+
+    return $currentPath
+}
+
 function Get-PSModulePath {
     $modulePaths = $Env:PSModulePath -split ';'
     $modulePaths

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -13,7 +13,7 @@ GUID = '74c9fd30-734b-4c89-a8ae-7727ad21d1d5'
 Author = 'Keith Dahlby and contributors'
 
 # Copyright statement for this module
-Copyright = '(c) 2010-2017 Keith Dahlby and contributors'
+Copyright = '(c) 2010-2018 Keith Dahlby and contributors'
 
 # Description of the functionality provided by this module
 Description = 'Provides prompt with Git status summary information and tab completion for Git commands, parameters, remotes and branch names.'

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -63,16 +63,13 @@ PrivateData = @{
         Tags = @('git', 'prompt', 'tab', 'tab-completion', 'tab-expansion', 'tabexpansion')
 
         # A URL to the license for this module.
-        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/v0.7.2-pre1/LICENSE.txt'
+        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/v0.7.2/LICENSE.txt'
 
         # A URL to the main website for this project.
         ProjectUri = 'https://github.com/dahlbyk/posh-git'
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/v0.7.2-pre1/CHANGELOG.md'
-
-        # TODO: REMOVE BEFOE RELEASE
-        Prerelease = 'pre1'
+        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/v0.7.2/CHANGELOG.md'
     }
 
 }

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -4,7 +4,7 @@
 ModuleToProcess = 'posh-git.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.7.3.0'
+ModuleVersion = '0.7.3'
 
 # ID used to uniquely identify this module
 GUID = '74c9fd30-734b-4c89-a8ae-7727ad21d1d5'
@@ -63,16 +63,13 @@ PrivateData = @{
         Tags = @('git', 'prompt', 'tab', 'tab-completion', 'tab-expansion', 'tabexpansion')
 
         # A URL to the license for this module.
-        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/v0/LICENSE.txt'
+        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/v0.7.3/LICENSE.txt'
 
         # A URL to the main website for this project.
         ProjectUri = 'https://github.com/dahlbyk/posh-git'
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/v0/CHANGELOG.md'
-
-        # TODO: REMOVE BEFORE RELEASE
-        Prerelease = 'pre0'
+        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/v0.7.3/CHANGELOG.md'
     }
 
 }

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -25,6 +25,7 @@ PowerShellVersion = '2.0'
 FunctionsToExport = @(
     'Invoke-NullCoalescing',
     'Add-PoshGitToProfile',
+    'Get-PromptPath',
     'Write-GitStatus',
     'Write-Prompt',
     'Write-VcsStatus',

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -47,7 +47,7 @@ FunctionsToExport = @(
 CmdletsToExport = @()
 
 # Variables to export from this module
-VariablesToExport = @()
+VariablesToExport = @('GitPromptScriptBlock')
 
 # Aliases to export from this module
 AliasesToExport = @('??')

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -4,7 +4,7 @@
 ModuleToProcess = 'posh-git.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.7.2.0'
+ModuleVersion = '0.7.2'
 
 # ID used to uniquely identify this module
 GUID = '74c9fd30-734b-4c89-a8ae-7727ad21d1d5'
@@ -62,16 +62,16 @@ PrivateData = @{
         Tags = @('git', 'prompt', 'tab', 'tab-completion', 'tab-expansion', 'tabexpansion')
 
         # A URL to the license for this module.
-        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/master/LICENSE.txt'
+        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/v0.7.2-pre1/LICENSE.txt'
 
         # A URL to the main website for this project.
         ProjectUri = 'https://github.com/dahlbyk/posh-git'
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/master/CHANGELOG.md'
+        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/v0.7.2-pre1/CHANGELOG.md'
 
         # TODO: REMOVE BEFOE RELEASE
-        PreReleaseVersion = 'pre0'
+        PreReleaseVersion = 'pre1'
     }
 
 }

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -71,7 +71,7 @@ PrivateData = @{
         ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/v0.7.2-pre1/CHANGELOG.md'
 
         # TODO: REMOVE BEFOE RELEASE
-        PreReleaseVersion = 'pre1'
+        Prerelease = 'pre1'
     }
 
 }

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -4,7 +4,7 @@
 ModuleToProcess = 'posh-git.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.7.2'
+ModuleVersion = '0.7.3.0'
 
 # ID used to uniquely identify this module
 GUID = '74c9fd30-734b-4c89-a8ae-7727ad21d1d5'
@@ -63,13 +63,16 @@ PrivateData = @{
         Tags = @('git', 'prompt', 'tab', 'tab-completion', 'tab-expansion', 'tabexpansion')
 
         # A URL to the license for this module.
-        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/v0.7.2/LICENSE.txt'
+        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/v0/LICENSE.txt'
 
         # A URL to the main website for this project.
         ProjectUri = 'https://github.com/dahlbyk/posh-git'
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/v0.7.2/CHANGELOG.md'
+        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/v0/CHANGELOG.md'
+
+        # TODO: REMOVE BEFORE RELEASE
+        Prerelease = 'pre0'
     }
 
 }

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -4,7 +4,7 @@
 ModuleToProcess = 'posh-git.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.7.3'
+ModuleVersion = '0.7.4.0'
 
 # ID used to uniquely identify this module
 GUID = '74c9fd30-734b-4c89-a8ae-7727ad21d1d5'
@@ -63,13 +63,16 @@ PrivateData = @{
         Tags = @('git', 'prompt', 'tab', 'tab-completion', 'tab-expansion', 'tabexpansion')
 
         # A URL to the license for this module.
-        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/v0.7.3/LICENSE.txt'
+        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/v0/LICENSE.txt'
 
         # A URL to the main website for this project.
         ProjectUri = 'https://github.com/dahlbyk/posh-git'
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/v0.7.3/CHANGELOG.md'
+        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/v0/CHANGELOG.md'
+
+        # TODO: REMOVE BEFORE RELEASE
+        Prerelease = 'pre0'
     }
 
 }

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -34,8 +34,70 @@ else {
     $defaultPromptDef = [Runspace]::DefaultRunspace.InitialSessionState.Commands['prompt'].Definition
 }
 
-# If there is no prompt function or the prompt function is the default, replace the current prompt function definition
-$poshGitPromptScriptBlock = $null
+# The built-in posh-git prompt function in ScriptBlock form.
+$GitPromptScriptBlock = {
+    if ($GitPromptSettings.DefaultPromptEnableTiming) {
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    }
+    $origLastExitCode = $global:LASTEXITCODE
+
+    # A UNC path has no drive so it's better to use the ProviderPath e.g. "\\server\share".
+    # However for any path with a drive defined, it's better to use the Path property.
+    # In this case, ProviderPath is "\LocalMachine\My"" whereas Path is "Cert:\LocalMachine\My".
+    # The latter is more desirable.
+    $pathInfo = $ExecutionContext.SessionState.Path.CurrentLocation
+    $currentPath = if ($pathInfo.Drive) { $pathInfo.Path } else { $pathInfo.ProviderPath }
+
+    # File system paths are case-sensitive on Linux and case-insensitive on Windows and macOS
+    if (($PSVersionTable.PSVersion.Major -ge 6) -and $IsLinux) {
+        $stringComparison = [System.StringComparison]::Ordinal
+    }
+    else {
+        $stringComparison = [System.StringComparison]::OrdinalIgnoreCase
+    }
+
+    # Abbreviate path by replacing beginning of path with ~ *iff* the path is in the user's home dir
+    $abbrevHomeDir = $GitPromptSettings.DefaultPromptAbbreviateHomeDirectory
+    if ($abbrevHomeDir -and $currentPath -and $currentPath.StartsWith($Home, $stringComparison))
+    {
+        $currentPath = "~" + $currentPath.SubString($Home.Length)
+    }
+
+    # Display default prompt prefix if not empty.
+    $defaultPromptPrefix = [string]$GitPromptSettings.DefaultPromptPrefix
+    if ($defaultPromptPrefix) {
+        $expandedDefaultPromptPrefix = $ExecutionContext.SessionState.InvokeCommand.ExpandString($defaultPromptPrefix)
+        Write-Prompt $expandedDefaultPromptPrefix
+    }
+
+    # Write the abbreviated current path
+    Write-Prompt $currentPath
+
+    # Write the Git status summary information
+    Write-VcsStatus
+
+    # If stopped in the debugger, the prompt needs to indicate that in some fashion
+    $hasInBreakpoint = [runspace]::DefaultRunspace.Debugger | Get-Member -Name InBreakpoint -MemberType property
+    $debugMode = (Test-Path Variable:/PSDebugContext) -or ($hasInBreakpoint -and [runspace]::DefaultRunspace.Debugger.InBreakpoint)
+    $promptSuffix = if ($debugMode) { $GitPromptSettings.DefaultPromptDebugSuffix } else { $GitPromptSettings.DefaultPromptSuffix }
+
+    # If user specifies $null or empty string, set to ' ' to avoid "PS>" unexpectedly being displayed
+    if (!$promptSuffix) {
+        $promptSuffix = ' '
+    }
+
+    $expandedPromptSuffix = $ExecutionContext.SessionState.InvokeCommand.ExpandString($promptSuffix)
+
+    # If prompt timing enabled, display elapsed milliseconds
+    if ($GitPromptSettings.DefaultPromptEnableTiming) {
+        $sw.Stop()
+        $elapsed = $sw.ElapsedMilliseconds
+        Write-Prompt " ${elapsed}ms"
+    }
+
+    $global:LASTEXITCODE = $origLastExitCode
+    $expandedPromptSuffix
+}
 
 $currentPromptDef = if ($funcInfo = Get-Command prompt -ErrorAction SilentlyContinue) { $funcInfo.Definition }
 
@@ -51,74 +113,10 @@ if (!$currentPromptDef) {
     function global:prompt { ' ' }
 }
 
+# If there is no prompt function or the prompt function is the default, replace the current prompt function definition
 if ($ForcePoshGitPrompt -or !$currentPromptDef -or ($currentPromptDef -eq $defaultPromptDef)) {
-    # Have to use [scriptblock]::Create() to get debugger detection to work in PS v2
-    $poshGitPromptScriptBlock = [scriptblock]::Create(@'
-        if ($GitPromptSettings.DefaultPromptEnableTiming) {
-            $sw = [System.Diagnostics.Stopwatch]::StartNew()
-        }
-        $origLastExitCode = $global:LASTEXITCODE
-
-        # A UNC path has no drive so it's better to use the ProviderPath e.g. "\\server\share".
-        # However for any path with a drive defined, it's better to use the Path property.
-        # In this case, ProviderPath is "\LocalMachine\My"" whereas Path is "Cert:\LocalMachine\My".
-        # The latter is more desirable.
-        $pathInfo = $ExecutionContext.SessionState.Path.CurrentLocation
-        $currentPath = if ($pathInfo.Drive) { $pathInfo.Path } else { $pathInfo.ProviderPath }
-
-        # File system paths are case-sensitive on Linux and case-insensitive on Windows and macOS
-        if (($PSVersionTable.PSVersion.Major -ge 6) -and $IsLinux) {
-            $stringComparison = [System.StringComparison]::Ordinal
-        }
-        else {
-            $stringComparison = [System.StringComparison]::OrdinalIgnoreCase
-        }
-
-        # Abbreviate path by replacing beginning of path with ~ *iff* the path is in the user's home dir
-        $abbrevHomeDir = $GitPromptSettings.DefaultPromptAbbreviateHomeDirectory
-        if ($abbrevHomeDir -and $currentPath -and $currentPath.StartsWith($Home, $stringComparison))
-        {
-            $currentPath = "~" + $currentPath.SubString($Home.Length)
-        }
-
-        # Display default prompt prefix if not empty.
-        $defaultPromptPrefix = [string]$GitPromptSettings.DefaultPromptPrefix
-        if ($defaultPromptPrefix) {
-            $expandedDefaultPromptPrefix = $ExecutionContext.SessionState.InvokeCommand.ExpandString($defaultPromptPrefix)
-            Write-Prompt $expandedDefaultPromptPrefix
-        }
-
-        # Write the abbreviated current path
-        Write-Prompt $currentPath
-
-        # Write the Git status summary information
-        Write-VcsStatus
-
-        # If stopped in the debugger, the prompt needs to indicate that in some fashion
-        $hasInBreakpoint = [runspace]::DefaultRunspace.Debugger | Get-Member -Name InBreakpoint -MemberType property
-        $debugMode = (Test-Path Variable:/PSDebugContext) -or ($hasInBreakpoint -and [runspace]::DefaultRunspace.Debugger.InBreakpoint)
-        $promptSuffix = if ($debugMode) { $GitPromptSettings.DefaultPromptDebugSuffix } else { $GitPromptSettings.DefaultPromptSuffix }
-
-        # If user specifies $null or empty string, set to ' ' to avoid "PS>" unexpectedly being displayed
-        if (!$promptSuffix) {
-            $promptSuffix = ' '
-        }
-
-        $expandedPromptSuffix = $ExecutionContext.SessionState.InvokeCommand.ExpandString($promptSuffix)
-
-        # If prompt timing enabled, display elapsed milliseconds
-        if ($GitPromptSettings.DefaultPromptEnableTiming) {
-            $sw.Stop()
-            $elapsed = $sw.ElapsedMilliseconds
-            Write-Prompt " ${elapsed}ms"
-        }
-
-        $global:LASTEXITCODE = $origLastExitCode
-        $expandedPromptSuffix
-'@)
-
     # Set the posh-git prompt as the default prompt
-    Set-Item Function:\prompt -Value $poshGitPromptScriptBlock
+    Set-Item Function:\prompt -Value $GitPromptScriptBlock
 }
 
 # Install handler for removal/unload of the module
@@ -127,7 +125,7 @@ $ExecutionContext.SessionState.Module.OnRemove = {
 
     # Check if the posh-git prompt function itself has been replaced. If so, do not restore the prompt function
     $promptDef = if ($funcInfo = Get-Command prompt -ErrorAction SilentlyContinue) { $funcInfo.Definition }
-    if ($promptDef -eq $poshGitPromptScriptBlock) {
+    if ($promptDef -eq $GitPromptScriptBlock) {
         Set-Item Function:\prompt -Value ([scriptblock]::Create($defaultPromptDef))
         return
     }
@@ -156,6 +154,9 @@ $exportModuleMemberParams = @{
         'Get-SshPath',
         'Update-AllBranches',
         'tgit'
+    )
+    Variable = @(
+        'GitPromptScriptBlock'
     )
 }
 


### PR DESCRIPTION
I've pulled a few backward-compatible changes down from `develop`. In particular:

- #478/#479
- `$GitPromptScriptBlock` from #513 for #501
- #509 
- `$GitPromptSettings.DefaultPromptPath` from #520 for #469

I also split off the changelog entries from #521 that apply to this release.
  