### PR TITLE
Add Travis config for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: false
+      addons:
+        apt:
+          sources:
+            - sourceline: deb [arch=amd64] https://packages.microsoft.com/ubuntu/14.04/prod trusty main
+              key_url: https://packages.microsoft.com/keys/microsoft.asc
+          packages:
+            - powershell
+      before_install:
+        - pwsh -c 'Set-PSRepository -Name PSGallery -InstallationPolicy Trusted'
+        - pwsh -c 'Install-Module Pester -Scope CurrentUser'
+
+script:
+  - pwsh -c 'Import-Module Pester; Invoke-Pester -EnableExit'


### PR DESCRIPTION
.travis.yml as discussed in #302. Linux only at the moment, Mac OS builds have a very long queue so taking longer to test.

Pester is set to use the number of failed tests as the exit code, so build is reported as failed due to 41 tests failing (a large chunk are references to `git.exe` or the C: drive).