### PR TITLE
Release v1.0.0-beta2

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ You can also tab complete remote names and branch names e.g.: `git pull or<tab> 
 
 #### Releases
 
+- v1.0.0-beta2
+  ( [README][v1b2-readme] • [CHANGELOG][v1b2-change] )
 - v1.0.0-beta1
   ( [README][v1b1-readme] • [CHANGELOG][v1b1-change] )
 
@@ -423,7 +425,7 @@ function prompt {
 [choco-site]:      https://chocolatey.org/packages/poshgit/
 [psgallery-img]:   https://img.shields.io/powershellgallery/dt/posh-git.svg
 [psgallery-site]:  https://www.powershellgallery.com/packages/posh-git
-[psgallery-v1]:    https://www.powershellgallery.com/packages/posh-git/1.0.0-beta1
+[psgallery-v1]:    https://www.powershellgallery.com/packages/posh-git/1.0.0-beta2
 [w3c-colors]:      https://www.w3schools.com/colors/colors_names.asp
 
 [prompt-def-long]: https://github.com/dahlbyk/posh-git/wiki/images/PromptDefaultLong.png   "~\GitHub\posh-git [master ≡ +0 ~1 -0 | +0 ~1 -0 !]> "
@@ -452,5 +454,8 @@ function prompt {
 
 [v1b1-change]:     https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta1/CHANGELOG.md
 [v1b1-readme]:     https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta1/README.md
+
+[v1b2-change]:     https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta2/CHANGELOG.md
+[v1b2-readme]:     https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta2/README.md
 
 [wiki-custom-prompt]: https://github.com/dahlbyk/posh-git/wiki/Customizing-Your-PowerShell-Prompt

--- a/chocolatey/poshgit.nuspec
+++ b/chocolatey/poshgit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>poshgit</id>
     <title>posh-git</title>
-    <version>1.0.0-beta2</version>
+    <version>1.0.0-beta2x</version>
     <authors>Keith Dahlby, Mark Embling, Jeremy Skinner, Keith Hill</authors>
     <owners>Keith Dahlby</owners>
     <description>### posh-git
@@ -27,7 +27,7 @@ Note on performance: displaying file status in the git prompt for a very large r
     <summary>Provides prompt with Git status summary information and tab completion for Git commands, parameters, remotes and branch names.</summary>
     <tags>poshgit posh-git powershell git</tags>
     <projectUrl>https://github.com/dahlbyk/posh-git</projectUrl>
-    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta2/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/master/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
       <dependency id="chocolatey" version="0.9.10" />

--- a/chocolatey/poshgit.nuspec
+++ b/chocolatey/poshgit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>poshgit</id>
     <title>posh-git</title>
-    <version>1.0.0-beta1x</version>
+    <version>1.0.0-beta2</version>
     <authors>Keith Dahlby, Mark Embling, Jeremy Skinner, Keith Hill</authors>
     <owners>Keith Dahlby</owners>
     <description>### posh-git
@@ -27,7 +27,7 @@ Note on performance: displaying file status in the git prompt for a very large r
     <summary>Provides prompt with Git status summary information and tab completion for Git commands, parameters, remotes and branch names.</summary>
     <tags>poshgit posh-git powershell git</tags>
     <projectUrl>https://github.com/dahlbyk/posh-git</projectUrl>
-    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/master/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta2/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
       <dependency id="chocolatey" version="0.9.10" />

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -4,7 +4,7 @@
 RootModule = 'posh-git.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.0.0'
+ModuleVersion = '1.0.0'
 
 # ID used to uniquely identify this module
 GUID = '74c9fd30-734b-4c89-a8ae-7727ad21d1d5'
@@ -66,16 +66,16 @@ PrivateData = @{
         Tags = @('git', 'prompt', 'tab', 'tab-completion', 'tab-expansion', 'tabexpansion', 'PSEdition_Core')
 
         # A URL to the license for this module.
-        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/master/LICENSE.txt'
+        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta2/LICENSE.txt'
 
         # A URL to the main website for this project.
         ProjectUri = 'https://github.com/dahlbyk/posh-git'
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/master/CHANGELOG.md'
+        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta2/CHANGELOG.md'
 
         # OVERRIDE THIS FIELD FOR PUBLISHED RELEASES - LEAVE AT 'alpha' FOR CLONED/LOCAL REPO USAGE
-        Prerelease = 'beta1x'
+        Prerelease = 'beta2'
     }
 }
 

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -4,7 +4,7 @@
 RootModule = 'posh-git.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.0'
+ModuleVersion = '1.0.0.0'
 
 # ID used to uniquely identify this module
 GUID = '74c9fd30-734b-4c89-a8ae-7727ad21d1d5'
@@ -66,16 +66,16 @@ PrivateData = @{
         Tags = @('git', 'prompt', 'tab', 'tab-completion', 'tab-expansion', 'tabexpansion', 'PSEdition_Core')
 
         # A URL to the license for this module.
-        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta2/LICENSE.txt'
+        LicenseUri = 'https://github.com/dahlbyk/posh-git/blob/master/LICENSE.txt'
 
         # A URL to the main website for this project.
         ProjectUri = 'https://github.com/dahlbyk/posh-git'
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/v1.0.0-beta2/CHANGELOG.md'
+        ReleaseNotes = 'https://github.com/dahlbyk/posh-git/blob/master/CHANGELOG.md'
 
         # OVERRIDE THIS FIELD FOR PUBLISHED RELEASES - LEAVE AT 'alpha' FOR CLONED/LOCAL REPO USAGE
-        Prerelease = 'beta2'
+        Prerelease = 'beta2x'
     }
 }
 


### PR DESCRIPTION
Following on from #542, I've tagged v1.0.0-beta2 and released to PowerShell Gallery. I'm trying to remember if there was a reason I didn't publish v1.0.0-beta1 to the Chocolatey Gallery as well...? Anyway, I'm holding off on that until I convince myself it's not an issue. Maybe I was thinking we shouldn't publish anything 1.0 to Chocolatey until we know how 1.0 is going to work with Chocolatey? Seems reasonable...

@rkeithhill since you tend to kick off the release process with a PR to update the changelog, feel free to name those as release branches and we can do this all at once (e.g. beta1 was tagged in #521).