### PR TITLE
Expand PathStatusSeparator

### DIFF
--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -175,7 +175,7 @@ function Write-GitStatus {
 
     # When prompt is first (default), place the separator before the status summary
     if (!$s.DefaultPromptWriteStatusFirst) {
-        $sb | Write-Prompt $s.PathStatusSeparator > $null
+        $sb | Write-Prompt $s.PathStatusSeparator.Expand() > $null
     }
 
     $sb | Write-Prompt $s.BeforeStatus > $null
@@ -205,7 +205,7 @@ function Write-GitStatus {
 
     # When status is first, place the separator after the status summary
     if ($s.DefaultPromptWriteStatusFirst) {
-        $sb | Write-Prompt $s.PathStatusSeparator > $null
+        $sb | Write-Prompt $s.PathStatusSeparator.Expand() > $null
     }
 
     $sb.ToString()
@@ -864,7 +864,7 @@ $PoshGitVcsPrompt = {
 
             # When prompt is first (default), place the separator before the status summary
             if (!$s.DefaultPromptWriteStatusFirst) {
-                $sb | Write-Prompt $s.PathStatusSeparator > $null
+                $sb | Write-Prompt $s.PathStatusSeparator.Expand() > $null
             }
             $sb | Write-Prompt $s.BeforeStatus > $null
 

--- a/test/DefaultPrompt.Tests.ps1
+++ b/test/DefaultPrompt.Tests.ps1
@@ -97,6 +97,44 @@ A  test/Foo.Tests.ps1
             $path = GetHomeRelPath $PSScriptRoot
             $res | Should BeExactly "$path [master +1 ~0 -0 | +0 ~1 -1 !]> "
         }
+
+        It 'Returns the expected prompt string with changed PathStatusSeparator' {
+            Mock -ModuleName posh-git -CommandName git {
+                $OFS = " "
+                if ($args -contains 'rev-parse') {
+                    $res = Invoke-Expression "&$gitbin $args"
+                    return $res
+                }
+                Convert-NativeLineEnding -SplitLines @'
+## master
+
+'@
+            }
+            $GitPromptSettings.PathStatusSeparator.Text = ' !! '
+            $res = [string](&$prompt *>&1)
+            Assert-MockCalled git -ModuleName posh-git -Scope It
+            $path = GetHomeRelPath $PSScriptRoot
+            $res | Should BeExactly "$path !! [master]> "
+        }
+
+        It 'Returns the expected prompt string with expanded PathStatusSeparator' {
+            Mock -ModuleName posh-git -CommandName git {
+                $OFS = " "
+                if ($args -contains 'rev-parse') {
+                    $res = Invoke-Expression "&$gitbin $args"
+                    return $res
+                }
+                Convert-NativeLineEnding -SplitLines @'
+## master
+
+'@
+            }
+            $GitPromptSettings.PathStatusSeparator.Text = ' - $(6*7) '
+            $res = [string](&$prompt *>&1)
+            Assert-MockCalled git -ModuleName posh-git -Scope It
+            $path = GetHomeRelPath $PSScriptRoot
+            $res | Should BeExactly "$path - 42 [master]> "
+        }
     }
 }
 
@@ -201,6 +239,45 @@ A  test/Foo.Tests.ps1
             Assert-MockCalled git -ModuleName posh-git
             $path = GetHomeRelPath $PSScriptRoot
             $res | Should BeExactly "$path ${csi}93m[${csi}0m${csi}96mmaster${csi}0m${csi}32m${csi}49m +1${csi}0m${csi}32m${csi}49m ~0${csi}0m${csi}32m${csi}49m -0${csi}0m${csi}93m |${csi}0m${csi}31m${csi}49m +0${csi}0m${csi}31m${csi}49m ~1${csi}0m${csi}31m${csi}49m -1${csi}0m${csi}31m !${csi}0m${csi}93m]${csi}0m> "
+        }
+
+        It 'Returns the expected prompt string with changed PathStatusSeparator' {
+            Mock -ModuleName posh-git -CommandName git {
+                $OFS = " "
+                if ($args -contains 'rev-parse') {
+                    $res = Invoke-Expression "&$gitbin $args"
+                    return $res
+                }
+                Convert-NativeLineEnding -SplitLines @'
+## master
+
+'@
+            }
+            $GitPromptSettings.PathStatusSeparator.Text = ' !! '
+            $GitPromptSettings.PathStatusSeparator.BackgroundColor = [ConsoleColor]::White
+            $res = [string](&$prompt *>&1)
+            Assert-MockCalled git -ModuleName posh-git -Scope It
+            $path = GetHomeRelPath $PSScriptRoot
+            $res | Should BeExactly "$path${csi}107m !! ${csi}0m${csi}93m[${csi}0m${csi}96mmaster${csi}0m${csi}93m]${csi}0m> "
+        }
+        It 'Returns the expected prompt string with expanded PathStatusSeparator' {
+            Mock -ModuleName posh-git -CommandName git {
+                $OFS = " "
+                if ($args -contains 'rev-parse') {
+                    $res = Invoke-Expression "&$gitbin $args"
+                    return $res
+                }
+                Convert-NativeLineEnding -SplitLines @'
+## master
+
+'@
+            }
+            $GitPromptSettings.PathStatusSeparator.Text = ' [$(hostname)] '
+            $GitPromptSettings.PathStatusSeparator.BackgroundColor = [ConsoleColor]::White
+            $res = [string](&$prompt *>&1)
+            Assert-MockCalled git -ModuleName posh-git -Scope It
+            $path = GetHomeRelPath $PSScriptRoot
+            $res | Should BeExactly "$path${csi}107m [$(hostname)] ${csi}0m${csi}93m[${csi}0m${csi}96mmaster${csi}0m${csi}93m]${csi}0m> "
         }
     }
 }


### PR DESCRIPTION
Maybe it's not too useful, but it seemed like PathStatusSeparator should be expanded like the other parts of the prompt.