### PR TITLE
Shorten window title text

### DIFF
--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -271,7 +271,7 @@ class PoshGitPromptSettings {
     [string[]]$RepositoriesInWhichToDisableFileStatus = @()
 
     [string]$DescribeStyle = ''
-    [psobject]$WindowTitle = {param($GitStatus, [bool]$IsAdmin) "$(if ($IsAdmin) {'Admin: '})$(if ($GitStatus) {"$($GitStatus.RepoName) [$($GitStatus.Branch)]"} else {Get-PromptPath}) - PowerShell $($PSVersionTable.PSVersion) $([IntPtr]::Size * 8)-bit ($PID)"}
+    [psobject]$WindowTitle = {param($GitStatus, [bool]$IsAdmin) "$(if ($IsAdmin) {'Admin: '})$(if ($GitStatus) {"$($GitStatus.RepoName) [$($GitStatus.Branch)]"} else {Get-PromptPath}) ~ PowerShell $($PSVersionTable.PSVersion) $([IntPtr]::Size * 8)-bit ($PID)"}
 
     [PoshGitTextSpan]$DefaultPromptPrefix       = ''
     [PoshGitTextSpan]$DefaultPromptPath         = '$(Get-PromptPath)'

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -271,7 +271,7 @@ class PoshGitPromptSettings {
     [string[]]$RepositoriesInWhichToDisableFileStatus = @()
 
     [string]$DescribeStyle = ''
-    [psobject]$WindowTitle = {param($GitStatus, [bool]$IsAdmin) "$(if ($IsAdmin) {'Administrator: '})$(if ($GitStatus) {"posh~git ~ $($GitStatus.RepoName) [$($GitStatus.Branch)] ~ "})PowerShell $($PSVersionTable.PSVersion) $([IntPtr]::Size * 8)-bit ($PID)"}
+    [psobject]$WindowTitle = {param($GitStatus, [bool]$IsAdmin) "$(if ($IsAdmin) {'Admin: '})$(if ($GitStatus) {"$($GitStatus.RepoName) [$($GitStatus.Branch)]"} else {Get-PromptPath}) - PowerShell $($PSVersionTable.PSVersion) $([IntPtr]::Size * 8)-bit ($PID)"}
 
     [PoshGitTextSpan]$DefaultPromptPrefix       = ''
     [PoshGitTextSpan]$DefaultPromptPath         = '$(Get-PromptPath)'

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -300,8 +300,10 @@ function Get-PromptPath {
 
     $stringComparison = Get-PathStringComparison
 
-    # Abbreviate path by replacing beginning of path with ~ *iff* the path is in the user's home dir
-    if ($abbrevHomeDir -and $currentPath -and $currentPath.StartsWith($Home, $stringComparison)) {
+    # Abbreviate path by replacing beginning of path with ~ *iff* the path is under the user's home dir
+    if ($abbrevHomeDir -and $currentPath -and !$currentPath.Equals($Home, $stringComparison) -and
+        $currentPath.StartsWith($Home, $stringComparison)) {
+
         $currentPath = "~" + $currentPath.SubString($Home.Length)
     }
 

--- a/test/DefaultPrompt.Tests.ps1
+++ b/test/DefaultPrompt.Tests.ps1
@@ -217,13 +217,13 @@ Describe 'Default Prompt WindowTitle Tests' {
         $homePath = [regex]::Escape((GetHomePath))
 
         [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-        $repoAdminRegex = '^Admin: posh-git \[master\] - PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \d\d-bit \(\d+\)$'
+        $repoAdminRegex = '^Admin: posh-git \[master\] \~ PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \d\d-bit \(\d+\)$'
         [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-        $repoRegex = '^posh-git \[master\] - PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \d\d-bit \(\d+\)$'
+        $repoRegex = '^posh-git \[master\] \~ PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \d\d-bit \(\d+\)$'
         [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-        $nonRepoAdminRegex = '^Admin: ' + $homePath + ' - PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \d\d-bit \(\d+\)$'
+        $nonRepoAdminRegex = '^Admin: ' + $homePath + ' \~ PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \d\d-bit \(\d+\)$'
         [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-        $nonRepoRegex = '^' + $homePath + ' - PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \d\d-bit \(\d+\)$'
+        $nonRepoRegex = '^' + $homePath + ' \~ PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \d\d-bit \(\d+\)$'
     }
     AfterAll {
         $global:PSDefaultParameterValues = $originalDefaultParameterValues

--- a/test/DefaultPrompt.Tests.ps1
+++ b/test/DefaultPrompt.Tests.ps1
@@ -46,7 +46,7 @@ Describe 'Default Prompt Tests - NO ANSI' {
             Set-Location $Home -ErrorAction Stop
             $GitPromptSettings.DefaultPromptAbbreviateHomeDirectory = $true
             $res = [string](&$prompt *>&1)
-            $res | Should BeExactly "~> "
+            $res | Should BeExactly "$(GetHomePath)> "
         }
         It 'Returns the expected prompt string with DefaultPromptAbbreviateHomeDirectory disabled' {
             Set-Location $Home -ErrorAction Stop
@@ -60,7 +60,7 @@ Describe 'Default Prompt Tests - NO ANSI' {
             $GitPromptSettings.DefaultPromptSuffix.Text = ' - $(6*7)> '
             $GitPromptSettings.DefaultPromptAbbreviateHomeDirectory = $true
             $res = [string](&$prompt *>&1)
-            $res | Should BeExactly "[$(hostname)] ~ - 42> "
+            $res | Should BeExactly "[$(hostname)] $(GetHomePath) - 42> "
         }
         It 'Returns the expected prompt string with prompt timing enabled' {
             Set-Location $Home -ErrorAction Stop
@@ -154,7 +154,7 @@ Describe 'Default Prompt Tests - ANSI' {
             $GitPromptSettings.DefaultPromptPath.ForegroundColor = [ConsoleColor]::DarkCyan
             $GitPromptSettings.DefaultPromptPath.BackgroundColor = [ConsoleColor]::DarkRed
             $res = &$prompt
-            $res | Should BeExactly "${csi}36m${csi}41m~${csi}0m> "
+            $res | Should BeExactly "${csi}36m${csi}41m$(GetHomePath)${csi}0m> "
         }
         It 'Returns the expected prompt string with prefix, suffix and abbrev home set' {
             Set-Location $Home -ErrorAction Stop
@@ -164,7 +164,7 @@ Describe 'Default Prompt Tests - ANSI' {
             $GitPromptSettings.DefaultPromptSuffix.ForegroundColor = [ConsoleColor]::DarkBlue
             $GitPromptSettings.DefaultPromptAbbreviateHomeDirectory = $true
             $res = &$prompt
-            $res | Should BeExactly "${csi}38;2;245;245;245m[$(hostname)] ${csi}0m~${csi}34m - 42> ${csi}0m"
+            $res | Should BeExactly "${csi}38;2;245;245;245m[$(hostname)] ${csi}0m$(GetHomePath)${csi}34m - 42> ${csi}0m"
         }
         It 'Returns the expected prompt string with prompt timing enabled' {
             Set-Location $Home -ErrorAction Stop
@@ -214,14 +214,16 @@ Describe 'Default Prompt WindowTitle Tests' {
             $PSDefaultParameterValues["it:skip"] = $true
         }
 
+        $homePath = [regex]::Escape((GetHomePath))
+
         [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-        $repoAdminRegex = '^Administrator: posh~git ~ posh-git \[master\] ~ PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \d\d-bit \(\d+\)$'
+        $repoAdminRegex = '^Admin: posh-git \[master\] - PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \d\d-bit \(\d+\)$'
         [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-        $repoRegex = '^posh~git ~ posh-git \[master\] ~ PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \d\d-bit \(\d+\)$'
+        $repoRegex = '^posh-git \[master\] - PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \d\d-bit \(\d+\)$'
         [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-        $nonRepoAdminRegex = '^Administrator: PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \d\d-bit \(\d+\)$'
+        $nonRepoAdminRegex = '^Admin: ' + $homePath + ' - PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \d\d-bit \(\d+\)$'
         [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-        $nonRepoRegex = '^PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \d\d-bit \(\d+\)$'
+        $nonRepoRegex = '^' + $homePath + ' - PowerShell \d+\.\d+\.\d+(\.\d+|-\S+)? \d\d-bit \(\d+\)$'
     }
     AfterAll {
         $global:PSDefaultParameterValues = $originalDefaultParameterValues

--- a/test/Shared.ps1
+++ b/test/Shared.ps1
@@ -40,7 +40,7 @@ function global:Convert-NativeLineEnding([string]$content, [switch]$SplitLines) 
 }
 
 function GetHomePath() {
-    if ($GitPromptSettings.DefaultPromptAbbreviateHomeDirectory) {"~"} else {$HOME}
+    $Home
 }
 
 function GetHomeRelPath([string]$Path) {


### PR DESCRIPTION
Modify Get-PromptPath to return full dir when path is equal to $Home.
It will use ~ when path is a subdir *under* $HOME.

This does not address other path shortening techniques.
We could do those in this PR or another one.

Fixes #565 

Also I think this supersedes PR #538 for the 1.x branch.
