### PR TITLE
Update subcommand lists

### DIFF
--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -6,16 +6,31 @@ $Global:GitTabSettings = New-Object PSObject -Property @{
 }
 
 $subcommands = @{
-    bisect = 'start bad good skip reset visualize replay log run'
-    notes = 'edit show'
-    reflog = 'expire delete show'
-    remote = 'add rename rm set-head show prune update'
-    stash = 'list show drop pop apply branch save clear create'
-    submodule = 'add status init update summary foreach sync'
-    svn = 'init fetch clone rebase dcommit branch tag log blame find-rev set-tree create-ignore show-ignore mkdirs commit-diff info proplist propget show-externals gc reset'
-    tfs = 'bootstrap checkin checkintool ct cleanup cleanup-workspaces clone diagnostics fetch help init pull quick-clone rcheckin shelve shelve-list unshelve verify'
-    flow = 'init feature bugfix release hotfix support help version config finish delete publish rebase'
-    worktree = 'add list prune'
+    bisect = "start bad good skip reset visualize replay log run"
+    notes = 'add append copy edit get-ref list merge prune remove show'
+    reflog = "show delete expire"
+    remote = "
+        add rename remove set-head set-branches
+        get-url set-url show prune update
+        "
+    rerere = "clear forget diff remaining status gc"
+    stash = 'push save list show apply clear drop pop create branch'
+    submodule = "add status init deinit update summary foreach sync"
+    svn = "
+        init fetch clone rebase dcommit log find-rev
+        set-tree commit-diff info create-ignore propget
+        proplist show-ignore show-externals branch tag blame
+        migrate mkdirs reset gc
+        "
+    tfs = "
+        list-remote-branches clone quick-clone bootstrap init
+        clone fetch pull quick-clone unshelve shelve-list labels
+        rcheckin checkin checkintool shelve shelve-delete
+        branch
+        info cleanup cleanup-workspaces help verify autotag subtree reset-remote checkout
+        "
+    flow = "init feature release hotfix support help version"
+    worktree = "add list lock move prune remove unlock"
 }
 
 $gitflowsubcommands = @{
@@ -29,7 +44,7 @@ $gitflowsubcommands = @{
 }
 
 function script:gitCmdOperations($commands, $command, $filter) {
-    $commands.$command -split ' ' | Where-Object { $_ -like "$filter*" }
+    $commands.$command.Trim() -split '\s+' | Where-Object { $_ -like "$filter*" }
 }
 
 $script:someCommands = @('add','am','annotate','archive','bisect','blame','branch','bundle','checkout','cherry',

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -4,6 +4,40 @@ Describe 'TabExpansion Tests' {
     It 'Exports a TabExpansion function' {
         $module.ExportedFunctions.Keys -contains 'TabExpansion' | Should Be $true
     }
+    Context 'Subcommand TabExpansion Tests' {
+        It 'Tab completes without subcommands' {
+            $result = & $module GitTabExpansionInternal 'git whatever '
+
+            $result | Should Be @()
+        }
+        It 'Tab completes bisect subcommands' {
+            $result = & $module GitTabExpansionInternal 'git bisect '
+
+            $result -contains '' | Should Be $false
+            $result -contains 'start' | Should Be $true
+            $result -contains 'run' | Should Be $true
+
+            $result2 = & $module GitTabExpansionInternal 'git bisect s'
+
+            $result2 -contains 'start' | Should Be $true
+            $result2 -contains 'skip' | Should Be $true
+        }
+        It 'Tab completes remote subcommands' {
+            $result = & $module GitTabExpansionInternal 'git remote '
+
+            $result -contains '' | Should Be $false
+            $result -contains 'add' | Should Be $true
+            $result -contains 'set-branches' | Should Be $true
+            $result -contains 'get-url' | Should Be $true
+            $result -contains 'update' | Should Be $true
+
+            $result2 = & $module GitTabExpansionInternal 'git remote s'
+
+            $result2 -contains 'set-branches' | Should Be $true
+            $result2 -contains 'set-head' | Should Be $true
+            $result2 -contains 'set-url' | Should Be $true
+        }
+    }
     Context 'Fetch/Push/Pull TabExpansion Tests' {
         BeforeEach {
             # Ensure master branch exists


### PR DESCRIPTION
Fix #561, among other gaps in subcommand lists. To make further maintenance easier, I just copy/pasted the various `subcommands` lists from [`git-completion.bash`](https://github.com/git/git/blob/1f1cddd558b54bb0ce19c8ace353fd07b758510d/contrib/completion/git-completion.bash), e.g.

https://github.com/git/git/blob/1f1cddd558b54bb0ce19c8ace353fd07b758510d/contrib/completion/git-completion.bash#L2593-L2596

And from `git-flow-completion`:

https://github.com/bobthecow/git-flow-completion/blob/44e4872df089128a6714f5ff39f917b7d7b0f52b/git-flow-completion.bash#L50

git-tfs doesn't have a bash completion, that I can find, but I've updated its command list from https://github.com/git-tfs/git-tfs#use-git-tfs.