### PR TITLE
Add Get-GitRemotes function

### DIFF
--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -405,3 +405,35 @@ function Update-AllBranches($Upstream = 'master', [switch]$Quiet) {
 
     git checkout -q $head
 }
+
+<#
+.SYNOPSIS
+    Gets a Git remotes object
+.DESCRIPTION
+    Gets a git remotes object
+    The object contains the name and URL of all remotes
+.EXAMPLE
+    PS C:\> $s = Get-GitRemotes
+    Returns: 
+        Name   Url
+        ----   ---
+        origin git@github.com:dahlbyk/posh-git.git
+.INPUTS
+    None
+.OUTPUTS
+    System.Management.Automation.PSMethod
+#>
+function Get-GitRemotes {
+    $remoteNames = git remote
+    $remotes = New-Object System.Collections.ArrayList
+    foreach ($remoteName in $remoteNames) {
+        $remoteUrl = git remote get-url $remoteName
+
+        $remote = New-Object System.Object
+        $remote | Add-Member -MemberType NoteProperty -Name "Name" -Value $remoteName
+        $remote | Add-Member -MemberType NoteProperty -Name "Url" -Value $remoteUrl
+
+        $remotes.Add($remote) | Out-Null
+    }
+    $remotes
+}

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -414,7 +414,7 @@ function Update-AllBranches($Upstream = 'master', [switch]$Quiet) {
     The object contains the name and URL of all remotes
 .EXAMPLE
     PS C:\> $s = Get-GitRemotes
-    Returns: 
+    Returns:
         Name   Url
         ----   ---
         origin git@github.com:dahlbyk/posh-git.git
@@ -424,10 +424,10 @@ function Update-AllBranches($Upstream = 'master', [switch]$Quiet) {
     System.Management.Automation.PSMethod
 #>
 function Get-GitRemotes {
-    $remoteNames = git remote
+    $remoteNames = Invoke-Utf8ConsoleCommand { git remote }
     $remotes = New-Object System.Collections.ArrayList
     foreach ($remoteName in $remoteNames) {
-        $remoteUrl = git remote get-url $remoteName
+        $remoteUrl = Invoke-Utf8ConsoleCommand { git remote get-url $remoteName }
 
         $remote = New-Object System.Object
         $remote | Add-Member -MemberType NoteProperty -Name "Name" -Value $remoteName

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -421,7 +421,7 @@ function Update-AllBranches($Upstream = 'master', [switch]$Quiet) {
 .INPUTS
     None
 .OUTPUTS
-    System.Management.Automation.PSMethod
+    System.Management.Automation.PSObject
 #>
 function Get-GitRemotes {
     $remoteNames = Invoke-Utf8ConsoleCommand { git remote }

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -30,6 +30,7 @@ FunctionsToExport = @(
     'Get-GitDirectory',
     'Get-PromptPath',
     'Update-AllBranches',
+    'Get-GitRemotes',
     'Write-GitStatus',
     'Write-GitBranchName',
     'Write-GitBranchStatus',

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -179,6 +179,7 @@ $exportModuleMemberParams = @{
         'Get-GitStatus',
         'Get-PromptPath',
         'Update-AllBranches',
+        'Get-GitRemotes',
         'Write-GitStatus',
         'Write-GitBranchName',
         'Write-GitBranchStatus',


### PR DESCRIPTION
I've added a function that returns an object with all git remotes and the url for each remote. 

The output of the function is as follows (with one remote): 

```
Name   Url
----   ---
origin git@github.com:hugo-vrijswijk/posh-git.git
```

The idea behind this function is that [I am working on a feature for an oh-my-posh theme that shows an icon for certain remotes](https://github.com/hugo-vrijswijk/oh-my-posh/tree/remote-icon), and there is no simple way to get the remote from posh-git. Result would be like this for GitHub:
![image](https://user-images.githubusercontent.com/10114577/37115812-8b50abca-224c-11e8-9b28-55385c658b0b.png)

Instead of having oh-my-posh query git, I thought it would be more sensible to extract the function to posh-git, so it could be reused should anyone see use in it.

I thought about adding it to `Get-GitStatus` but decided against it as it's not part of the default `git status` anyway