### PR TITLE
Add Get-PromptConnectionInfo as DefaultPromptPrefix

### DIFF
--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -280,6 +280,7 @@ class PoshGitPromptSettings {
     [PoshGitTextSpan]$DefaultPromptSuffix       = '$(">" * ($nestedPromptLevel + 1)) '
 
     [bool]$DefaultPromptAbbreviateHomeDirectory = $true
+    [string]$DefaultPromptConnectionFormat      = '[{1}@{0}]: '
     [bool]$DefaultPromptWriteStatusFirst        = $false
     [bool]$DefaultPromptEnableTiming            = $false
     [PoshGitTextSpan]$DefaultPromptTimingFormat = ' {0}ms'

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -273,7 +273,7 @@ class PoshGitPromptSettings {
     [string]$DescribeStyle = ''
     [psobject]$WindowTitle = {param($GitStatus, [bool]$IsAdmin) "$(if ($IsAdmin) {'Admin: '})$(if ($GitStatus) {"$($GitStatus.RepoName) [$($GitStatus.Branch)]"} else {Get-PromptPath}) ~ PowerShell $($PSVersionTable.PSVersion) $([IntPtr]::Size * 8)-bit ($PID)"}
 
-    [PoshGitTextSpan]$DefaultPromptPrefix       = ''
+    [PoshGitTextSpan]$DefaultPromptPrefix       = '$(Get-PromptConnectionInfo)'
     [PoshGitTextSpan]$DefaultPromptPath         = '$(Get-PromptPath)'
     [PoshGitTextSpan]$DefaultPromptBeforeSuffix = ''
     [PoshGitTextSpan]$DefaultPromptDebug        = [PoshGitTextSpan]::new(' [DBG]:', [ConsoleColor]::Magenta)

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -273,14 +273,13 @@ class PoshGitPromptSettings {
     [string]$DescribeStyle = ''
     [psobject]$WindowTitle = {param($GitStatus, [bool]$IsAdmin) "$(if ($IsAdmin) {'Admin: '})$(if ($GitStatus) {"$($GitStatus.RepoName) [$($GitStatus.Branch)]"} else {Get-PromptPath}) ~ PowerShell $($PSVersionTable.PSVersion) $([IntPtr]::Size * 8)-bit ($PID)"}
 
-    [PoshGitTextSpan]$DefaultPromptPrefix       = '$(Get-PromptConnectionInfo)'
+    [PoshGitTextSpan]$DefaultPromptPrefix       = '$(Get-PromptConnectionInfo -Format "[{1}@{0}]: ")'
     [PoshGitTextSpan]$DefaultPromptPath         = '$(Get-PromptPath)'
     [PoshGitTextSpan]$DefaultPromptBeforeSuffix = ''
     [PoshGitTextSpan]$DefaultPromptDebug        = [PoshGitTextSpan]::new(' [DBG]:', [ConsoleColor]::Magenta)
     [PoshGitTextSpan]$DefaultPromptSuffix       = '$(">" * ($nestedPromptLevel + 1)) '
 
     [bool]$DefaultPromptAbbreviateHomeDirectory = $true
-    [string]$DefaultPromptConnectionFormat      = '[{1}@{0}]: '
     [bool]$DefaultPromptWriteStatusFirst        = $false
     [bool]$DefaultPromptEnableTiming            = $false
     [PoshGitTextSpan]$DefaultPromptTimingFormat = ' {0}ms'

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -307,7 +307,7 @@ $sshUserName = Get-Runspace | ForEach-Object ConnectionInfo |
 
 function Get-PromptConnectionInfo {
     if (Test-Path Env:SSH_CONNECTION) {
-        if ($sshUserName -and $sshUserName -ne [System.Environment]::UserName) {
+        if ($sshUserName -and $sshUserName -cne [System.Environment]::UserName) {
             "[$sshUserName@$([System.Environment]::MachineName)]: "
         } else {
             "[$([System.Environment]::MachineName)]: "

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -301,14 +301,22 @@ function Get-PromptPath {
     return $currentPath
 }
 
-function Get-PromptConnectionInfo {
+<#
+.SYNOPSIS
+    Gets a string with current machine name and user name when connected with SSH
+.PARAMETER Format
+    Format string to use for displaying machine name ({0}) and user name ({1}).
+    Default: "[{1}@{0}]: ", i.e. "[user@machine]: "
+.INPUTS
+    None
+.OUTPUTS
+    [String]
+#>
+function Get-PromptConnectionInfo($Format = '[{1}@{0}]: ') {
     if ($GitPromptSettings -and (Test-Path Env:SSH_CONNECTION)) {
-        $format = $GitPromptSettings.DefaultPromptConnectionFormat
-        if (!$format) { return }
-
         $MachineName = [System.Environment]::MachineName
         $UserName = [System.Environment]::UserName
-        $format -f $MachineName,$UserName
+        $Format -f $MachineName,$UserName
     }
 }
 

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -302,8 +302,13 @@ function Get-PromptPath {
 }
 
 function Get-PromptConnectionInfo {
-    if (Test-Path Env:SSH_CONNECTION) {
-        "[$([System.Environment]::UserName)@$([System.Environment]::MachineName)]: "
+    if ($GitPromptSettings -and (Test-Path Env:SSH_CONNECTION)) {
+        $format = $GitPromptSettings.DefaultPromptConnectionFormat
+        if (!$format) { return }
+
+        $MachineName = [System.Environment]::MachineName
+        $UserName = [System.Environment]::UserName
+        $format -f $MachineName,$UserName
     }
 }
 

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -301,17 +301,9 @@ function Get-PromptPath {
     return $currentPath
 }
 
-$sshType = 'System.Management.Automation.Runspaces.SSHConnectionInfo' -as [Type]
-$sshUserName = Get-Runspace | ForEach-Object ConnectionInfo |
-  Where-Object { $sshType -and $_ -is $sshType } | ForEach-Object UserName
-
 function Get-PromptConnectionInfo {
     if (Test-Path Env:SSH_CONNECTION) {
-        if ($sshUserName -and $sshUserName -cne [System.Environment]::UserName) {
-            "[$sshUserName@$([System.Environment]::MachineName)]: "
-        } else {
-            "[$([System.Environment]::MachineName)]: "
-        }
+        "[$([System.Environment]::UserName)@$([System.Environment]::MachineName)]: "
     }
 }
 

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -301,6 +301,20 @@ function Get-PromptPath {
     return $currentPath
 }
 
+$sshType = 'System.Management.Automation.Runspaces.SSHConnectionInfo' -as [Type]
+$sshUserName = Get-Runspace | ForEach-Object ConnectionInfo |
+  Where-Object { $sshType -and $_ -is $sshType } | ForEach-Object UserName
+
+function Get-PromptConnectionInfo {
+    if (Test-Path Env:SSH_CONNECTION) {
+        if ($sshUserName -and $sshUserName -ne [System.Environment]::UserName) {
+            "[$sshUserName@$([System.Environment]::MachineName)]: "
+        } else {
+            "[$([System.Environment]::MachineName)]: "
+        }
+    }
+}
+
 function Get-PSModulePath {
     $modulePaths = $Env:PSModulePath -split ';'
     $modulePaths

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -29,6 +29,7 @@ FunctionsToExport = @(
     'Get-GitBranchStatusColor',
     'Get-GitStatus',
     'Get-GitDirectory',
+    'Get-PromptConnectionInfo',
     'Get-PromptPath',
     'Update-AllBranches',
     'Write-GitStatus',

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -194,6 +194,7 @@ $exportModuleMemberParams = @{
         'Get-GitBranchStatusColor',
         'Get-GitDirectory',
         'Get-GitStatus',
+        'Get-PromptConnectionInfo',
         'Get-PromptPath',
         'Update-AllBranches',
         'Write-GitStatus',

--- a/test/Utils.Tests.ps1
+++ b/test/Utils.Tests.ps1
@@ -125,10 +125,10 @@ New-Alias pscore C:\Users\Keith\GitHub\rkeithhill\PowerShell\src\powershell-win-
 
             Get-PromptConnectionInfo | Should BeExactly $null
         }
-        It 'Returns "[hostname]: " if Env:SSH_CONNECTION is set' {
+        It 'Returns "[username@hostname]: " if Env:SSH_CONNECTION is set' {
             Set-Item Env:SSH_CONNECTION 'test'
 
-            Get-PromptConnectionInfo | Should BeExactly "[$([System.Environment]::MachineName)]: "
+            Get-PromptConnectionInfo | Should BeExactly "[$([System.Environment]::UserName)@$([System.Environment]::MachineName)]: "
         }
     }
 

--- a/test/Utils.Tests.ps1
+++ b/test/Utils.Tests.ps1
@@ -103,6 +103,9 @@ New-Alias pscore C:\Users\Keith\GitHub\rkeithhill\PowerShell\src\powershell-win-
 
     Context 'Get-PromptConnectionInfo' {
         BeforeEach {
+            [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
+            $format = $GitPromptSettings.DefaultPromptConnectionFormat
+
             if (Test-Path Env:SSH_CONNECTION) {
                 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
                 $ssh_connection = $Env:SSH_CONNECTION
@@ -111,6 +114,8 @@ New-Alias pscore C:\Users\Keith\GitHub\rkeithhill\PowerShell\src\powershell-win-
             }
         }
         AfterEach {
+            $GitPromptSettings.DefaultPromptConnectionFormat = $format
+
             if ($ssh_connection) {
                 Set-Item Env:SSH_CONNECTION $ssh_connection
             } elseif (Test-Path Env:SSH_CONNECTION) {
@@ -129,6 +134,12 @@ New-Alias pscore C:\Users\Keith\GitHub\rkeithhill\PowerShell\src\powershell-win-
             Set-Item Env:SSH_CONNECTION 'test'
 
             Get-PromptConnectionInfo | Should BeExactly "[$([System.Environment]::UserName)@$([System.Environment]::MachineName)]: "
+        }
+        It 'Returns custom string if Env:SSH_CONNECTION is set with custom format' {
+            Set-Item Env:SSH_CONNECTION 'test'
+            $GitPromptSettings.DefaultPromptConnectionFormat = "[{0}]({1}) "
+
+            Get-PromptConnectionInfo | Should BeExactly "[$([System.Environment]::MachineName)]($([System.Environment]::UserName)) "
         }
     }
 

--- a/test/Utils.Tests.ps1
+++ b/test/Utils.Tests.ps1
@@ -101,6 +101,37 @@ New-Alias pscore C:\Users\Keith\GitHub\rkeithhill\PowerShell\src\powershell-win-
         }
     }
 
+    Context 'Get-PromptConnectionInfo' {
+        BeforeEach {
+            if (Test-Path Env:SSH_CONNECTION) {
+                [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
+                $ssh_connection = $Env:SSH_CONNECTION
+
+                Remove-Item Env:SSH_CONNECTION
+            }
+        }
+        AfterEach {
+            if ($ssh_connection) {
+                Set-Item Env:SSH_CONNECTION $ssh_connection
+            } elseif (Test-Path Env:SSH_CONNECTION) {
+                Remove-Item Env:SSH_CONNECTION
+            }
+        }
+        It 'Returns null if Env:SSH_CONNECTION is not set' {
+            Get-PromptConnectionInfo | Should BeExactly $null
+        }
+        It 'Returns null if Env:SSH_CONNECTION is empty' {
+            Set-Item Env:SSH_CONNECTION ''
+
+            Get-PromptConnectionInfo | Should BeExactly $null
+        }
+        It 'Returns "[hostname]: " if Env:SSH_CONNECTION is set' {
+            Set-Item Env:SSH_CONNECTION 'test'
+
+            Get-PromptConnectionInfo | Should BeExactly "[$([System.Environment]::MachineName)]: "
+        }
+    }
+
     Context 'Test-PoshGitImportedInScript Tests' {
         BeforeEach {
             [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]

--- a/test/Utils.Tests.ps1
+++ b/test/Utils.Tests.ps1
@@ -103,9 +103,6 @@ New-Alias pscore C:\Users\Keith\GitHub\rkeithhill\PowerShell\src\powershell-win-
 
     Context 'Get-PromptConnectionInfo' {
         BeforeEach {
-            [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-            $format = $GitPromptSettings.DefaultPromptConnectionFormat
-
             if (Test-Path Env:SSH_CONNECTION) {
                 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
                 $ssh_connection = $Env:SSH_CONNECTION
@@ -114,8 +111,6 @@ New-Alias pscore C:\Users\Keith\GitHub\rkeithhill\PowerShell\src\powershell-win-
             }
         }
         AfterEach {
-            $GitPromptSettings.DefaultPromptConnectionFormat = $format
-
             if ($ssh_connection) {
                 Set-Item Env:SSH_CONNECTION $ssh_connection
             } elseif (Test-Path Env:SSH_CONNECTION) {
@@ -135,11 +130,10 @@ New-Alias pscore C:\Users\Keith\GitHub\rkeithhill\PowerShell\src\powershell-win-
 
             Get-PromptConnectionInfo | Should BeExactly "[$([System.Environment]::UserName)@$([System.Environment]::MachineName)]: "
         }
-        It 'Returns custom string if Env:SSH_CONNECTION is set with custom format' {
+        It 'Returns formatted string if Env:SSH_CONNECTION is set with -Format' {
             Set-Item Env:SSH_CONNECTION 'test'
-            $GitPromptSettings.DefaultPromptConnectionFormat = "[{0}]({1}) "
 
-            Get-PromptConnectionInfo | Should BeExactly "[$([System.Environment]::MachineName)]($([System.Environment]::UserName)) "
+            Get-PromptConnectionInfo -Format "[{0}]({1}) " | Should BeExactly "[$([System.Environment]::MachineName)]($([System.Environment]::UserName)) "
         }
     }
 


### PR DESCRIPTION
Procrastination!

Closes #591 by roughly imitating https://github.com/PowerShell/PowerShell/pull/7191 (show `[user@host]` if user seems to not match, otherwise `[host]`). I don't use PS remoting, so I'll need some help verifying this works as expected.

Rather than place the logic inline, I figure exporting `Get-PromptConnectionInfo` affords flexibility to make this configurable (e.g. `$GitPromptSettings.DefaultPromptConnectionShowUserName = 'always|never|different'` or `$GitPromptSettings.DefaultPromptConnectionFormatWithUserName`).