### PR TITLE
Lookup HtmlColors before ConsoleColors

### DIFF
--- a/src/AnsiUtils.ps1
+++ b/src/AnsiUtils.ps1
@@ -58,11 +58,11 @@ function Get-VirtualTerminalSequence ($color, [int]$offset = 0) {
 
     if ($color -is [String]) {
         try {
-            if ($null -ne ($color -as [System.ConsoleColor])) {
-                $color = [System.ConsoleColor]$color
-            }
-            elseif ($ColorTranslatorType) {
+            if ($ColorTranslatorType) {
                 $color = $ColorTranslatorType::FromHtml($color)
+            }
+            elseif ($null -ne ($color -as [System.ConsoleColor])) {
+                $color = [System.ConsoleColor]$color
             }
         }
         catch {

--- a/src/AnsiUtils.ps1
+++ b/src/AnsiUtils.ps1
@@ -61,12 +61,14 @@ function Get-VirtualTerminalSequence ($color, [int]$offset = 0) {
             if ($ColorTranslatorType) {
                 $color = $ColorTranslatorType::FromHtml($color)
             }
-            elseif ($null -ne ($color -as [System.ConsoleColor])) {
-                $color = [System.ConsoleColor]$color
-            }
         }
         catch {
             Write-Debug $_
+        }
+
+        # Hard to get here but DarkYellow is not an HTML color but is a ConsoleColor
+        if (($color -isnot $ColorType) -and ($null -ne ($consoleColor = $color -as [System.ConsoleColor]))) {
+            $color = $consoleColor
         }
     }
 

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -62,7 +62,7 @@ AliasesToExport = @()
 PrivateData = @{
     PSData = @{
         # Tags applied to this module. These help with module discovery in online galleries.
-        Tags = @('git', 'prompt', 'tab', 'tab-completion', 'tab-expansion', 'tabexpansion')
+        Tags = @('git', 'prompt', 'tab', 'tab-completion', 'tab-expansion', 'tabexpansion', 'PSEdition_Core')
 
         # A URL to the license for this module.
         LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/develop/LICENSE.txt'


### PR DESCRIPTION
Turns out ConsoleColors are a lot easier to specify than HtmlColors (that happen to match ConsoleColor names).

Add `PSEdition_Core` tag so that posh-git shows up if someone searches for that tag - https://www.powershellgallery.com/items?q=tags%3Apsedition_core&x=0&y=0