### PR TITLE
Even in PS Core on Windows, we need to set the console mode

### DIFF
--- a/src/ConsoleMode.ps1
+++ b/src/ConsoleMode.ps1
@@ -1,10 +1,7 @@
 # Hack! https://gist.github.com/lzybkr/f2059cb2ee8d0c13c65ab933b75e998c
 
 # Always skip setting the console mode on non-Windows platforms.
-# On Windows, *if* we are running in PowerShell Core *and* the host is the "ConsoleHost",
-# rely on PS Core to manage the console mode.  This speeds up module import on standard
-# PowerShell Core on Windows.
-if (($IsWindows -eq $false) -or (($PSVersionTable.PSVersion.Major -ge 6) -and ($host.Name -eq 'ConsoleHost'))) {
+if (($PSVersionTable.PSVersion.Major -ge 6) -and !$IsWindows) {
     function Set-ConsoleMode {
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
         param()


### PR DESCRIPTION
Without this, I see a garbage prompt after running a command like
measure-command {git stash list}

Which generates this prompt (for my settings):

C:\Users\Keith[38;2;127;127;127m
02-18 15:30:32[0m 32ms 3>

Basically the prompt showed the VT seqs instead of interpreting them