### PR TITLE
Fixes two bugs - one ANSI and one PS Core

### DIFF
--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -101,7 +101,7 @@ function Write-Prompt {
 
         if ($s.AnsiConsole) {
             if ($Object -is [PoshGitTextSpan]) {
-                $str = $Object.RenderAnsi()
+                $str = $Object.ToAnsiString()
             }
             else {
                 $e = [char]27 + "["

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -131,57 +131,7 @@ class PoshGitTextSpan {
         $this.CustomAnsi = $null
     }
 
-    [string] ToEscapedString() {
-        if ($global:GitPromptSettings.AnsiConsole) {
-            $ansiTerm = EscapseAnsiString ([char]27 + "[0m")
-
-            if ($this.CustomAnsi) {
-                $escAnsi = EscapseAnsiString $this.CustomAnsi
-                $str = "${escAnsi}$($this.Text)$ansiTerm"
-            }
-            else {
-                $color = [PoshGitCellColor]::new($this.ForegroundColor, $this.BackgroundColor)
-                $escAnsi = $color.ToEscapedString()
-                if ($escAnsi) {
-                    $str = "${escAnsi}$($this.Text)$ansiTerm"
-                }
-                else {
-                    $str = $this.Text
-                }
-            }
-        }
-        else {
-            $str = $this.Text
-        }
-
-        return $str
-    }
-
-    [string] ToString() {
-        if ($global:GitPromptSettings.AnsiConsole) {
-            if ($this.CustomAnsi) {
-                $e = [char]27 + "["
-                $ansi = $this.CustomAnsi
-                $escAnsi = EscapseAnsiString $this.CustomAnsi
-                $txt = $this.RenderAnsi()
-                $str = "Text: '$txt',`t CustomAnsi: '${ansi}${escAnsi}${e}0m'"
-            }
-            else {
-                $color = [PoshGitCellColor]::new($this.ForegroundColor, $this.BackgroundColor)
-                $txt = $this.RenderAnsi()
-                $str = "Text: '$txt',`t $($color.ToString())"
-            }
-        }
-        else {
-            $color = [PoshGitCellColor]::new($this.ForegroundColor, $this.BackgroundColor)
-            $txt = $this.Text
-            $str = "Text: '$txt',`t $($color.ToString())"
-        }
-
-        return $str
-    }
-
-    [string] RenderAnsi() {
+    [string] ToAnsiString() {
         $e = [char]27 + "["
         $txt = $this.Text
 
@@ -206,6 +156,41 @@ class PoshGitTextSpan {
             else {
                 $str = $txt
             }
+        }
+
+        return $str
+    }
+
+    [string] ToEscapedString() {
+        if ($global:GitPromptSettings.AnsiConsole) {
+            $str = EscapseAnsiString $this.ToAnsiString()
+        }
+        else {
+            $str = $this.Text
+        }
+
+        return $str
+    }
+
+    [string] ToString() {
+        if ($global:GitPromptSettings.AnsiConsole) {
+            if ($this.CustomAnsi) {
+                $e = [char]27 + "["
+                $ansi = $this.CustomAnsi
+                $escAnsi = EscapseAnsiString $this.CustomAnsi
+                $txt = $this.ToAnsiString()
+                $str = "Text: '$txt',`t CustomAnsi: '${ansi}${escAnsi}${e}0m'"
+            }
+            else {
+                $color = [PoshGitCellColor]::new($this.ForegroundColor, $this.BackgroundColor)
+                $txt = $this.ToAnsiString()
+                $str = "Text: '$txt',`t $($color.ToString())"
+            }
+        }
+        else {
+            $color = [PoshGitCellColor]::new($this.ForegroundColor, $this.BackgroundColor)
+            $txt = $this.Text
+            $str = "Text: '$txt',`t $($color.ToString())"
         }
 
         return $str

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -19,7 +19,7 @@ class PoshGitCellColor {
         $this.BackgroundColor = $BackgroundColor
     }
 
-    hidden [string] ToString($color) {
+    hidden static [string] ToString($color) {
         $ansiTerm = "$([char]0x1b)[0m"
         $colorSwatch = "  "
 
@@ -44,11 +44,41 @@ class PoshGitCellColor {
         return $str
     }
 
+    [string] ToEscapedString() {
+        if (!$global:GitPromptSettings.AnsiConsole) {
+            return ""
+        }
+
+        $str = ""
+
+        if ($this.ForegroundColor) {
+            if (Test-VirtualTerminalSequece $this.ForegroundColor) {
+                $str += EscapseAnsiString $this.ForegroundColor
+            }
+            else {
+                $seq = Get-ForegroundVirtualTerminalSequence $this.ForegroundColor
+                $str += EscapseAnsiString $seq
+            }
+        }
+
+        if ($this.BackgroundColor) {
+            if (Test-VirtualTerminalSequece $this.BackgroundColor) {
+                $str += EscapseAnsiString $this.BackgroundColor
+            }
+            else {
+                $seq = Get-BackgroundVirtualTerminalSequence $this.BackgroundColor
+                $str += EscapseAnsiString $seq
+            }
+        }
+
+        return $str
+    }
+
     [string] ToString() {
         $str = "ForegroundColor: "
-        $str += $this.ToString($this.ForegroundColor) + ", "
+        $str += [PoshGitCellColor]::ToString($this.ForegroundColor) + ", "
         $str += "BackgroundColor: "
-        $str += $this.ToString($this.BackgroundColor)
+        $str += [PoshGitCellColor]::ToString($this.BackgroundColor)
         return $str
     }
 }
@@ -101,6 +131,32 @@ class PoshGitTextSpan {
         $this.CustomAnsi = $null
     }
 
+    [string] ToEscapedString() {
+        if ($global:GitPromptSettings.AnsiConsole) {
+            $ansiTerm = EscapseAnsiString ([char]27 + "[0m")
+
+            if ($this.CustomAnsi) {
+                $escAnsi = EscapseAnsiString $this.CustomAnsi
+                $str = "${escAnsi}$($this.Text)$ansiTerm"
+            }
+            else {
+                $color = [PoshGitCellColor]::new($this.ForegroundColor, $this.BackgroundColor)
+                $escAnsi = $color.ToEscapedString()
+                if ($escAnsi) {
+                    $str = "${escAnsi}$($this.Text)$ansiTerm"
+                }
+                else {
+                    $str = $this.Text
+                }
+            }
+        }
+        else {
+            $str = $this.Text
+        }
+
+        return $str
+    }
+
     [string] ToString() {
         if ($global:GitPromptSettings.AnsiConsole) {
             if ($this.CustomAnsi) {
@@ -144,7 +200,12 @@ class PoshGitTextSpan {
                 $fg = Get-ForegroundVirtualTerminalSequence $fg
             }
 
-            $str = "${fg}${bg}${txt}${e}0m"
+            if (($null -ne $fg) -or ($null -ne $bg)) {
+                $str = "${fg}${bg}${txt}${e}0m"
+            }
+            else {
+                $str = $txt
+            }
         }
 
         return $str

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -246,7 +246,12 @@ function Add-PoshGitToProfile {
     Adapted from http://www.west-wind.com/Weblog/posts/197245.aspx
 #>
 function Get-FileEncoding($Path) {
-    $bytes = [byte[]](Get-Content $Path -Encoding byte -ReadCount 4 -TotalCount 4)
+    if ($PSVersionTable.PSVersion.Major -ge 6) {
+        $bytes = [byte[]](Get-Content $Path -AsByteStream -ReadCount 4 -TotalCount 4)
+    }
+    else {
+        $bytes = [byte[]](Get-Content $Path -Encoding byte -ReadCount 4 -TotalCount 4)
+    }
 
     if (!$bytes) { return 'utf8' }
 


### PR DESCRIPTION
The ANSI bug is that if both fg and bg are default ($null) we were still emitting the terminating seq `e[0m.

The PS Core bug is that on PS Core there is no byte value for Get-Content -Encoding.   The replacement is Get-Content -AsByteStream.

Also. added ToEscapedString() method to [PoshGitCellColor] and [PoshGitTextSpan].  Was invaluable for working on the Pester tests and  I think it will be very handy for debugging.  If someone's GitPrompSettings isn't displaying properly we can ask them to execute: `$GitPromptSettings.DelimText.ToEscapedString()`

This will output:
``` `e[93m |`e[0m```