### PR TITLE
On Windows PowerShell, defer Add-Type until Set-ConsoleMode executed

### DIFF
--- a/src/ConsoleMode.ps1
+++ b/src/ConsoleMode.ps1
@@ -1,6 +1,10 @@
 # Hack! https://gist.github.com/lzybkr/f2059cb2ee8d0c13c65ab933b75e998c
 
-if ($IsWindows -eq $false) {
+# Always skip setting the console mode on non-Windows platforms.
+# On Windows, *if* we are running in PowerShell Core *and* the host is the "ConsoleHost",
+# rely on PS Core to manage the console mode.  This speeds up module import on standard
+# PowerShell Core on Windows.
+if (($IsWindows -eq $false) -or (($PSVersionTable.PSVersion.Major -ge 6) -and ($host.Name -eq 'ConsoleHost'))) {
     function Set-ConsoleMode {
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
         param()

--- a/src/ConsoleMode.ps1
+++ b/src/ConsoleMode.ps1
@@ -1,9 +1,6 @@
 # Hack! https://gist.github.com/lzybkr/f2059cb2ee8d0c13c65ab933b75e998c
 
-# We do not need to set the console mode in PowerShell Core on any platform.
-# On Windows, PowerShell Core added this support in this PR:
-# https://github.com/PowerShell/PowerShell/pull/2991
-if ($PSVersionTable.PSVersion.Major -ge 6) {
+if ($IsWindows -eq $false) {
     function Set-ConsoleMode {
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
         param()

--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -849,7 +849,7 @@ function Global:Write-VcsStatus {
     Set-ConsoleMode -ANSI
 
     $OFS = ""
-    $sb = [System.Text.StringBuilder]::new(150)
+    $sb = [System.Text.StringBuilder]::new(256)
 
     foreach ($promptStatus in $global:VcsPromptStatuses) {
         [void]$sb.Append("$(& $promptStatus)")


### PR DESCRIPTION
On PS Core, do not set the console mode at all.
PS Core, since the release of 6.0.0 has handled setting/resetting the
console mode, so no need for posh-git to do this. See:
https://github.com/PowerShell/PowerShell/pull/2991

This speeds up module import by ~.5 to .7 seconds on PSCore and by
~150-200 msecs on Windows PowerShell.

Fix #637 and maybe #635