### PR TITLE
Set `$Env:COLUMNS` on prompt if necessary

### DIFF
--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -222,6 +222,7 @@ class PoshGitTextSpan {
 
 class PoshGitPromptSettings {
     [bool]$AnsiConsole = $Host.UI.SupportsVirtualTerminal -or ($Env:ConEmuANSI -eq "ON")
+    [bool]$SetEnvColumns = !(Test-Path Env:COLUMNS)
 
     [PoshGitCellColor]$DefaultColor = [PoshGitCellColor]::new()
     [PoshGitCellColor]$BranchColor  = [PoshGitCellColor]::new([ConsoleColor]::Cyan)

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -222,7 +222,7 @@ class PoshGitTextSpan {
 
 class PoshGitPromptSettings {
     [bool]$AnsiConsole = $Host.UI.SupportsVirtualTerminal -or ($Env:ConEmuANSI -eq "ON")
-    [bool]$SetEnvColumns = !(Test-Path Env:COLUMNS)
+    [bool]$SetEnvColumns = $true
 
     [PoshGitCellColor]$DefaultColor = [PoshGitCellColor]::new()
     [PoshGitCellColor]$BranchColor  = [PoshGitCellColor]::new([ConsoleColor]::Cyan)

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -40,6 +40,11 @@ $GitPromptScriptBlock = {
 
     $origLastExitCode = $global:LASTEXITCODE
 
+    if ($settings.SetEnvColumns) {
+        # Set COLUMNS so git knows how wide the terminal is
+        $Env:COLUMNS = $Host.UI.RawUI.WindowSize.Width
+    }
+
     # Construct/write the prompt text
     $prompt = ''
 


### PR DESCRIPTION
Git uses `COLUMNS`, which is not set by PowerShell, for formatting output (e.g. `git log --stat`). To account for resized windows, we'll set `COLUMNS` to `WindowSize.Width` on every prompt.

Setting `COLUMNS` is currently disabled if it's already set when posh-git loads, or by setting $`GitPromptSettings.SetEnvColumns = $false`.