### PR TITLE
Add Travis config for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: false
+      addons:
+        apt:
+          sources:
+            - sourceline: deb [arch=amd64] https://packages.microsoft.com/ubuntu/14.04/prod trusty main
+              key_url: https://packages.microsoft.com/keys/microsoft.asc
+          packages:
+            - powershell
+      before_install:
+        - pwsh -c 'Set-PSRepository -Name PSGallery -InstallationPolicy Trusted'
+        - pwsh -c 'Install-Module Pester -Scope CurrentUser'
+
+script:
+  - pwsh -c 'Import-Module Pester; Invoke-Pester -EnableExit'


### PR DESCRIPTION
For #302, rebased against develop as requested in #523.

Reports as failed due to 40 tests failing, again largely references to `git.exe` and `C:`.
