### PR TITLE
Install module to 'Program Files' and remove modifying $PROFILE

### DIFF
--- a/chocolatey/poshgit.nuspec
+++ b/chocolatey/poshgit.nuspec
@@ -25,10 +25,13 @@ See profile.example.ps1 as to how you can integrate the tab completion and/or gi
 Note on performance: displaying file status in the git prompt for a very large repo can be prohibitively slow. Rather than turn off file status entirely, you can disable it on a repo-by-repo basis by adding individual repository paths to `$GitPromptSettings.RepositoriesInWhichToDisableFileStatus`.
     </description>
     <summary>Provides prompt with Git status summary information and tab completion for Git commands, parameters, remotes and branch names.</summary>
-    <tags>poshgit posh-git powershell git</tags>
+    <tags>admin posh-git powershell module git</tags>
     <projectUrl>https://github.com/dahlbyk/posh-git</projectUrl>
     <licenseUrl>https://github.com/dahlbyk/posh-git/blob/v0/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <packageSourceUrl>https://github.com/dahlbyk/posh-git</packageSourceUrl>
+    <docsUrl>https://github.com/pauby/posh-git/blob/master/README.md</docsUrl>
+    <bugTrackerUrl>https://github.com/dahlbyk/posh-git/issues</bugTrackerUrl>
     <dependencies>
       <dependency id="chocolatey" version="0.9.10" />
       <dependency id="git" />

--- a/chocolatey/tools/chocolateyBeforeModify.ps1
+++ b/chocolatey/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,4 @@
+$ErrorActionPreference = 'Stop'
+
+$moduleName = 'posh-git'     # this could be different from package name
+Remove-Module -Name $moduleName -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
This is the Chocolatey package install / uninstall files I use which copies the embedded module to the `Program Files\WindowsPowerShell\Modules` folder. 

The module itself is embedded into the package for easier distribution and I do this using an automatic update script. As you're not using that then simply add the code you want to distribute into a folder called `posh-git` within the tools folder. Inside the `posh-git` folder should be the code itself. The installer script takes care of creating a version folder if needed for PS 5+.

See my other modules for PSScriptAnalyzer, PSCodeHealth, Plaster, PlatyPS, PSStringTemplate and EditorServicesCommandSuite [here](https://github.com/pauby/ChocoPackages/tree/master/automatic) for more info.