### PR TITLE
Do not update WindowTitle at all in prompt func if setting is $null

### DIFF
--- a/src/WindowTitle.ps1
+++ b/src/WindowTitle.ps1
@@ -1,0 +1,51 @@
+$HostSupportsSettingWindowTitle = $null
+
+function Test-WindowTitleIsWriteable {
+    # Probe $Host.UI.RawUI.WindowTitle to see if it can be set without errors
+    $script:HostSupportsSettingWindowTitle = $false
+    try {
+        $global:PoshGitOrigWindowTitle = $Host.UI.RawUI.WindowTitle
+        $newTitle = "${global:PoshGitOrigWindowTitle} "
+        $Host.UI.RawUI.WindowTitle = $newTitle
+        $script:HostSupportsSettingWindowTitle = ($Host.UI.RawUI.WindowTitle -eq $newTitle)
+        $Host.UI.RawUI.WindowTitle = $global:PoshGitOrigWindowTitle
+    }
+    catch {
+        $global:PoshGitOrigWindowTitle = $null
+        Write-Debug "Probing for HostSupportsSettingWindowTitle errored: $_"
+    }
+}
+
+function Reset-WindowTitle {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+    param()
+
+    # Revert original WindowTitle but only if posh-git is currently configured to set it
+    if ($HostSupportsSettingWindowTitle -and $global:GitPromptSettings.WindowTitle -and $global:PoshGitOrigWindowTitle) {
+        $Host.UI.RawUI.WindowTitle = $global:PoshGitOrigWindowTitle
+    }
+}
+
+function Set-WindowTitle {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+    param($GitStatus, $IsAdmin)
+    $settings = $global:GitPromptSettings
+
+    # Update the host's WindowTitle if host supports it and user has not disabled $GitPromptSettings.WindowTitle
+    if ($HostSupportsSettingWindowTitle -and $settings.WindowTitle) {
+        try {
+            if ($settings.WindowTitle -is [scriptblock]) {
+                $windowTitleText = & $settings.WindowTitle $GitStatus $IsAdmin
+            }
+            else {
+                $windowTitleText = $ExecutionContext.SessionState.InvokeCommand.ExpandString("$($settings.WindowTitle)")
+            }
+
+            # Put $windowTitleText in a string to ensure results returned by scriptblock are flattened into a string
+            $Host.UI.RawUI.WindowTitle = "$windowTitleText"
+        }
+        catch {
+            Write-Debug "Error occurred during evaluation of `$GitPromptSettings.WindowTitle: $_"
+        }
+    }
+}

--- a/src/WindowTitle.ps1
+++ b/src/WindowTitle.ps1
@@ -1,17 +1,18 @@
 $HostSupportsSettingWindowTitle = $null
+$OriginalWindowTitle = $null
 
 function Test-WindowTitleIsWriteable {
     if ($null -eq $HostSupportsSettingWindowTitle) {
         # Probe $Host.UI.RawUI.WindowTitle to see if it can be set without errors
         try {
-            $global:PoshGitOrigWindowTitle = $Host.UI.RawUI.WindowTitle
-            $newTitle = "${global:PoshGitOrigWindowTitle} "
+            $script:OriginalWindowTitle = $Host.UI.RawUI.WindowTitle
+            $newTitle = "${OriginalWindowTitle} "
             $Host.UI.RawUI.WindowTitle = $newTitle
             $script:HostSupportsSettingWindowTitle = ($Host.UI.RawUI.WindowTitle -eq $newTitle)
-            $Host.UI.RawUI.WindowTitle = $global:PoshGitOrigWindowTitle
+            $Host.UI.RawUI.WindowTitle = $OriginalWindowTitle
         }
         catch {
-            $global:PoshGitOrigWindowTitle = $null
+            $script:OriginalWindowTitle = $null
             $script:HostSupportsSettingWindowTitle = $false
             Write-Debug "Probing for HostSupportsSettingWindowTitle errored: $_"
         }
@@ -22,10 +23,11 @@ function Test-WindowTitleIsWriteable {
 function Reset-WindowTitle {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
     param()
+    $settings = $global:GitPromptSettings
 
-    # Revert original WindowTitle but only if posh-git is currently configured to set it
-    if ($HostSupportsSettingWindowTitle -and $global:GitPromptSettings.WindowTitle -and $global:PoshGitOrigWindowTitle) {
-        $Host.UI.RawUI.WindowTitle = $global:PoshGitOrigWindowTitle
+    # Revert to original WindowTitle, but only if posh-git is currently configured to set it
+    if ($HostSupportsSettingWindowTitle -and $OriginalWindowTitle -and $settings.WindowTitle) {
+        $Host.UI.RawUI.WindowTitle = $OriginalWindowTitle
     }
 }
 

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -18,8 +18,6 @@ if (!$Env:HOME) { $Env:HOME = "$Env:USERPROFILE" }
 
 $IsAdmin = Test-Administrator
 
-Test-WindowTitleIsWriteable
-
 # Get the default prompt definition.
 $initialSessionState = [Runspace]::DefaultRunspace.InitialSessionState
 if (!$initialSessionState.Commands -or !$initialSessionState.Commands['prompt']) {


### PR DESCRIPTION
We used to restore the previousWindowTitle but this had the effect of
always updating the WindowTitle with a fixed string - whatever we
captured in $PreviousWindowTitle.

However, we still restore the original window title when the module is
removed. But we only do this if the module is configured to supply the
window title.

Rename variable to make its intent clearer.

Fixes #594