### PR TITLE
Update git status to always show untracked files.

### DIFF
--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -87,6 +87,9 @@ $global:GitPromptSettings = [pscustomobject]@{
 
     ShowStatusWhenZero                          = $true
 
+    # Valid values are "all", "no", and "normal"
+    UntrackedFilesMode                          = $null
+
     AutoRefreshIndex                            = $true
 
     # Valid values are "Full", "Compact", and "Minimal"

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -232,7 +232,7 @@ function Get-GitStatus($gitDir = (Get-GitDirectory)) {
                 if ($cacheResponse.State) { $branch += "|" + $cacheResponse.State }
             } else {
                 dbg 'Getting status' $sw
-                $status = Invoke-Utf8ConsoleCommand { git -c core.quotepath=false -c color.status=false status --short --branch 2>$null }
+                $status = Invoke-Utf8ConsoleCommand { git -c core.quotepath=false -c color.status=false status -uall --short --branch 2>$null }
                 if($settings.EnableStashStatus) {
                     dbg 'Getting stash count' $sw
                     $stashCount = $null | git stash list 2>$null | measure-object | Select-Object -expand Count

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -232,7 +232,8 @@ function Get-GitStatus($gitDir = (Get-GitDirectory)) {
                 if ($cacheResponse.State) { $branch += "|" + $cacheResponse.State }
             } else {
                 dbg 'Getting status' $sw
-                $status = Invoke-Utf8ConsoleCommand { git -c core.quotepath=false -c color.status=false status -uall --short --branch 2>$null }
+                $untrackedFilesOption = if($settings.UntrackedFilesMode) { "-u$($settings.UntrackedFilesMode)" } else { "" }
+                $status = Invoke-Utf8ConsoleCommand { git -c core.quotepath=false -c color.status=false status $untrackedFilesOption --short --branch 2>$null }
                 if($settings.EnableStashStatus) {
                     dbg 'Getting stash count' $sw
                     $stashCount = $null | git stash list 2>$null | measure-object | Select-Object -expand Count


### PR DESCRIPTION
Fixes dahlbyk/posh-git#556.

This assumes we want to *always* show untracked files rather than providing an option to include untracked files or not. If this is not the preferred way to fix this issue, let me know what is desired and I can probably implement it.