### PR TITLE
Travis for Mac OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+  - develop
+
 stages:
 - linux
 - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ matrix:
       before_install:
         - pwsh -c 'Set-PSRepository -Name PSGallery -InstallationPolicy Trusted'
         - pwsh -c 'Install-Module Pester -Scope CurrentUser'
-    - os: osx
+    - if: branch = develop
+      os: osx
       before_install:
         - brew update
         - brew tap caskroom/cask

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: false
+      addons:
+        apt:
+          sources:
+            - sourceline: deb [arch=amd64] https://packages.microsoft.com/ubuntu/14.04/prod trusty main
+              key_url: https://packages.microsoft.com/keys/microsoft.asc
+          packages:
+            - powershell
+      before_install:
+        - pwsh -c 'Set-PSRepository -Name PSGallery -InstallationPolicy Trusted'
+        - pwsh -c 'Install-Module Pester -Scope CurrentUser'
+
+script:
+  - pwsh -c 'Import-Module Pester; Invoke-Pester -EnableExit'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,13 @@ matrix:
       before_install:
         - pwsh -c 'Set-PSRepository -Name PSGallery -InstallationPolicy Trusted'
         - pwsh -c 'Install-Module Pester -Scope CurrentUser'
+    - os: osx
+      before_install:
+        - brew update
+        - brew tap caskroom/cask
+        - brew cask install powershell
+        - pwsh -c 'Set-PSRepository -Name PSGallery -InstallationPolicy Trusted'
+        - pwsh -c 'Install-Module Pester -Scope CurrentUser'
 
 script:
   - pwsh -c 'Import-Module Pester; Invoke-Pester -EnableExit'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: generic
 
-matrix:
+stages:
+- linux
+- osx
+
+jobs:
   include:
-    - os: linux
+    - stage: linux
+      os: linux
       dist: trusty
       sudo: false
       addons:
@@ -15,7 +20,8 @@ matrix:
       before_install:
         - pwsh -c 'Set-PSRepository -Name PSGallery -InstallationPolicy Trusted'
         - pwsh -c 'Install-Module Pester -Scope CurrentUser'
-    - if: branch = develop
+    - stage: osx
+      if: branch = develop
       os: osx
       before_install:
         - brew update


### PR DESCRIPTION
Builds on the Linux config in #524, from #302.

Mac OS builds report the same errors as Linux (which makes sense, since from a PowerShell perspective they're about identical), so adding it as a target may not be desirable, given the very long queue lengths Travis normally has- a couple of hours at the moment. Travis won't report back to GitHub until both builds are done, but results for Linux and Mac OS can be seen separately on the actual build page.