### PR TITLE
Update develop from master

### DIFF
--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -862,8 +862,17 @@ $PoshGitVcsPrompt = {
             $errorText = "PoshGitVcsPrompt error: $_"
             $sb = [System.Text.StringBuilder]::new()
 
+            # When prompt is first (default), place the separator before the status summary
+            if (!$s.DefaultPromptWriteStatusFirst) {
+                $sb | Write-Prompt $s.PathStatusSeparator > $null
+            }
             $sb | Write-Prompt $s.BeforeStatus > $null
+
             $sb | Write-Prompt $errorText -Color $s.ErrorColor > $null
+            if ($s.Debug) {
+                if (!$s.AnsiConsole) { Write-Host }
+                Write-Verbose "PoshGitVcsPrompt error details: $($_ | Format-List * -Force | Out-String)" -Verbose
+            }
             $sb | Write-Prompt $s.AfterStatus > $null
 
             $sb.ToString()

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -224,8 +224,8 @@ function script:expandParamValues($cmd, $param, $filter) {
         ForEach-Object { -join ("--", $param, "=", $_) }
 }
 
-function GitTabExpansion($lastBlock) {
-    $res = Invoke-Utf8ConsoleCommand { GitTabExpansionInternal $lastBlock $Global:GitStatus }
+function Expand-GitCommand($Command) {
+    $res = Invoke-Utf8ConsoleCommand { GitTabExpansionInternal $Command $Global:GitStatus }
     $res
 }
 
@@ -403,7 +403,7 @@ if ($PowerTab_RegisterTabExpansion) {
         $line = $Context.Line
         $lastBlock = [regex]::Split($line, '[|;]')[-1].TrimStart()
         $TabExpansionHasOutput.Value = $true
-        GitTabExpansion $lastBlock
+        Expand-GitCommand $lastBlock
     }
     return
 }
@@ -417,9 +417,9 @@ function TabExpansion($line, $lastWord) {
 
     switch -regex ($lastBlock) {
         # Execute git tab completion for all git-related commands
-        "^$(Get-AliasPattern git) (.*)" { GitTabExpansion $lastBlock }
-        "^$(Get-AliasPattern tgit) (.*)" { GitTabExpansion $lastBlock }
-        "^$(Get-AliasPattern gitk) (.*)" { GitTabExpansion $lastBlock }
+        "^$(Get-AliasPattern git) (.*)" { Expand-GitCommand $lastBlock }
+        "^$(Get-AliasPattern tgit) (.*)" { Expand-GitCommand $lastBlock }
+        "^$(Get-AliasPattern gitk) (.*)" { Expand-GitCommand $lastBlock }
 
         # Fall back on existing tab expansion
         default {

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -24,6 +24,7 @@ PowerShellVersion = '5.0'
 # Functions to export from this module
 FunctionsToExport = @(
     'Add-PoshGitToProfile',
+    'Expand-GitCommand',
     'Format-GitBranchName',
     'Get-GitBranchStatusColor',
     'Get-GitStatus',

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -190,6 +190,7 @@ $ExecutionContext.SessionState.Module.OnRemove = {
 $exportModuleMemberParams = @{
     Function = @(
         'Add-PoshGitToProfile',
+        'Expand-GitCommand',
         'Format-GitBranchName',
         'Get-GitBranchStatusColor',
         'Get-GitDirectory',


### PR DESCRIPTION
Includes #563 and an adjustment to #560 to accommodate ANSI prompt:

<details>

```
~ [PoshGitVcsPrompt error: oops]>$GitPromptSettings.Debug = $true
VERBOSE: PoshGitVcsPrompt error details:

PSMessageDetails      :
Exception             : System.Management.Automation.RuntimeException: oops
TargetObject          : oops
CategoryInfo          : OperationStopped: (oops:String) [], RuntimeException
FullyQualifiedErrorId : oops
ErrorDetails          :
InvocationInfo        : System.Management.Automation.InvocationInfo
ScriptStackTrace      : at <ScriptBlock>, C:\Dev\OSS\posh-git\src\GitPrompt.ps1: line 859
                        at <ScriptBlock>, C:\Dev\OSS\posh-git\src\GitPrompt.ps1: line 850
                        at Global:Write-VcsStatus, C:\Dev\OSS\posh-git\src\GitPrompt.ps1: line 850
                        at <ScriptBlock>, C:\Dev\OSS\posh-git\src\posh-git.psm1: line 76
                        at <ScriptBlock>, <No file>: line 1
PipelineIterationInfo : {}



~ [PoshGitVcsPrompt error: oops]> $GitPromptSettings.AnsiConsole = $false
~ [PoshGitVcsPrompt error: oops
VERBOSE: PoshGitVcsPrompt error details:

PSMessageDetails      :
Exception             : System.Management.Automation.RuntimeException: oops
TargetObject          : oops
CategoryInfo          : OperationStopped: (oops:String) [], RuntimeException
FullyQualifiedErrorId : oops
ErrorDetails          :
InvocationInfo        : System.Management.Automation.InvocationInfo
ScriptStackTrace      : at <ScriptBlock>, C:\Dev\OSS\posh-git\src\GitPrompt.ps1: line 859
                        at <ScriptBlock>, C:\Dev\OSS\posh-git\src\GitPrompt.ps1: line 850
                        at Global:Write-VcsStatus, C:\Dev\OSS\posh-git\src\GitPrompt.ps1: line 850
                        at <ScriptBlock>, C:\Dev\OSS\posh-git\src\posh-git.psm1: line 76
                        at <ScriptBlock>, <No file>: line 1
PipelineIterationInfo : {}



]>
```

</details>