### PR TITLE
Switch to Register-ArgumentCompleter for tab expansion

### DIFF
--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -443,6 +443,7 @@ function GitTabExpansionInternal($lastBlock, $GitStatus = $null) {
 @('git', 'tgit', 'gitk') | ForEach-Object {
     Register-ArgumentCompleter -CommandName $_ -Native -ScriptBlock {
         param($wordToComplete, $commandAst, $cursorPosition)
-        Expand-GitCommand $commandAst.toString().PadRight($cursorPosition, ' ').substring(0, $cursorPosition)
+        $trimToLength = $cursorPosition - $commandAst.Extent.StartOffset
+        Expand-GitCommand $commandAst.toString().PadRight($trimToLength, ' ').substring(0, $trimToLength)
     }
 }

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -1,9 +1,6 @@
 . $PSScriptRoot\Shared.ps1
 
 Describe 'TabExpansion Tests' {
-    It 'Exports a TabExpansion function' {
-        $module.ExportedFunctions.Keys -contains 'TabExpansion' | Should Be $true
-    }
     Context 'Subcommand TabExpansion Tests' {
         It 'Tab completes without subcommands' {
             $result = & $module GitTabExpansionInternal 'git whatever '


### PR DESCRIPTION
I saw talk of switching to the more modern `Register-ArgumentCompleter` for tab completion.  This is the most minimal implementation of such a switch.  Completion logic is the same.  We register ourselves as a `-Native` completer for `git`, `gitk`, and `tgit`.  When invoked, we convert the command AST into a string, trim it to match what the old completion logic is expecting, and pass it along.