### PR TITLE
Improved WindowTitle customization experience

### DIFF
--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -17,7 +17,7 @@
     # Use ExcludeRules when you want to run most of the default set of rules except
     # for a few rules you wish to "exclude".  Note: if a rule is in both IncludeRules
     # and ExcludeRules, the rule will be excluded.
-    ExcludeRules = @('PSAvoidUsingWriteHost', 'PSAvoidGlobalVars')
+    ExcludeRules = @('PSAvoidUsingWriteHost', 'PSAvoidGlobalVars', 'PSAvoidUsingInvokeExpression')
 
     # You can use the following entry to supply parameters to rules that take parameters.
     # For instance, the PSAvoidUsingCmdletAliases rule takes a whitelist for aliases you

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -340,6 +340,7 @@ function Get-GitStatus {
 
         $result = New-Object PSObject -Property @{
             GitDir          = $GitDir
+            RepoName        = Split-Path (Split-Path $GitDir -Parent) -Leaf
             Branch          = $branch
             AheadBy         = $aheadBy
             BehindBy        = $behindBy

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -197,7 +197,7 @@ class PoshGitTextSpan {
     }
 }
 
-class GitPromptSettings {
+class PoshGitPromptSettings {
     [bool]$AnsiConsole = $Host.UI.SupportsVirtualTerminal -or ($Env:ConEmuANSI -eq "ON")
 
     [PoshGitCellColor]$DefaultColor = [PoshGitCellColor]::new()
@@ -244,8 +244,9 @@ class GitPromptSettings {
     [Nullable[bool]]$EnableFileStatusFromCache        = $null
     [string[]]$RepositoriesInWhichToDisableFileStatus = @()
 
-    [string]$DescribeStyle       = ''
-    [psobject]$EnableWindowTitle = 'posh~git ~ '
+    [string]$DescribeStyle   = ''
+    [bool]$EnableWindowTitle = $true
+    [psobject]$WindowTitle   = {param($GitStatus, [bool]$IsAdmin) "$(if ($IsAdmin) {'Admin: '})posh~git ~ $($GitStatus.RepoName) [$($GitStatus.Branch)]"}
 
     [PoshGitTextSpan]$DefaultPromptPrefix       = ''
     [PoshGitTextSpan]$DefaultPromptSuffix       = '$(''>'' * ($nestedPromptLevel + 1)) '

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -245,8 +245,7 @@ class PoshGitPromptSettings {
     [string[]]$RepositoriesInWhichToDisableFileStatus = @()
 
     [string]$DescribeStyle   = ''
-    [bool]$EnableWindowTitle = $true
-    [psobject]$WindowTitle   = {param($GitStatus, [bool]$IsAdmin) "$(if ($IsAdmin) {'Admin: '})posh~git ~ $($GitStatus.RepoName) [$($GitStatus.Branch)]"}
+    [psobject]$WindowTitle   = {param($GitStatus, [bool]$IsAdmin) "$(if ($IsAdmin) {'Administrator: '})posh~git ~ $($GitStatus.RepoName) [$($GitStatus.Branch)]"}
 
     [PoshGitTextSpan]$DefaultPromptPrefix       = ''
     [PoshGitTextSpan]$DefaultPromptSuffix       = '$(''>'' * ($nestedPromptLevel + 1)) '

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -245,7 +245,7 @@ class PoshGitPromptSettings {
     [string[]]$RepositoriesInWhichToDisableFileStatus = @()
 
     [string]$DescribeStyle   = ''
-    [psobject]$WindowTitle   = {param($GitStatus, [bool]$IsAdmin) "$(if ($IsAdmin) {'Administrator: '})posh~git ~ $($GitStatus.RepoName) [$($GitStatus.Branch)]"}
+    [psobject]$WindowTitle   = {param($GitStatus, [bool]$IsAdmin) "$(if ($IsAdmin) {'Administrator: '})$(if ($GitStatus) {"posh~git ~ $($GitStatus.RepoName) [$($GitStatus.Branch)] ~ "})PowerShell $($PSVersionTable.PSVersion) ($PID)"}
 
     [PoshGitTextSpan]$DefaultPromptPrefix       = ''
     [PoshGitTextSpan]$DefaultPromptSuffix       = '$(''>'' * ($nestedPromptLevel + 1)) '

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -92,7 +92,7 @@ $GitPromptScriptBlock = {
     # Update the host's WindowTitle is host supports it and user has not disabled $GitPromptSettings.WindowTitle
     if ($WindowTitleSupported) {
         $windowTitle = $settings.WindowTitle
-        if (($null -eq $windowTitle) -or ($null -eq $global:GitStatus)) {
+        if ($null -eq $windowTitle) {
             if ($global:PreviousWindowTitle) {
                 $Host.UI.RawUI.WindowTitle = $global:PreviousWindowTitle
             }
@@ -154,6 +154,11 @@ if ($ForcePoshGitPrompt -or !$currentPromptDef -or ($currentPromptDef -eq $defau
 # Install handler for removal/unload of the module
 $ExecutionContext.SessionState.Module.OnRemove = {
     $global:VcsPromptStatuses = $global:VcsPromptStatuses | Where-Object { $_ -ne $PoshGitVcsPrompt }
+
+    # Revert original WindowTitle
+    if ($WindowTitleSupported -and $global:PreviousWindowTitle) {
+        $Host.UI.RawUI.WindowTitle = $global:PreviousWindowTitle
+    }
 
     # Check if the posh-git prompt function itself has been replaced. If so, do not restore the prompt function
     $promptDef = if ($funcInfo = Get-Command prompt -ErrorAction SilentlyContinue) { $funcInfo.Definition }

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -92,7 +92,7 @@ $GitPromptScriptBlock = {
     # Update the host's WindowTitle is host supports it and user has not disabled $GitPromptSettings.WindowTitle
     if ($WindowTitleSupported) {
         $windowTitle = $settings.WindowTitle
-        if ($null -eq $windowTitle) {
+        if (!$windowTitle) {
             if ($global:PreviousWindowTitle) {
                 $Host.UI.RawUI.WindowTitle = $global:PreviousWindowTitle
             }

--- a/test/DefaultPrompt.Tests.ps1
+++ b/test/DefaultPrompt.Tests.ps1
@@ -2,6 +2,7 @@
 
 Describe 'Default Prompt Tests - NO ANSI' {
     BeforeAll {
+        [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
         $prompt = Get-Item Function:\prompt
         $OFS = ''
     }
@@ -94,6 +95,7 @@ A  test/Foo.Tests.ps1
 
 Describe 'Default Prompt Tests - ANSI' {
     BeforeAll {
+        [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
         $prompt = Get-Item Function:\prompt
         $OFS = ''
     }
@@ -197,14 +199,20 @@ A  test/Foo.Tests.ps1
 
 Describe 'Default Prompt WindowTitle Tests' {
     BeforeAll {
+        [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
         $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
         if (!(& $module {$WindowTitleSupported})) {
             Write-Warning "Current PowerShell Host does not support changing its WindowTitle."
             $PSDefaultParameterValues["it:skip"] = $true
         }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
         $repoAdminRegex = '^Administrator: posh~git ~ posh-git \[master\] ~ PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \(\d+\)$'
+        [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
         $repoRegex = '^posh~git ~ posh-git \[master\] ~ PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \(\d+\)$'
+        [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
         $nonRepoAdminRegex = '^Administrator: PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \(\d+\)$'
+        [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
         $nonRepoRegex = '^PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \(\d+\)$'
     }
     AfterAll {
@@ -237,7 +245,7 @@ M test/Baz.Tests.ps1
 
         It 'Default GitPromptSettings.WindowTitle sets the expected Window title text' {
             Set-Location $PSScriptRoot
-            $res = & $GitPromptScriptBlock 6>&1
+            & $GitPromptScriptBlock 6>&1
             Assert-MockCalled git -ModuleName posh-git -Scope It
             $title = $Host.UI.RawUI.WindowTitle
             if (& $module {$IsAdmin}) {
@@ -254,7 +262,7 @@ M test/Baz.Tests.ps1
                 param($s, $admin)
                 "$(if ($admin) {'daboss:'} else {'loser:'}) poshgit == $($s.RepoName) / $($s.Branch)"
             }
-            $res = & $GitPromptScriptBlock 6>&1
+            & $GitPromptScriptBlock 6>&1
             Assert-MockCalled git -ModuleName posh-git -Scope It
             $title = $Host.UI.RawUI.WindowTitle
             if (& $module {$IsAdmin}) {
@@ -268,7 +276,7 @@ M test/Baz.Tests.ps1
         It 'Custom GitPromptSettings.WindowTitle single quoted string sets the expected Window title text' {
             Set-Location $PSScriptRoot
             $GitPromptSettings.WindowTitle = '$(if ($IsAdmin) {"daboss:"} else {"loser:"}) poshgit == $($GitStatus.RepoName) / $($GitStatus.Branch)'
-            $res = & $GitPromptScriptBlock 6>&1
+            & $GitPromptScriptBlock 6>&1
             Assert-MockCalled git -ModuleName posh-git -Scope It
             $title = $Host.UI.RawUI.WindowTitle
             if (& $module {$IsAdmin}) {
@@ -282,7 +290,7 @@ M test/Baz.Tests.ps1
         It 'Does not set Window title when GitPromptSettings.WindowText is $null' {
             Set-Location $PSScriptRoot
             $GitPromptSettings.WindowTitle = $null
-            $res = & $GitPromptScriptBlock 6>&1
+            & $GitPromptScriptBlock 6>&1
             Assert-MockCalled git -ModuleName posh-git -Scope It
             $title = $Host.UI.RawUI.WindowTitle
             $title | Should Match '^(Windows )?PowerShell'
@@ -292,7 +300,7 @@ M test/Baz.Tests.ps1
     Context 'Not in a Git repo' {
         It 'Does not display posh-git status info in Window title when not in a Git repo' {
             Set-Location $Home
-            $res = & $GitPromptScriptBlock 6>&1
+            & $GitPromptScriptBlock 6>&1
             $title = $Host.UI.RawUI.WindowTitle
             if (& $module {$IsAdmin}) {
                 $title | Should Match $nonRepoAdminRegex
@@ -321,7 +329,7 @@ M test/Baz.Tests.ps1
 
         It 'Displays the correct Window title as we move in and out of a Git repo' {
             Set-Location $Home
-            $res = & $GitPromptScriptBlock 6>&1
+            & $GitPromptScriptBlock 6>&1
             $title = $Host.UI.RawUI.WindowTitle
             if (& $module {$IsAdmin}) {
                 $title | Should Match $nonRepoAdminRegex
@@ -331,7 +339,7 @@ M test/Baz.Tests.ps1
             }
 
             Set-Location $PSScriptRoot
-            $res = & $GitPromptScriptBlock 6>&1
+            & $GitPromptScriptBlock 6>&1
             Assert-MockCalled git -ModuleName posh-git -Scope It
             $title = $Host.UI.RawUI.WindowTitle
             if (& $module {$IsAdmin}) {
@@ -342,7 +350,7 @@ M test/Baz.Tests.ps1
             }
 
             Set-Location $Home
-            $res = & $GitPromptScriptBlock 6>&1
+            & $GitPromptScriptBlock 6>&1
             $title = $Host.UI.RawUI.WindowTitle
             if (& $module {$IsAdmin}) {
                 $title | Should Match $nonRepoAdminRegex

--- a/test/DefaultPrompt.Tests.ps1
+++ b/test/DefaultPrompt.Tests.ps1
@@ -295,6 +295,24 @@ M test/Baz.Tests.ps1
             $title = $Host.UI.RawUI.WindowTitle
             $title | Should Match '^(Windows )?PowerShell'
         }
+
+        It 'Does not set Window title when GitPromptSettings.WindowText is $false' {
+            Set-Location $PSScriptRoot
+            $GitPromptSettings.WindowTitle = $false
+            & $GitPromptScriptBlock 6>&1
+            Assert-MockCalled git -ModuleName posh-git -Scope It
+            $title = $Host.UI.RawUI.WindowTitle
+            $title | Should Match '^(Windows )?PowerShell'
+        }
+
+        It 'Does not set Window title when GitPromptSettings.WindowText is ""' {
+            Set-Location $PSScriptRoot
+            $GitPromptSettings.WindowTitle = ''
+            & $GitPromptScriptBlock 6>&1
+            Assert-MockCalled git -ModuleName posh-git -Scope It
+            $title = $Host.UI.RawUI.WindowTitle
+            $title | Should Match '^(Windows )?PowerShell'
+        }
     }
 
     Context 'Not in a Git repo' {

--- a/test/DefaultPrompt.Tests.ps1
+++ b/test/DefaultPrompt.Tests.ps1
@@ -202,10 +202,10 @@ Describe 'Default Prompt WindowTitle Tests' {
             Write-Warning "Current PowerShell Host does not support changing its WindowTitle."
             $PSDefaultParameterValues["it:skip"] = $true
         }
-        $repoAdminRegex = '^Administrator: posh~git ~ posh-git \[master\] ~ PowerShell \d+\.\d+\.\d+\.\d+ \(\d+\)$'
-        $repoRegex = '^posh~git ~ posh-git \[master\] ~ PowerShell \d+\.\d+\.\d+\.\d+ \(\d+\)$'
-        $nonRepoAdminRegex = '^Administrator: PowerShell \d+\.\d+\.\d+\.\d+ \(\d+\)$'
-        $nonRepoRegex = '^PowerShell \d+\.\d+\.\d+\.\d+ \(\d+\)$'
+        $repoAdminRegex = '^Administrator: posh~git ~ posh-git \[master\] ~ PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \(\d+\)$'
+        $repoRegex = '^posh~git ~ posh-git \[master\] ~ PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \(\d+\)$'
+        $nonRepoAdminRegex = '^Administrator: PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \(\d+\)$'
+        $nonRepoRegex = '^PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \(\d+\)$'
     }
     AfterAll {
         $global:PSDefaultParameterValues = $originalDefaultParameterValues


### PR DESCRIPTION
v1 fix for https://github.com/dahlbyk/posh-git/issues/537

Needs more Pester tests.  Also, I think we might want to keep `EnableWindowTitle` as a simple bool.  If you disable the WindowTitle by setting it to $null, you lose the original definition.  

Also you made a comment about evaluating the WindowTitle scriptblock during prompt eval. It does seem a bit unusual that we change the WindowTitle in the Write-GitStatus function.  Is the proposal to move the setting of the host WindowTitle to the built-in prompt?

BTW there was some code we used to determine WindowTitleSupported that I've thought was circumspect for a while. This gave me a chance to take a better (I hope) approach.