### PR TITLE
Add support for win10 openssh

### DIFF
--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -517,11 +517,18 @@ function Find-Ssh($program = 'ssh-agent') {
 }
 
 # Loosely based on bash script from http://help.github.com/ssh-key-passphrases/
-function Start-SshAgent(
-    [switch]$Quiet,
+function Start-SshAgent {
+    param(
+       [Parameter(Position = 0)]
+       [ValidateSet("Automatic", "Boot", "Disabled", "Manual", "System")]
+       [string]
+       $StartupType = "Manual",
 
-    [ValidateSet("Automatic", "Boot", "Disabled", "Manual", "System")]
-    [string]$StartupType = 'Manual') {
+       [Parameter()]
+       [switch]
+       $Quiet
+    )
+
     # If we're using the win10 native ssh client,
     # we can just interact with the service directly.
     if (Start-NativeSshAgent -Quiet:$Quiet -StartupType:$StartupType) {

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -439,8 +439,7 @@ function Start-NativeSshAgent([switch]$Quiet, [string]$StartupType = 'Manual') {
     # Enable the servivce if it's disabled and we're an admin
     if ($service.StartType -eq "Disabled") {
         if (Test-Administrator) {
-            # Must pipe rather than calling Set-Service $service or this won't work on PS <= 5.
-            $service | Set-Service -StartupType $StartupType
+            Set-Service "ssh-agent" -StartupType $StartupType
         }
         else {
             Write-Error "The ssh-agent service is disabled. Please start the service and try again."
@@ -454,11 +453,11 @@ function Start-NativeSshAgent([switch]$Quiet, [string]$StartupType = 'Manual') {
         if (!$Quiet) {
             Write-Host "Starting ssh agent service."
         }
-        Start-Service $service
+        Start-Service "ssh-agent"
     }
 
     # Make sure GIT_SSH is set to OpenSSH-Win32
-    setenv 'GIT_SSH' (Get-Command ssh.exe -ErrorAction Ignore | Select-Object -ExpandProperty Path)
+    setenv "GIT_SSH" (Get-Command ssh.exe -ErrorAction Ignore | Select-Object -ExpandProperty Path)
     
     if (!$Quiet) {
         Write-Host "Setting GIT_SSH set to $($env:GIT_SSH)."

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -457,16 +457,21 @@ function Start-NativeSshAgent([switch]$Quiet, [string]$StartupType = 'Manual') {
     }
 
     # Make sure git is configured to use OpenSSH-Win32
-    $hasSshExplicitlySet = git config --global core.sshCommand
+    $sshCommand = (Get-Command ssh.exe -ErrorAction Ignore | Select-Object -ExpandProperty Path).Replace("\", "/")
+    $configuredSshCommand = git config --global core.sshCommand
 
-    if (!$hasSshExplicitlySet) {
-        $path = (Get-Command ssh.exe -ErrorAction Ignore | Select-Object -ExpandProperty Path)
-        if (!$Quiet) {
-            Write-Host "Setting core.sshCommand to $path in .gitconfig"
+    if ($configuredSshCommand) {
+        # If it's already set to something else, warn the user.
+        if ($configuredSshCommand -ne $sshCommand) {
+            Write-Warning "core.sshCommand in your .gitconfig is set to $configuredSshCommand, but it should be set to $sshCommand."
         }
-        $path = $path.Replace("\", "/")
-        $path = "`"$path`""
-        git config --global core.sshCommand $path
+    } 
+    else {
+        if (!$Quiet) {
+            Write-Host "Setting core.sshCommand to $sshCommand in .gitconfig"
+        }
+        $sshCommand = "`"$sshCommand`""
+        git config --global core.sshCommand $sshCommand
     }
 
     Add-SshKey -Quiet:$Quiet

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -457,6 +457,13 @@ function Start-NativeSshAgent([switch]$Quiet, [string]$StartupType = 'Manual') {
         Start-Service $service
     }
 
+    # Make sure GIT_SSH is set to OpenSSH-Win32
+    setenv 'GIT_SSH' (Get-Command ssh.exe -ErrorAction Ignore | Select-Object -ExpandProperty Path)
+    
+    if (!$Quiet) {
+        Write-Host "Setting GIT_SSH set to $($env:GIT_SSH)."
+    }
+
     Add-SshKey -Quiet:$Quiet
 
     return $true

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -613,9 +613,9 @@ function Add-SshKey([switch]$Quiet) {
             # Win10 ssh agent will prompt for key password even if the key has already been added
             # Check to see if any keys have been added. Only add keys if it's empty.
             if (Get-NativeSshAgent) {
-                # Review: Is this safe? Is this string localized in openssh or is it always in English?
-                $empty = (& $sshAdd -L) -eq "The agent has no identities."
-                if (!$empty) {
+                & $sshAdd -L | Out-Null
+                if ($LASTEXITCODE -eq 0) {
+                    # Keys have already been added
                     if (!$Quiet) {
                         Write-Host Keys have already been added to the ssh agent.
                     }

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -416,7 +416,7 @@ function Get-SshAgent() {
 }
 
 function Get-NativeSshAgent {
-    # $IsWindows is defined in PS Core. 
+    # $IsWindows is defined in PS Core.
     if (($PSVersionTable.PSVersion.Major -lt 6) -or $IsWindows) {
         # The ssh.exe binary version must include "OpenSSH"
         # The windows ssh-agent service must exist
@@ -431,7 +431,7 @@ function Get-NativeSshAgent {
 
 function Start-NativeSshAgent([switch]$Quiet, [string]$StartupType = 'Manual') {
     $service = Get-NativeSshAgent
-    
+
     if (!$service) {
         return $false;
     }
@@ -444,7 +444,7 @@ function Start-NativeSshAgent([switch]$Quiet, [string]$StartupType = 'Manual') {
         else {
             Write-Error "The ssh-agent service is disabled. Please start the service and try again."
             # Exit with true so Start-SshAgent doesn't try to do any other work.
-            return $true 
+            return $true
         }
     }
 
@@ -465,7 +465,7 @@ function Start-NativeSshAgent([switch]$Quiet, [string]$StartupType = 'Manual') {
         if ($configuredSshCommand -ne $sshCommand) {
             Write-Warning "core.sshCommand in your .gitconfig is set to $configuredSshCommand, but it should be set to $sshCommand."
         }
-    } 
+    }
     else {
         if (!$Quiet) {
             Write-Host "Setting core.sshCommand to $sshCommand in .gitconfig"
@@ -517,7 +517,11 @@ function Find-Ssh($program = 'ssh-agent') {
 }
 
 # Loosely based on bash script from http://help.github.com/ssh-key-passphrases/
-function Start-SshAgent([switch]$Quiet, [string]$StartupType = 'Manual') {
+function Start-SshAgent(
+    [switch]$Quiet,
+
+    [ValidateSet("Automatic", "Boot", "Disabled", "Manual", "System")]
+    [string]$StartupType = 'Manual') {
     # If we're using the win10 native ssh client,
     # we can just interact with the service directly.
     if (Start-NativeSshAgent -Quiet:$Quiet -StartupType:$StartupType) {

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -456,11 +456,17 @@ function Start-NativeSshAgent([switch]$Quiet, [string]$StartupType = 'Manual') {
         Start-Service "ssh-agent"
     }
 
-    # Make sure GIT_SSH is set to OpenSSH-Win32
-    setenv "GIT_SSH" (Get-Command ssh.exe -ErrorAction Ignore | Select-Object -ExpandProperty Path)
-    
-    if (!$Quiet) {
-        Write-Host "Setting GIT_SSH set to $($env:GIT_SSH)."
+    # Make sure git is configured to use OpenSSH-Win32
+    $hasSshExplicitlySet = git config --global core.sshCommand
+
+    if (!$hasSshExplicitlySet) {
+        $path = (Get-Command ssh.exe -ErrorAction Ignore | Select-Object -ExpandProperty Path)
+        if (!$Quiet) {
+            Write-Host "Setting core.sshCommand to $path in .gitconfig"
+        }
+        $path = $path.Replace("\", "/")
+        $path = "`"$path`""
+        git config --global core.sshCommand $path
     }
 
     Add-SshKey -Quiet:$Quiet

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -23,8 +23,11 @@ if ($psv.Major -lt 3 -and !$NoVersionWarn) {
 if (!$Env:HOME) { $Env:HOME = "$Env:HOMEDRIVE$Env:HOMEPATH" }
 if (!$Env:HOME) { $Env:HOME = "$Env:USERPROFILE" }
 
-Get-TempEnv 'SSH_AGENT_PID'
-Get-TempEnv 'SSH_AUTH_SOCK'
+if (!(Get-NativeSshAgent)) {
+    # Do not set these variables if we're using the Win10 native SSH agent as it breaks ssh-add.
+    Get-TempEnv 'SSH_AGENT_PID'
+    Get-TempEnv 'SSH_AUTH_SOCK'
+}
 
 # Get the default prompt definition.
 if (($psv.Major -eq 2) -or ![Runspace]::DefaultRunspace.InitialSessionState.Commands) {

--- a/test/Ssh.Tests.ps1
+++ b/test/Ssh.Tests.ps1
@@ -141,7 +141,7 @@ Describe 'SSH Function Tests' {
         It "Doesn't set the sshCommand in .gitconfig if it's already populated" {
             $service.Status = "Running"
             
-            Mock git { return "already-populated-ssh.exe" } -ParameterFilter {
+            Mock git { return "C:/Windows/System32/OpenSSH/ssh.exe" } -ParameterFilter {
                 "$args" -eq "config --global core.sshCommand"
             }
             

--- a/test/Ssh.Tests.ps1
+++ b/test/Ssh.Tests.ps1
@@ -35,8 +35,10 @@ Describe 'SSH Function Tests' {
 
             $sshCommand = New-Object PSObject -Property @{ 
                 FileVersionInfo = @{ProductVersion="OpenSSH"}; 
-                Path = "C:\Windows\System32\OpenSSH\openssh.exe"
+                Path = "C:\Windows\System32\OpenSSH\ssh.exe"
             }
+
+            $gitConfigSsh = ''
 
             Mock Get-Service { return $service } -ParameterFilter { $Name -eq "ssh-agent" }
             Mock Get-Command { return $sshCommand } -ParameterFilter { $Name -eq "ssh.exe" }
@@ -44,6 +46,7 @@ Describe 'SSH Function Tests' {
             Mock Start-Service {} -ParameterFilter { $Name -eq "ssh-agent" }
             Mock Set-Service {} -ParameterFilter { $Name -eq "ssh-agent" }
             Mock Test-Administrator { return $false }
+            Mock git {}
             Mock setenv {}
         }
         AfterEach {
@@ -59,7 +62,7 @@ Describe 'SSH Function Tests' {
             Mock Test-Administrator { return $true }
             $result = Start-NativeSshAgent -Quiet
             $result | Should Be $true
-            Assert-MockCalled Start-Service -Times 1
+            Assert-MockCalled Start-Service -Times 1 -Exactly -Scope It
         }
 
         It "Starts and Enables the service when disabled and user is admin" {
@@ -69,8 +72,8 @@ Describe 'SSH Function Tests' {
             $result = Start-NativeSshAgent -Quiet 
             $result | Should Be $true
 
-            Assert-MockCalled Set-Service -Times 1 -ParameterFilter { $StartupType -eq "Manual" }
-            Assert-MockCalled Start-Service -Times 1
+            Assert-MockCalled Set-Service -Times 1 -Exactly -ParameterFilter { $StartupType -eq "Manual" } -Scope It
+            Assert-MockCalled Start-Service -Times 1 -Exactly -Scope It
         }
         
         It "Doesn't enable the service when user is not an admin" {
@@ -80,8 +83,8 @@ Describe 'SSH Function Tests' {
             $result = Start-NativeSshAgent
             $result | Should Be $true
 
-            Assert-MockCalled Start-Service -Times 0 -Exactly -ParameterFilter { $StartupType -eq "Manual" }
-            Assert-MockCalled Write-Error -ParameterFilter { $Message -eq "The ssh-agent service is disabled. Please start the service and try again." }
+            Assert-MockCalled Start-Service -Times 0 -Exactly -ParameterFilter { $StartupType -eq "Manual" } -Scope It
+            Assert-MockCalled Write-Error -ParameterFilter { $Message -eq "The ssh-agent service is disabled. Please start the service and try again." } -Scope It
         }
 
         It "Adds keys if not already added" {
@@ -125,13 +128,28 @@ Describe 'SSH Function Tests' {
 
             $script:keysAdded | Should Be $false
         }
-        It "Sets the GIT_SSH environment variable" {
+        It "Sets the sshCommand in .gitconfig" {
             $service.Status = "Running"
+            
             $result = Start-NativeSshAgent -Quiet
             
-            Assert-MockCalled setenv -ParameterFilter { 
-                $key -eq 'GIT_SSH' -and $value -eq $sshCommand.Path  
+            Assert-MockCalled git -Times 1 -Exactly -ParameterFilter { 
+                "$args" -eq 'config --global core.sshCommand "C:/Windows/System32/OpenSSH/ssh.exe"'
+            } -Scope It
+        }
+
+        It "Doesn't set the sshCommand in .gitconfig if it's already populated" {
+            $service.Status = "Running"
+            
+            Mock git { return "already-populated-ssh.exe" } -ParameterFilter {
+                "$args" -eq "config --global core.sshCommand"
             }
+            
+            $result = Start-NativeSshAgent -Quiet
+            
+            Assert-MockCalled git -Times 0 -Exactly -ParameterFilter { 
+                "$args" -eq 'config --global core.sshCommand "C:/Windows/System32/OpenSSH/ssh.exe"'
+            } -Scope It
         }
     }
 

--- a/test/Ssh.Tests.ps1
+++ b/test/Ssh.Tests.ps1
@@ -38,8 +38,6 @@ Describe 'SSH Function Tests' {
                 Path = "C:\Windows\System32\OpenSSH\openssh.exe"
             }
 
-            
-
             Mock Get-Service { return $service } -ParameterFilter { $Name -eq "ssh-agent" }
             Mock Get-Command { return $sshCommand } -ParameterFilter { $Name -eq "ssh.exe" }
             Mock Get-Command { return {} } -ParameterFilter { $Name -eq "ssh-add" }
@@ -127,7 +125,6 @@ Describe 'SSH Function Tests' {
 
             $script:keysAdded | Should Be $false
         }
-
         It "Sets the GIT_SSH environment variable" {
             $service.Status = "Running"
             $result = Start-NativeSshAgent -Quiet

--- a/test/Ssh.Tests.ps1
+++ b/test/Ssh.Tests.ps1
@@ -1,4 +1,7 @@
 . $PSScriptRoot\Shared.ps1
+# Need explicit imports as we're testing some functions not exposed by the module.
+. $PSScriptRoot\..\src\Utils.ps1
+. $PSScriptRoot\..\src\GitUtils.ps1
 
 Describe 'SSH Function Tests' {
     Context 'Get-SshPath Tests' {
@@ -21,4 +24,118 @@ Describe 'SSH Function Tests' {
             }
         }
     }
+
+    Context "Win32-OpenSSH Tests" {
+        BeforeEach {
+            $service = New-Object PSObject -Property @{
+                Name = "ssh-agent"
+                StartType = "Manual"
+                Status = "Stopped"
+            }
+
+            $sshCommand = New-Object PSObject -Property @{ 
+                FileVersionInfo = @{ProductVersion="OpenSSH"}; 
+                Path = "C:\Windows\System32\OpenSSH\openssh.exe"
+            }
+
+            
+
+            Mock Get-Service { return $service } -ParameterFilter { $Name -eq "ssh-agent" }
+            Mock Get-Command { return $sshCommand } -ParameterFilter { $Name -eq "ssh.exe" }
+            Mock Get-Command { return {} } -ParameterFilter { $Name -eq "ssh-add" }
+            Mock Start-Service {} -ParameterFilter { $Name -eq "ssh-agent" }
+            Mock Set-Service {} -ParameterFilter { $Name -eq "ssh-agent" }
+            Mock Test-Administrator { return $false }
+            Mock setenv {}
+        }
+        AfterEach {
+            $global:LASTEXITCODE = 0
+        }
+        It "Finds the service" {
+            $result = Get-NativeSshAgent
+            $result | Should Not Be $null
+            $result.Name | Should Be "ssh-agent"
+        }
+
+        It "Starts the service when stopped and user is admin" {
+            Mock Test-Administrator { return $true }
+            $result = Start-NativeSshAgent -Quiet
+            $result | Should Be $true
+            Assert-MockCalled Start-Service -Times 1
+        }
+
+        It "Starts and Enables the service when disabled and user is admin" {
+            $service.StartType = "Disabled"
+            Mock Test-Administrator { return $true }
+
+            $result = Start-NativeSshAgent -Quiet 
+            $result | Should Be $true
+
+            Assert-MockCalled Set-Service -Times 1 -ParameterFilter { $StartupType -eq "Manual" }
+            Assert-MockCalled Start-Service -Times 1
+        }
+        
+        It "Doesn't enable the service when user is not an admin" {
+            $service.StartType = "Disabled"
+            Mock Write-Error
+
+            $result = Start-NativeSshAgent
+            $result | Should Be $true
+
+            Assert-MockCalled Start-Service -Times 0 -Exactly -ParameterFilter { $StartupType -eq "Manual" }
+            Assert-MockCalled Write-Error -ParameterFilter { $Message -eq "The ssh-agent service is disabled. Please start the service and try again." }
+        }
+
+        It "Adds keys if not already added" {
+            $service.Status = "Running"
+            $script:keysAdded = $false
+
+            $block = {
+                # Mock ssh-add -L to set $LASTEXITCODE = 1, meaning no keys are added yet.
+                if ($args[0] -eq "-L") {
+                    $global:LASTEXITCODE = 1
+                }
+                else {
+                    $script:keysAdded = $true;
+                }
+            }
+
+            Mock Get-Command { return $block } -ParameterFilter { $Name -eq "ssh-add" }
+
+            Start-NativeSshAgent -Quiet 
+
+            $script:keysAdded | Should Be $true
+        }
+
+        It "Doesn't add keys if already added" {
+            $service.Status = "Running"
+            $script:keysAdded = $false
+
+            $block = {
+                # Mock ssh-add -L to set $LASTEXITCODE = 0, meaning keys were already added.
+                if ($args[0] -eq "-L") {
+                    $global:LASTEXITCODE = 0
+                }
+                else {
+                    $keysAdded = $true;
+                }
+            }
+
+            Mock Get-Command { return $block } -ParameterFilter { $Name -eq "ssh-add" }
+
+            Start-NativeSshAgent -Quiet 
+
+            $script:keysAdded | Should Be $false
+        }
+
+        It "Sets the GIT_SSH environment variable" {
+            $service.Status = "Running"
+            $result = Start-NativeSshAgent -Quiet
+            
+            Assert-MockCalled setenv -ParameterFilter { 
+                $key -eq 'GIT_SSH' -and $value -eq $sshCommand.Path  
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
@dahlbyk @rkeithhill  As discussed, adds support for the windows 10 native openssh agent (#583) 

- `Get-NativeSshAgent` determines if the Win32-OpenSSH client is installed and the agent service exists
- `Start-NativeSshAgent` will start the service if it's running (and the user is administrator)
- `Start-SshAgent` now calls into `Start-NativeSshAgent` and does no further processing if it returns true.
- `Stop-SshAgent` stops the agent service (if the user is admin)
- If we're using the native agent, then `Add-SshKey` checks to see if keys have already been added as each time you call ssh-add.exe, it'll prompt for the key password again (even if it's already been added)

I didn't want to change `Start-SshAgent` too much as master has already diverged from v0, which is why I added the new function.

A couple of questions that need some thought:
- Is it safe to check if the agent is empty by comparing the output of `ssh-add -L` to `"The agent has no identities."`? Is that string ever likely to be localized?
- If the service can't be started because the user isn't an admin, do we want to display a message or throw an exception?
- Do we want to provide a way to override this? For example if the user wants to force use of ssh.exe that's part of git for windows? At the moment the only way to override this would be editing PATH. 

Please take a look and let me know if you'd like me to change anything.