### PR TITLE
Modifying tab completion for files to be relative.

### DIFF
--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -169,7 +169,7 @@ function script:gitTfsShelvesets($filter) {
 }
 
 function script:gitFiles($filter, $gitDir, $files) {
-    [string] $repoDir = Split-Path -Path $gitDir -Parent
+    $repoDir = Split-Path -Path $gitDir -Parent
 
     $files | Sort-Object |
         Where-Object { $_ -like "$filter*" } |

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -168,39 +168,43 @@ function script:gitTfsShelvesets($filter) {
         quoteStringWithSpecialChars
 }
 
-function script:gitFiles($filter, $files) {
+function script:gitFiles($filter, $gitDir, $files) {
+    [string] $repoDir = Split-Path -Path $gitDir -Parent
+
     $files | Sort-Object |
         Where-Object { $_ -like "$filter*" } |
+        ForEach-Object { Join-Path -Path $repoDir -ChildPath $_ } |
+        Resolve-Path -Relative |
         quoteStringWithSpecialChars
 }
 
 function script:gitIndex($GitStatus, $filter) {
-    gitFiles $filter $GitStatus.Index
+    gitFiles $filter $GitStatus.GitDir $GitStatus.Index
 }
 
 function script:gitAddFiles($GitStatus, $filter) {
-    gitFiles $filter (@($GitStatus.Working.Unmerged) + @($GitStatus.Working.Modified) + @($GitStatus.Working.Added))
+    gitFiles $filter $GitStatus.GitDir (@($GitStatus.Working.Unmerged) + @($GitStatus.Working.Modified) + @($GitStatus.Working.Added))
 }
 
 function script:gitCheckoutFiles($GitStatus, $filter) {
-    gitFiles $filter (@($GitStatus.Working.Unmerged) + @($GitStatus.Working.Modified) + @($GitStatus.Working.Deleted))
+    gitFiles $filter $GitStatus.GitDir (@($GitStatus.Working.Unmerged) + @($GitStatus.Working.Modified) + @($GitStatus.Working.Deleted))
 }
 
 function script:gitDiffFiles($GitStatus, $filter, $staged) {
     if ($staged) {
-        gitFiles $filter $GitStatus.Index.Modified
+        gitFiles $filter $GitStatus.GitDir $GitStatus.Index.Modified
     }
     else {
-        gitFiles $filter (@($GitStatus.Working.Unmerged) + @($GitStatus.Working.Modified) + @($GitStatus.Index.Modified))
+        gitFiles $filter $GitStatus.GitDir (@($GitStatus.Working.Unmerged) + @($GitStatus.Working.Modified) + @($GitStatus.Index.Modified))
     }
 }
 
 function script:gitMergeFiles($GitStatus, $filter) {
-    gitFiles $filter $GitStatus.Working.Unmerged
+    gitFiles $filter $GitStatus.GitDir $GitStatus.Working.Unmerged
 }
 
 function script:gitDeleted($GitStatus, $filter) {
-    gitFiles $filter $GitStatus.Working.Deleted
+    gitFiles $filter $GitStatus.GitDir $GitStatus.Working.Deleted
 }
 
 function script:gitAliases($filter) {

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -196,12 +196,13 @@ Describe 'TabExpansion Tests' {
             &$gitbin config core.quotepath true # Problematic (default) config
 
             $fileName = "posh$([char]8226)git.txt"
-            New-Item $fileName -ItemType File
+            $file = New-Item $fileName -ItemType File
+            $expected = ($file | Resolve-Path -Relative)  # ./posh\u8226git.txt or .\posh\u8226git.txt, depending on OS
 
             $gitStatus = & $module Get-GitStatus
 
             $result = & $module GitTabExpansionInternal 'git add ' $gitStatus
-            $result | Should BeExactly $fileName
+            $result | Should BeExactly $expected
         }
     }
 
@@ -299,12 +300,13 @@ Describe 'TabExpansion Tests' {
         }
         It 'Tab completes add file in working dir with special char as quoted' {
             $filename = 'foo{bar} (x86).txt';
-            New-Item $filename -ItemType File
+            $file = New-Item $filename -ItemType File
+            $expected = ($file | Resolve-Path -Relative)  # ./posh\u8226git.txt or .\posh\u8226git.txt, depending on OS
 
             $gitStatus = & $module Get-GitStatus
 
             $result = & $module GitTabExpansionInternal 'git add ' $gitStatus
-            $result | Should BeExactly "'$filename'"
+            $result | Should BeExactly "'$expected'"
         }
     }
 }


### PR DESCRIPTION
Right now if you are in a subdirectory of a Git repository, and you attempt to tab complete a list of files, you get repo-relative paths.

This patch modifies the tab completion to get paths relative to your current path so that the paths can be used properly in git commands like `add`.

I ran the tests by hand (`gci -Filter '*.ps1' .\test\ | ForEach-Object { & $_.FullName }`) and did not find any test differences from master.

Please let me know if you need more information.

Thanks!
\# Chris
