### PR TITLE
Ensure origin exists for tests

### DIFF
--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -8,6 +8,12 @@ Describe 'TabExpansion Tests' {
         BeforeEach {
             # Ensure master branch exists
             &$gitbin branch -q master 2>$null
+            # Ensure an origin remote exists
+            &$gitbin remote add origin . 2>$null
+            # Fetch origin/master
+            &$gitbin fetch origin master 2>$null
+            # Ensure origin/HEAD exists
+            &$gitbin remote set-head origin --auto 2>$null
         }
         It 'Tab completes all remotes' {
             (&$gitbin remote) -contains 'origin' | Should Be $true


### PR DESCRIPTION
Continuing on from #545 and #546, `develop` branch tests are now failing because `origin/master` doesn't exist. So let's ensure `origin` exists, just for good measure, then `origin/master` and `origin/HEAD`. Integration tests are such a pain... Wish we could adequately test this outside of `develop`!