### PR TITLE
Enhance $GitPromptSettings to display RGB in hex, better spacing

### DIFF
--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -38,7 +38,12 @@ class PoshGitCellColor {
                 $str += "${bg}${colorSwatch}${ansiTerm} "
             }
 
-            $str += $color.ToString()
+            if ($color -is [int]) {
+                $str += "0x{0:X6}" -f $color
+            }
+            else {
+                $str += $color.ToString()
+            }
         }
 
         return $str
@@ -173,24 +178,29 @@ class PoshGitTextSpan {
     }
 
     [string] ToString() {
+        $sep = " "
+        if ($this.Text.Length -lt 2) {
+            $sep = " " * (3 - $this.Text.Length)
+        }
+
         if ($global:GitPromptSettings.AnsiConsole) {
             if ($this.CustomAnsi) {
                 $e = [char]27 + "["
                 $ansi = $this.CustomAnsi
                 $escAnsi = EscapeAnsiString $this.CustomAnsi
                 $txt = $this.ToAnsiString()
-                $str = "Text: '$txt',`t CustomAnsi: '${ansi}${escAnsi}${e}0m'"
+                $str = "Text: '$txt',${sep}CustomAnsi: '${ansi}${escAnsi}${e}0m'"
             }
             else {
                 $color = [PoshGitCellColor]::new($this.ForegroundColor, $this.BackgroundColor)
                 $txt = $this.ToAnsiString()
-                $str = "Text: '$txt',`t $($color.ToString())"
+                $str = "Text: '$txt',${sep}$($color.ToString())"
             }
         }
         else {
             $color = [PoshGitCellColor]::new($this.ForegroundColor, $this.BackgroundColor)
             $txt = $this.Text
-            $str = "Text: '$txt',`t $($color.ToString())"
+            $str = "Text: '$txt',${sep}$($color.ToString())"
         }
 
         return $str


### PR DESCRIPTION
This is a simple change to the `ToString()` formatting that displays the contents of `$GitPromptSettings`.

Same as other PR, this one is simple and safe.  I'll merge it shortly.

Changes it from this (note wide spacing and the base10 value for 0xDCDCAA):

![image](https://user-images.githubusercontent.com/5177512/36930418-797c7868-1e5d-11e8-8cd2-2b71454c8900.png)

to this:

![image](https://user-images.githubusercontent.com/5177512/36930421-89036d3c-1e5d-11e8-8289-2afbff406ee4.png)
