### PR TITLE
Add last checkouts to tabcompletion

### DIFF
--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -101,6 +101,13 @@ function script:gitCommands($filter, $includeAliases) {
     $cmdList | Sort-Object
 }
 
+function script:lastCheckouts($filter){
+    git reflog |
+    Where-Object { $_ -match ': checkout: moving from (.*) to (.*)' } |
+    ForEach-Object { $Matches[1] } |
+    Where-Object { $_ -like "$filter*" }
+}
+
 function script:gitRemotes($filter) {
     git remote |
         Where-Object { $_ -like "$filter*" } |
@@ -387,6 +394,7 @@ function GitTabExpansionInternal($lastBlock, $GitStatus = $null) {
         # Handles git checkout <ref>
         "^(?:checkout).* (?<ref>\S*)$" {
             & {
+                lastCheckouts $matches['ref']
                 gitBranches $matches['ref'] $true
                 gitRemoteUniqueBranches $matches['ref']
                 gitTags $matches['ref']

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -187,7 +187,7 @@ Describe 'TabExpansion Tests' {
     Context 'Add/Reset/Checkout TabExpansion Tests' {
         BeforeEach {
             [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-            $repoPath = NewGitTempRepo
+            $repoPath = NewGitTempRepo -MakeInitialCommit
         }
         AfterEach {
             RemoveGitTempRepo $repoPath
@@ -202,6 +202,17 @@ Describe 'TabExpansion Tests' {
 
             $result = & $module GitTabExpansionInternal 'git add ' $gitStatus
             $result | Should BeExactly $fileName
+        }
+        It 'Tab completes last checkouts first' {
+            &$gitbin checkout -q -b 'test-branch-b' 2>$null
+            &$gitbin checkout -q -b 'test-branch-c' 2>$null
+            &$gitbin checkout -q -b 'test-branch-a' 2>$null
+            &$gitbin checkout -q 'master' 2>$null
+
+            $result = & $module GitTabExpansionInternal 'git checkout '
+            $firstThreeResults = $result[0..2]
+
+            $firstThreeResults | Should -BeExactly @('test-branch-a', 'test-branch-c', 'test-branch-b')
         }
     }
 


### PR DESCRIPTION
Hi, thanks for this great project!
I think this small feature will make it even better ;-)

I really like git [`@{-N}` syntax](https://stackoverflow.com/questions/7206801/is-there-any-way-to-git-checkout-previous-branch) to checkout last used branches. I thought that if posh-git could suggest this last used branches first we would have nice user experience. You could just `Tab` and `Shift+Tab` and quickly choose the recent branch you need to work on again. 

It would be very useful when you work on a lot of branches that have long names and you don't remember the name correctly (for example because it has Jira key at beginning, and who remembers that ;-)).

It looks that git [source code](https://github.com/git/git/blob/cd69ec8cde54af1817630331fc441f493866f0d4/sha1-name.c#L1255) does something very similar to what I have done here to get last checkout commits.