### PR TITLE
Enhance PoshGitTextSpan support for custom VT seqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### Removed
 
-- SSH agent functionality has been removed from `posh-git` and put into another module focused solely on
+- BREAKING: Removed SSH agent functionality from `posh-git` and put into another module focused solely on
   Git SSH support. See [posh-sshell](https://github.com/dahlbyk/posh-sshell).
+- BREAKING: Removed `PoshGitTextSpan.CustomAnsi` property - now just put your custom VT sequences in the
+  `PoshGitTextSpan.Text` property. Be sure to terminate your VT sequences with `"$([char]27)[0m"`
 
 ### Added
 

--- a/src/AnsiUtils.ps1
+++ b/src/AnsiUtils.ps1
@@ -38,10 +38,10 @@ function EscapeAnsiString([string]$AnsiString) {
 function Test-VirtualTerminalSequece([psobject[]]$Object, [switch]$Force) {
     foreach ($obj in $Object) {
         if (($Force -or $global:GitPromptSettings.AnsiConsole) -and ($obj -is [string])) {
-            return $obj.Contains($AnsiEscape)
+            $obj.Contains($AnsiEscape)
         }
         else {
-            return $false
+            $false
         }
     }
 }
@@ -68,7 +68,7 @@ function Get-VirtualTerminalSequence ($color, [int]$offset = 0) {
             Write-Debug $_
         }
 
-        # Hard to get here but DarkYellow is not an HTML color but is a ConsoleColor
+        # Hard to get here but DarkYellow is not an HTML color but it is a ConsoleColor
         if (($color -isnot $ColorType) -and ($null -ne ($consoleColor = $color -as [System.ConsoleColor]))) {
             $color = $consoleColor
         }

--- a/src/AnsiUtils.ps1
+++ b/src/AnsiUtils.ps1
@@ -35,12 +35,14 @@ function EscapeAnsiString([string]$AnsiString) {
     $res
 }
 
-function Test-VirtualTerminalSequece([psobject]$Object) {
-    if ($global:GitPromptSettings.AnsiConsole -and ($Object -is [string])) {
-        return $Object.Contains($AnsiEscape)
-    }
-    else {
-        return $false
+function Test-VirtualTerminalSequece([psobject[]]$Object, [switch]$Force) {
+    foreach ($obj in $Object) {
+        if (($Force -or $global:GitPromptSettings.AnsiConsole) -and ($obj -is [string])) {
+            return $obj.Contains($AnsiEscape)
+        }
+        else {
+            return $false
+        }
     }
 }
 

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -21,22 +21,26 @@ class PoshGitCellColor {
     }
 
     hidden static [string] ToString($color) {
-        $ansiTerm = "$([char]0x1b)[0m"
+        $ansiTerm = "$([char]27)[0m"
         $colorSwatch = "  "
+        $str = ""
 
         if (!$color) {
             $str = "<default>"
         }
-        elseif (Test-VirtualTerminalSequece $color) {
+        elseif (Test-VirtualTerminalSequece $color -Force) {
             $txt = EscapeAnsiString $color
-            $str = "${color}${colorSwatch}${ansiTerm} $txt"
-        }
-        else {
-            $str = ""
 
             if ($global:GitPromptSettings.AnsiConsole) {
+                $str = "${color}${colorSwatch}${ansiTerm} "
+            }
+
+            $str += "$txt"
+        }
+        else {
+            if ($global:GitPromptSettings.AnsiConsole) {
                 $bg = Get-BackgroundVirtualTerminalSequence $color
-                $str += "${bg}${colorSwatch}${ansiTerm} "
+                $str = "${bg}${colorSwatch}${ansiTerm} "
             }
 
             if ($color -is [int]) {
@@ -93,133 +97,113 @@ class PoshGitTextSpan {
     [string]$Text
     [psobject]$BackgroundColor
     [psobject]$ForegroundColor
-    [string]$CustomAnsi
 
     PoshGitTextSpan() {
         $this.Text = ""
         $this.ForegroundColor = $null
         $this.BackgroundColor = $null
-        $this.CustomAnsi = $null
     }
 
     PoshGitTextSpan([string]$Text) {
         $this.Text = $Text
         $this.ForegroundColor = $null
         $this.BackgroundColor = $null
-        $this.CustomAnsi = $null
     }
 
     PoshGitTextSpan([string]$Text, [psobject]$ForegroundColor) {
         $this.Text = $Text
         $this.ForegroundColor = $ForegroundColor
         $this.BackgroundColor = $null
-        $this.CustomAnsi = $null
     }
 
     PoshGitTextSpan([string]$Text, [psobject]$ForegroundColor, [psobject]$BackgroundColor) {
         $this.Text = $Text
         $this.ForegroundColor = $ForegroundColor
         $this.BackgroundColor = $BackgroundColor
-        $this.CustomAnsi = $null
     }
 
     PoshGitTextSpan([PoshGitTextSpan]$PoshGitTextSpan) {
         $this.Text = $PoshGitTextSpan.Text
         $this.ForegroundColor = $PoshGitTextSpan.ForegroundColor
         $this.BackgroundColor = $PoshGitTextSpan.BackgroundColor
-        $this.CustomAnsi = $PoshGitTextSpan.CustomAnsi
     }
 
     PoshGitTextSpan([PoshGitCellColor]$PoshGitCellColor) {
         $this.Text = ''
         $this.ForegroundColor = $PoshGitCellColor.ForegroundColor
         $this.BackgroundColor = $PoshGitCellColor.BackgroundColor
-        $this.CustomAnsi = $null
     }
 
     [PoshGitTextSpan] Expand() {
-        if (!$this.Text -and !$this.CustomAnsi) {
+        if (!$this.Text) {
             return $this
         }
 
         $execContext = Get-Variable ExecutionContext -ValueOnly
-        if ($this.CustomAnsi -and $global:GitPromptSettings.AnsiConsole) {
-            $expandedText = $execContext.SessionState.InvokeCommand.ExpandString($this.CustomAnsi)
-            $newTextSpan = [PoshGitTextSpan]::new($this.Text, $this.ForegroundColor, $this.BackgroundColor)
-            $newTextSpan.CustomAnsi = $expandedText
-        }
-        else {
-            $expandedText = $execContext.SessionState.InvokeCommand.ExpandString($this.Text)
-            $newTextSpan = [PoshGitTextSpan]::new($expandedText, $this.ForegroundColor, $this.BackgroundColor)
-        }
-
+        $expandedText = $execContext.SessionState.InvokeCommand.ExpandString($this.Text)
+        $newTextSpan = [PoshGitTextSpan]::new($expandedText, $this.ForegroundColor, $this.BackgroundColor)
         return $newTextSpan
     }
 
+    # This method is used by Write-Prompt to render an instance of a PoshGitTextSpan and
+    # $GitPromptSettings.AnsiConsole is $true.
     [string] ToAnsiString() {
         $e = [char]27 + "["
+
+        if (!$global:GitPromptSettings.AnsiConsole) {
+            $str = $this.Text
+            if (Test-VirtualTerminalSequece $str -Force) {
+                # ALWAYS terminate a VT seq in case the host supports VT, or the host display can get messed up.
+                $str += "${e}0m"
+            }
+
+            return $str
+        }
+
+        $bg = $this.BackgroundColor
+        if (($null -ne $bg) -and !(Test-VirtualTerminalSequece $bg)) {
+            $bg = Get-BackgroundVirtualTerminalSequence $bg
+        }
+
+        $fg = $this.ForegroundColor
+        if (($null -ne $fg) -and !(Test-VirtualTerminalSequece $fg)) {
+            $fg = Get-ForegroundVirtualTerminalSequence $fg
+        }
+
         $txt = $this.Text
-
-        if ($this.CustomAnsi -and $global:GitPromptSettings.AnsiConsole) {
-            $ansi = $this.CustomAnsi
-            $str = "${ansi}${e}0m"
-        }
-        else {
-            $bg = $this.BackgroundColor
-            if (($null -ne $bg) -and !(Test-VirtualTerminalSequece $bg)) {
-                $bg = Get-BackgroundVirtualTerminalSequence $bg
-            }
-
-            $fg = $this.ForegroundColor
-            if (($null -ne $fg) -and !(Test-VirtualTerminalSequece $fg)) {
-                $fg = Get-ForegroundVirtualTerminalSequence $fg
-            }
-
-            if (($null -ne $fg) -or ($null -ne $bg)) {
-                $str = "${fg}${bg}${txt}${e}0m"
-            }
-            else {
-                $str = $txt
-            }
-        }
+        $str = "${fg}${bg}${txt}${e}0m"
 
         return $str
     }
 
     [string] ToEscapedString() {
-        if ($global:GitPromptSettings.AnsiConsole) {
-            $str = EscapeAnsiString $this.ToAnsiString()
-        }
-        else {
-            $str = $this.Text
-        }
-
+        $str = EscapeAnsiString $this.ToAnsiString()
         return $str
     }
 
+    # This method is used when displaying the "value" of PoshGitTextSpan e.g. when evaluating $GitPromptSettings
     [string] ToString() {
         $sep = " "
         if ($this.Text.Length -lt 2) {
             $sep = " " * (3 - $this.Text.Length)
         }
 
-        if ($global:GitPromptSettings.AnsiConsole) {
-            if ($this.CustomAnsi) {
-                $e = [char]27 + "["
-                $ansi = $this.CustomAnsi
-                $escAnsi = EscapeAnsiString $this.CustomAnsi
-                $txt = $this.ToAnsiString()
-                $str = "CustomAnsi: '${ansi}${escAnsi}${e}0m'"
+        if ((Test-VirtualTerminalSequece $this.Text, $this.ForegroundColor, $this.BackgroundColor -Force) -contains $true) {
+            $txt = $this.ToAnsiString()
+            $escAnsi = "ANSI: '$(EscapeAnsiString $txt)'"
+
+            if ($global:GitPromptSettings.AnsiConsole) {
+                $str = "Text: '$txt',${sep}${escAnsi}"
             }
             else {
-                $color = [PoshGitCellColor]::new($this.ForegroundColor, $this.BackgroundColor)
-                $txt = $this.ToAnsiString()
-                $str = "Text: '$txt',${sep}$($color.ToString())"
+                $str = "${escAnsi}"
             }
+            $escAnsi = "ANSI: '$(EscapeAnsiString $txt)'"
+            $str = "Text: '$txt',${sep}${escAnsi}"
         }
         else {
-            $color = [PoshGitCellColor]::new($this.ForegroundColor, $this.BackgroundColor)
             $txt = $this.Text
+            $color = [PoshGitCellColor]::new($this.ForegroundColor, $this.BackgroundColor)
             $str = "Text: '$txt',${sep}$($color.ToString())"
         }
 

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -20,7 +20,7 @@ class PoshGitCellColor {
         $this.BackgroundColor = $BackgroundColor
     }
 
-    hidden static [string] ToString($color) {
+    hidden [string] ToString($color) {
         $ansiTerm = "$([char]27)[0m"
         $colorSwatch = "  "
         $str = ""
@@ -29,12 +29,17 @@ class PoshGitCellColor {
             $str = "<default>"
         }
         elseif (Test-VirtualTerminalSequece $color -Force) {
-            $txt = EscapeAnsiString $color
-
             if ($global:GitPromptSettings.AnsiConsole) {
-                $str = "${color}${colorSwatch}${ansiTerm} "
+                # Use '#' for FG color swatch since we are just applying the VT seqs as-is and
+                # a " " swatch char won't show anything for a FG color.
+                if ($color -eq $this.ForegroundColor) {
+                    $colorSwatch = "#"
+                }
+
+                $str = "${color}$colorSwatch${ansiTerm} "
             }
 
+            $txt = EscapeAnsiString $color
             $str += "$txt"
         }
         else {
@@ -86,9 +91,9 @@ class PoshGitCellColor {
 
     [string] ToString() {
         $str = "ForegroundColor: "
-        $str += [PoshGitCellColor]::ToString($this.ForegroundColor) + ", "
+        $str += $this.ToString($this.ForegroundColor) + ", "
         $str += "BackgroundColor: "
-        $str += [PoshGitCellColor]::ToString($this.BackgroundColor)
+        $str += $this.ToString($this.BackgroundColor)
         return $str
     }
 }


### PR DESCRIPTION
@dahlbyk See what you think about this.  In the process of explaining for #612 how to use the `CustomAnsi` property on `PoshGitTextSpan` to customize built-in prompt, I realized my previous impl of this idea was too limiting.  For instance before the Path is display the user wanted this displayed in the prompt:

![image](https://user-images.githubusercontent.com/5177512/45003843-f46b4180-afa3-11e8-8055-c67623f6d3a7.png)

The ideal property to use for this info is the `$GitPromptSettings.DefaultPromptPrefix` but there are four different bits of info displayed with different colors.  That currently does NOT work.

My original idea with `CustomAnsi` was that folks could specify a custom sequence that would apply to the text.  That would allow the user to set other attributes like say underline or inverse as well as fg/bg colors.  But that sequence would apply to all of the text so you could have only a single span of text with those attributes.

Now I'm thinking perhaps we should just ditch the `CustomAnsi` property and allow folks to put as much custom seqs in the `Text` field as their heart desires.  For instance, with this change, I can achieve the above desired display with this one setting:
```
function Test-Administrator { $true }

$GitPromptSettings.DefaultPromptPrefix.Text =
    "`n`$(Get-PromptConnectionInfo -Format `"[{1}@{0}]: `")" +
    "`$(if (global:Test-Administrator) {`"$([char]27)[37m^`"})" +
    "$([char]27)[33m`${env:USERNAME}@$([char]27)[95m`${env:COMPUTERNAME}$([char]27)[90m:"
```

Thoughts?