### PR TITLE
Cheat to ensure origin refs exist

### DIFF
--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -11,7 +11,7 @@ Describe 'TabExpansion Tests' {
             # Ensure an origin remote exists
             &$gitbin remote add origin . 2>$null
             # Ensure origin/master exists
-            &$gitbin update-ref refs/remotes/origin/master master 2>$null
+            &$gitbin update-ref refs/remotes/origin/master $(git rev-parse master) 2>$null
             # Ensure origin/HEAD exists
             &$gitbin symbolic-ref refs/remotes/origin/HEAD master 2>$null
         }

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'TabExpansion Tests' {
             # Ensure origin/master exists
             &$gitbin update-ref refs/remotes/origin/master $(git rev-parse master) 2>$null
             # Ensure origin/HEAD exists
-            &$gitbin symbolic-ref refs/remotes/origin/HEAD master 2>$null
+            &$gitbin symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master 2>$null
         }
         It 'Tab completes all remotes' {
             (&$gitbin remote) -contains 'origin' | Should Be $true

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -10,10 +10,10 @@ Describe 'TabExpansion Tests' {
             &$gitbin branch -q master 2>$null
             # Ensure an origin remote exists
             &$gitbin remote add origin . 2>$null
-            # Fetch origin/master
-            &$gitbin fetch origin master 2>$null
+            # Ensure origin/master exists
+            &$gitbin update-ref refs/remotes/origin/master master 2>$null
             # Ensure origin/HEAD exists
-            &$gitbin remote set-head origin --auto 2>$null
+            &$gitbin symbolic-ref refs/remotes/origin/HEAD master 2>$null
         }
         It 'Tab completes all remotes' {
             (&$gitbin remote) -contains 'origin' | Should Be $true


### PR DESCRIPTION
#547 doesn't quite work due to how Travis clones:

```
git clone --depth=50 --branch=develop https://github.com/dahlbyk/posh-git.git dahlbyk/posh-git
```

This results in the following config setting:

```
remote.origin.fetch=+refs/heads/develop:refs/remotes/origin/develop
```

As opposed to the usual:

```
remote.origin.fetch=+refs/heads/*:refs/remotes/origin/*
```

In practice, this means `git fetch origin master` doesn't match a reference, so it's not fetched.

Rather than fix that, it seems easier to just create the refs the tests expect.