### PR TITLE
Rename tabs to match the repo and branch when in powershell ise

### DIFF
--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -209,6 +209,29 @@ function Write-GitStatus {
     }
 
     $sb.ToString()
+
+    # If the user is running Powershell ISE then name the tab
+    if($psISE){
+        $repo = $Status.RepoName
+        $branch = $Status.Branch
+        $tabName = "$repo=>$branch"
+        #you can't have 2 tabs with the same name so shove a number on the end
+        $tabCount = 0
+        foreach($tab in $psISE.PowerShellTabs){
+            $existingTabName = $tab.DisplayName
+            if($existingTabName.StartsWith($tabName) -and $existingTabName -ne $psise.CurrentPowerShellTab.DisplayName){
+                $tabCount++
+                $tabNumber = [int]$existingTabName.Replace($tabName, "").Replace("(", "").Replace(")", "").Trim()
+                if($tabCount -lt $tabNumber + 1){
+                    $tabCount = $tabNumber + 1
+                }
+            }
+        }
+        if($tabCount -gt 0){
+            $tabName= "$tabName ($tabCount)"
+        }
+        $psise.CurrentPowerShellTab.DisplayName = $tabName
+    }
 }
 
 <#

--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -214,7 +214,7 @@ function Write-GitStatus {
     if($psISE){
         $repo = $Status.RepoName
         $branch = $Status.Branch
-        $tabName = "$repo=>$branch"
+        $tabName = "$repo [$branch]"
         #you can't have 2 tabs with the same name so shove a number on the end
         $tabCount = 0
         foreach($tab in $psISE.PowerShellTabs){


### PR DESCRIPTION
I'm not sure if you want to embed IDE specific code in here at all.  If you do this also probably isn't the best place.
However I find this useful.  One of the main reasons I use posh-git is because I can use it in Powershell ISE and use the MDI to have a few repos available at once.
I thought I'd share the code and see if you like it/want to incorporate it in some way.
Cheers,
George