### PR TITLE
Initial support for vsts-cli

### DIFF
--- a/src/GitParamTabExpansion.ps1
+++ b/src/GitParamTabExpansion.ps1
@@ -81,6 +81,30 @@ $longGitParams = @{
     whatchanged = 'since'
 }
 
+$shortVstsGlobal = 'h o'
+$shortVstsParams = @{
+    abandon = "i $shortVstsGlobal"
+    create = "d i p r s t $shortVstsGlobal"
+    complete = "i $shortVstsGlobal"
+    list = "i p r s t $shortVstsGlobal"
+    reactivate = "i $shortVstsGlobal"
+    'set-vote' = "i $shortVstsGlobal"
+    show = "i $shortVstsGlobal"
+    update = "d i $shortVstsGlobal"
+}
+
+$longVstsGlobal = 'debug help output query verbose'
+$longVstsParams = @{
+    abandon = "id detect instance $longVstsGlobal"
+    create = "auto-complete delete-source-branch work-items bypass-policy bypass-policy-reason description detect instance merge-commit-message open project repository reviewers source-branch squash target-branch title $longVstsGlobal"
+    complete = "id detect instance $longVstsGlobal"
+    list = " $longVstsGlobal"
+    reactivate = " $longVstsGlobal"
+    'set-vote' = " $longVstsGlobal"
+    show = " $longVstsGlobal"
+    update = " $longVstsGlobal"
+}
+
 # Variable is used in GitTabExpansion.ps1
 $gitParamValues = @{
     blame = @{

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -276,23 +276,6 @@ function GitTabExpansionInternal($lastBlock, $GitStatus = $null) {
 
     switch -regex ($lastBlock -replace "^$(Get-AliasPattern git) ","") {
 
-        # Handles git pr alias
-        "vsts\.pr\s+(?<op>\S*)$" {
-            gitCmdOperations $subcommands 'vsts.pr' $matches['op']
-        }
-
-        # Handles git pr <cmd> --<param>
-        "vsts\.pr\s+(?<cmd>$vstsCommandsWithLongParams).*--(?<param>\S*)$"
-        {
-            expandLongParams $longVstsParams $matches['cmd'] $matches['param']
-        }
-
-        # Handles git pr <cmd> -<shortparam>
-        "vsts\.pr\s+(?<cmd>$vstsCommandsWithShortParams).*-(?<shortparam>\S*)$"
-        {
-            expandShortParams $shortVstsParams $matches['cmd'] $matches['shortparam']
-        }
-
         # Handles git <cmd> <op>
         "^(?<cmd>$($subcommands.Keys -join '|'))\s+(?<op>\S*)$" {
             gitCmdOperations $subcommands $matches['cmd'] $matches['op']
@@ -436,6 +419,24 @@ function GitTabExpansionInternal($lastBlock, $GitStatus = $null) {
         "^(?<cmd>$gitCommandsWithShortParams).* -(?<shortparam>\S*)$" {
             expandShortParams $shortGitParams $matches['cmd'] $matches['shortparam']
         }
+
+        # Handles git pr alias
+        "vsts\.pr\s+(?<op>\S*)$" {
+            gitCmdOperations $subcommands 'vsts.pr' $matches['op']
+        }
+
+        # Handles git pr <cmd> --<param>
+        "vsts\.pr\s+(?<cmd>$vstsCommandsWithLongParams).*--(?<param>\S*)$"
+        {
+            expandLongParams $longVstsParams $matches['cmd'] $matches['param']
+        }
+
+        # Handles git pr <cmd> -<shortparam>
+        "vsts\.pr\s+(?<cmd>$vstsCommandsWithShortParams).*-(?<shortparam>\S*)$"
+        {
+            expandShortParams $shortVstsParams $matches['cmd'] $matches['shortparam']
+        }
+
     }
 }
 

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -231,21 +231,21 @@ function script:expandGitAlias($cmd, $rest) {
 }
 
 function script:expandLongParams($hash, $cmd, $filter) {
-    $hash[$cmd] -split ' ' |
+    $hash[$cmd].Trim() -split ' ' |
         Where-Object { $_ -like "$filter*" } |
         Sort-Object |
         ForEach-Object { -join ("--", $_) }
 }
 
 function script:expandShortParams($hash, $cmd, $filter) {
-    $hash[$cmd] -split ' ' |
+    $hash[$cmd].Trim() -split ' ' |
         Where-Object { $_ -like "$filter*" } |
         Sort-Object |
         ForEach-Object { -join ("-", $_) }
 }
 
 function script:expandParamValues($cmd, $param, $filter) {
-    $gitParamValues[$cmd][$param] -split ' ' |
+    $gitParamValues[$cmd][$param].Trim() -split ' ' |
         Where-Object { $_ -like "$filter*" } |
         Sort-Object |
         ForEach-Object { -join ("--", $param, "=", $_) }

--- a/test/GitParamTabExpansionVsts.Tests.ps1
+++ b/test/GitParamTabExpansionVsts.Tests.ps1
@@ -6,33 +6,35 @@ Describe 'ParamsTabExpansion VSTS Tests' {
         BeforeEach {
             [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
             $repoPath = NewGitTempRepo
-            &$gitbin config alias.pr "!f() { exec vsts code pr \`"`$`@\`"; }; f"
+
+            # Test with non-standard vsts pr alias name
+            &$gitbin config alias.test-vsts-pr "!f() { exec vsts code pr \`"`$`@\`"; }; f"
         }
         AfterEach {
             RemoveGitTempRepo $repoPath
         }
 
         It 'Tab completes empty for git pr oops parameters values' {
-            $result = & $module GitTabExpansionInternal 'git pr oops --'
+            $result = & $module GitTabExpansionInternal 'git test-vsts-pr oops --'
             $result | Should Be @()
         }
 
         It 'Tab completes empty for git pr oops short parameter values' {
-            $result = & $module GitTabExpansionInternal 'git pr oops -'
+            $result = & $module GitTabExpansionInternal 'git test-vsts-pr oops -'
             $result | Should Be @()
         }
 
         It 'Tab completes git pr create parameters values' {
-            $result = & $module GitTabExpansionInternal 'git pr create --'
+            $result = & $module GitTabExpansionInternal 'git test-vsts-pr create --'
             $result -contains '--auto-complete' | Should Be $true
         }
         It 'Tab completes git pr create auto-complete parameters values' {
-            $result = & $module GitTabExpansionInternal 'git pr create --auto-complete --'
+            $result = & $module GitTabExpansionInternal 'git test-vsts-pr create --auto-complete --'
             $result -contains '--delete-source-branch' | Should Be $true
         }
 
         It 'Tab completes git pr show all parameters values' {
-            $result = & $module GitTabExpansionInternal 'git pr show --'
+            $result = & $module GitTabExpansionInternal 'git test-vsts-pr show --'
             $result -contains '--' | Should Be $false
             $result -contains '--debug' | Should Be $true
             $result -contains '--help' | Should Be $true
@@ -42,7 +44,7 @@ Describe 'ParamsTabExpansion VSTS Tests' {
         }
 
         It 'Tab completes git pr create all short push parameters' {
-            $result = & $module GitTabExpansionInternal 'git pr create -'
+            $result = & $module GitTabExpansionInternal 'git test-vsts-pr create -'
             $result -contains '-d' | Should Be $true
             $result -contains '-i' | Should Be $true
             $result -contains '-p' | Should Be $true

--- a/test/GitParamTabExpansionVsts.Tests.ps1
+++ b/test/GitParamTabExpansionVsts.Tests.ps1
@@ -1,0 +1,43 @@
+. $PSScriptRoot\Shared.ps1
+
+Describe 'ParamsTabExpansion VSTS Tests' {
+    Context 'Push Parameters TabExpansion Tests' {
+        # Create a git alias for 'pr', as if we'd installed vsts-cli
+        BeforeEach {
+            [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
+            $origPath = Get-Location
+            $temp = [System.IO.Path]::GetTempPath()
+            $repoPath = Join-Path $temp ([IO.Path]::GetRandomFileName())
+
+            &$gitbin init $repoPath
+            Set-Location $repoPath
+
+            &$gitbin config alias.pr "!f() { exec vsts code pr \`"`$`@\`"; }; f"
+        }
+        AfterEach {
+            Set-Location $origPath
+            if (Test-Path $repoPath) {
+                Remove-Item $repoPath -Recurse -Force
+            }
+        }
+
+        It 'Tab completes git pr create parameters values' {
+            $result = & $module GitTabExpansionInternal 'git pr create --'
+            $result -contains '--auto-complete' | Should Be $true
+        }
+        It 'Tab completes git pr create auto-complete parameters values' {
+            $result = & $module GitTabExpansionInternal 'git pr create --auto-complete --'
+            $result -contains '--delete-source-branch' | Should Be $true
+        }
+        It 'Tab completes git pr create all short push parameters' {
+            $result = & $module GitTabExpansionInternal 'git pr create -'
+            $result -contains '-d' | Should Be $true
+            $result -contains '-i' | Should Be $true
+            $result -contains '-p' | Should Be $true
+            $result -contains '-r' | Should Be $true
+            $result -contains '-s' | Should Be $true
+            $result -contains '-h' | Should Be $true
+            $result -contains '-o' | Should Be $true
+        }
+    }
+}

--- a/test/GitParamTabExpansionVsts.Tests.ps1
+++ b/test/GitParamTabExpansionVsts.Tests.ps1
@@ -5,20 +5,11 @@ Describe 'ParamsTabExpansion VSTS Tests' {
         # Create a git alias for 'pr', as if we'd installed vsts-cli
         BeforeEach {
             [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-            $origPath = Get-Location
-            $temp = [System.IO.Path]::GetTempPath()
-            $repoPath = Join-Path $temp ([IO.Path]::GetRandomFileName())
-
-            &$gitbin init $repoPath
-            Set-Location $repoPath
-
+            $repoPath = NewGitTempRepo
             &$gitbin config alias.pr "!f() { exec vsts code pr \`"`$`@\`"; }; f"
         }
         AfterEach {
-            Set-Location $origPath
-            if (Test-Path $repoPath) {
-                Remove-Item $repoPath -Recurse -Force
-            }
+            RemoveGitTempRepo $repoPath
         }
 
         It 'Tab completes git pr create parameters values' {

--- a/test/GitParamTabExpansionVsts.Tests.ps1
+++ b/test/GitParamTabExpansionVsts.Tests.ps1
@@ -12,6 +12,16 @@ Describe 'ParamsTabExpansion VSTS Tests' {
             RemoveGitTempRepo $repoPath
         }
 
+        It 'Tab completes empty for git pr oops parameters values' {
+            $result = & $module GitTabExpansionInternal 'git pr oops --'
+            $result | Should Be @()
+        }
+
+        It 'Tab completes empty for git pr oops short parameter values' {
+            $result = & $module GitTabExpansionInternal 'git pr oops -'
+            $result | Should Be @()
+        }
+
         It 'Tab completes git pr create parameters values' {
             $result = & $module GitTabExpansionInternal 'git pr create --'
             $result -contains '--auto-complete' | Should Be $true
@@ -20,6 +30,17 @@ Describe 'ParamsTabExpansion VSTS Tests' {
             $result = & $module GitTabExpansionInternal 'git pr create --auto-complete --'
             $result -contains '--delete-source-branch' | Should Be $true
         }
+
+        It 'Tab completes git pr show all parameters values' {
+            $result = & $module GitTabExpansionInternal 'git pr show --'
+            $result -contains '--' | Should Be $false
+            $result -contains '--debug' | Should Be $true
+            $result -contains '--help' | Should Be $true
+            $result -contains '--output' | Should Be $true
+            $result -contains '--query' | Should Be $true
+            $result -contains '--verbose' | Should Be $true
+        }
+
         It 'Tab completes git pr create all short push parameters' {
             $result = & $module GitTabExpansionInternal 'git pr create -'
             $result -contains '-d' | Should Be $true

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -168,6 +168,14 @@ Describe 'TabExpansion Tests' {
     }
 
     Context 'Vsts' {
+        BeforeEach {
+            [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
+            $repoPath = NewGitTempRepo
+            &$gitbin config alias.pr "!f() { exec vsts code pr \`"`$`@\`"; }; f"
+        }
+        AfterEach {
+            RemoveGitTempRepo $repoPath
+        }
         It 'Tab completes pr options' {
             $result = & $module GitTabExpansionInternal 'git pr '
             $result -contains 'abandon' | Should Be $true

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -167,6 +167,13 @@ Describe 'TabExpansion Tests' {
         }
     }
 
+    Context 'Vsts' {
+        It 'Tab completes pr options' {
+            $result = & $module GitTabExpansionInternal 'git pr '
+            $result -contains 'abandon' | Should Be $true
+        }
+    }
+
     Context 'Add/Reset/Checkout TabExpansion Tests' {
         BeforeEach {
             [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -171,13 +171,15 @@ Describe 'TabExpansion Tests' {
         BeforeEach {
             [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
             $repoPath = NewGitTempRepo
-            &$gitbin config alias.pr "!f() { exec vsts code pr \`"`$`@\`"; }; f"
+
+            # Test with non-standard vsts pr alias name
+            &$gitbin config alias.test-vsts-pr "!f() { exec vsts code pr \`"`$`@\`"; }; f"
         }
         AfterEach {
             RemoveGitTempRepo $repoPath
         }
         It 'Tab completes pr options' {
-            $result = & $module GitTabExpansionInternal 'git pr '
+            $result = & $module GitTabExpansionInternal 'git test-vsts-pr '
             $result -contains 'abandon' | Should Be $true
         }
     }


### PR DESCRIPTION
- Add all `pr` commands and short commands (equivalent to `vsts code pr`)
- Add test for filtering params

Implements #549

Not implemented in this pull request (future work):
- 'subgroups' (work-items set-vote policies)
- other `vsts code` operations (eg. `repo`) 