### PR TITLE
fix(status): Only reset changed colors

### DIFF
--- a/src/AnsiUtils.ps1
+++ b/src/AnsiUtils.ps1
@@ -47,6 +47,12 @@ function Test-VirtualTerminalSequece([psobject[]]$Object, [switch]$Force) {
 }
 
 function Get-VirtualTerminalSequence ($color, [int]$offset = 0) {
+    # Don't output ANSI escape sequences if the `$color` parameter is `$null`,
+    # they would be broken anyway
+    if ($null -eq $color) {
+        return $null;
+    }
+
     if ($color -is [byte]) {
         return "${AnsiEscape}$(38 + $offset);5;${color}m"
     }

--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -116,7 +116,7 @@ function Write-Prompt {
             }
             else {
                 # If we know which colors were changed, we can reset only these and leave others be.
-                [System.Collections.Generic.List[string]]$reset = @()
+                $reset = [System.Collections.Generic.List[string]]::new()
                 $e = [char]27 + "["
 
                 $fg = $fgColor
@@ -133,7 +133,8 @@ function Write-Prompt {
 
                 $str = "${Object}"
                 if (Test-VirtualTerminalSequece $str -Force) {
-                    $reset = @('0')
+                    $reset.Clear()
+                    $reset.Add('0')
                 }
 
                 $str = "${fg}${bg}" + $str

--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -119,16 +119,16 @@ function Write-Prompt {
                 [System.Collections.Generic.List[string]]$reset = @()
                 $e = [char]27 + "["
 
-                $bg = $bgColor
-                if (($null -ne $bg) -and !(Test-VirtualTerminalSequece $bg)) {
-                    $bg = Get-BackgroundVirtualTerminalSequence $bg
-                    $reset.Add('49')
-                }
-
                 $fg = $fgColor
                 if (($null -ne $fg) -and !(Test-VirtualTerminalSequece $fg)) {
                     $fg = Get-ForegroundVirtualTerminalSequence $fg
                     $reset.Add('39')
+                }
+
+                $bg = $bgColor
+                if (($null -ne $bg) -and !(Test-VirtualTerminalSequece $bg)) {
+                    $bg = Get-BackgroundVirtualTerminalSequence $bg
+                    $reset.Add('49')
                 }
 
                 $str = "${Object}"

--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -115,10 +115,31 @@ function Write-Prompt {
                 $str = $Object.ToAnsiString()
             }
             else {
+                # If we know which colors were changed, we can reset only these and leave others be.
+                [System.Collections.Generic.List[string]]$reset = @()
                 $e = [char]27 + "["
-                $fg = Get-ForegroundVirtualTerminalSequence $fgColor
-                $bg = Get-BackgroundVirtualTerminalSequence $bgColor
-                $str = "${fg}${bg}${Object}${e}0m"
+
+                $bg = $bgColor
+                if (($null -ne $bg) -and !(Test-VirtualTerminalSequece $bg)) {
+                    $bg = Get-BackgroundVirtualTerminalSequence $bg
+                    $reset.Add('49')
+                }
+
+                $fg = $fgColor
+                if (($null -ne $fg) -and !(Test-VirtualTerminalSequece $fg)) {
+                    $fg = Get-ForegroundVirtualTerminalSequence $fg
+                    $reset.Add('39')
+                }
+
+                $str = "${Object}"
+                if (Test-VirtualTerminalSequece $str -Force) {
+                    $reset = @('0')
+                }
+
+                $str = "${fg}${bg}" + $str
+                if ($reset.Count -gt 0) {
+                    $str += "${e}$($reset -join ';')m"
+                }
             }
 
             return $(if ($StringBuilder) { $StringBuilder.Append($str) } else { $str })

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -157,16 +157,16 @@ class PoshGitTextSpan {
         [System.Collections.Generic.List[string]]$reset = @()
         $e = [char]27 + "["
 
-        $bg = $this.BackgroundColor
-        if (($null -ne $bg) -and !(Test-VirtualTerminalSequece $bg)) {
-            $bg = Get-BackgroundVirtualTerminalSequence $bg
-            $reset.Add('49')
-        }
-
         $fg = $this.ForegroundColor
         if (($null -ne $fg) -and !(Test-VirtualTerminalSequece $fg)) {
             $fg = Get-ForegroundVirtualTerminalSequence $fg
             $reset.Add('39')
+        }
+
+        $bg = $this.BackgroundColor
+        if (($null -ne $bg) -and !(Test-VirtualTerminalSequece $bg)) {
+            $bg = Get-BackgroundVirtualTerminalSequence $bg
+            $reset.Add('49')
         }
 
         $txt = $this.Text

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -154,7 +154,7 @@ class PoshGitTextSpan {
     # implementation to display any ANSI seqs when AnsiConsole is $true.
     [string] ToAnsiString() {
         # If we know which colors were changed, we can reset only these and leave others be.
-        [System.Collections.Generic.List[string]]$reset = @()
+        $reset = [System.Collections.Generic.List[string]]::new()
         $e = [char]27 + "["
 
         $fg = $this.ForegroundColor
@@ -175,7 +175,8 @@ class PoshGitTextSpan {
         # ALWAYS terminate a VT sequence in case the host supports VT (regardless of AnsiConsole setting),
         # or the host display can get messed up.
         if (Test-VirtualTerminalSequece $txt -Force) {
-            $reset = @('0')
+            $reset.Clear()
+            $reset.Add('0')
         }
 
         if ($reset.Count -gt 0) {

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -153,16 +153,20 @@ class PoshGitTextSpan {
     # $GitPromptSettings.AnsiConsole is $true.  It is also used by the default ToString()
     # implementation to display any ANSI seqs when AnsiConsole is $true.
     [string] ToAnsiString() {
+        # If we know which colors were changed, we can reset only these and leave others be.
+        [System.Collections.Generic.List[string]]$reset = @()
         $e = [char]27 + "["
 
         $bg = $this.BackgroundColor
         if (($null -ne $bg) -and !(Test-VirtualTerminalSequece $bg)) {
             $bg = Get-BackgroundVirtualTerminalSequence $bg
+            $reset.Add('49')
         }
 
         $fg = $this.ForegroundColor
         if (($null -ne $fg) -and !(Test-VirtualTerminalSequece $fg)) {
             $fg = Get-ForegroundVirtualTerminalSequence $fg
+            $reset.Add('39')
         }
 
         $txt = $this.Text
@@ -170,8 +174,12 @@ class PoshGitTextSpan {
 
         # ALWAYS terminate a VT sequence in case the host supports VT (regardless of AnsiConsole setting),
         # or the host display can get messed up.
-        if (Test-VirtualTerminalSequece $str -Force) {
-            $str += "${e}0m"
+        if (Test-VirtualTerminalSequece $txt -Force) {
+            $reset = @('0')
+        }
+
+        if ($reset.Count -gt 0) {
+            $str += "${e}$($reset -join ';')m"
         }
 
         return $str

--- a/test/Ansi.Tests.ps1
+++ b/test/Ansi.Tests.ps1
@@ -5,12 +5,12 @@ Describe 'ANSI Tests' {
         It 'Setting BackgroundColor to 0x0 results in Black background' {
             $ts = & $module.NewBoundScriptBlock({[PoshGitTextSpan]::new("TEST", 0xFF0000, 0)})
             $ansiStr = $ts.toAnsiString()
-            $ansiStr | Should BeExactly "${csi}38;2;255;0;0m${csi}48;2;0;0;0mTEST${csi}0m"
+            $ansiStr | Should BeExactly "${csi}38;2;255;0;0m${csi}48;2;0;0;0mTEST${csi}39;49m"
         }
         It 'Setting ForegroundColor to 0x0 results in Black foreground' {
             $ts = & $module.NewBoundScriptBlock({[PoshGitTextSpan]::new("TEST", 0, 0xFFFFFF)})
             $ansiStr = $ts.toAnsiString()
-            $ansiStr | Should BeExactly "${csi}38;2;0;0;0m${csi}48;2;255;255;255mTEST${csi}0m"
+            $ansiStr | Should BeExactly "${csi}38;2;0;0;0m${csi}48;2;255;255;255mTEST${csi}39;49m"
         }
     }
 }

--- a/test/DefaultPrompt.Tests.ps1
+++ b/test/DefaultPrompt.Tests.ps1
@@ -162,7 +162,7 @@ Describe 'Default Prompt Tests - ANSI' {
             $GitPromptSettings.DefaultPromptSuffix.ForegroundColor = [ConsoleColor]::DarkBlue
             $GitPromptSettings.DefaultPromptSuffix.BackgroundColor = 0xFF6000 # Orange
             $res = &$prompt
-            $res | Should BeExactly "$(Get-PromptConnectionInfo)$(GetHomePath)${csi}34m${csi}48;2;255;96;0m`n> ${csi}0m"
+            $res | Should BeExactly "$(Get-PromptConnectionInfo)$(GetHomePath)${csi}34m${csi}48;2;255;96;0m`n> ${csi}39;49m"
         }
         It 'Returns the expected prompt string with expanded DefaultPromptSuffix' {
             Set-Location $Home -ErrorAction Stop
@@ -170,21 +170,21 @@ Describe 'Default Prompt Tests - ANSI' {
             $GitPromptSettings.DefaultPromptSuffix.ForegroundColor = [ConsoleColor]::DarkBlue
             $GitPromptSettings.DefaultPromptSuffix.BackgroundColor = 0xFF6000 # Orange
             $res = &$prompt
-            $res | Should BeExactly "$(Get-PromptConnectionInfo)$(GetHomePath)${csi}34m${csi}48;2;255;96;0m - 42> ${csi}0m"
+            $res | Should BeExactly "$(Get-PromptConnectionInfo)$(GetHomePath)${csi}34m${csi}48;2;255;96;0m - 42> ${csi}39;49m"
         }
         It 'Returns the expected prompt string with changed DefaultPromptPrefix' {
             Set-Location $Home -ErrorAction Stop
             $GitPromptSettings.DefaultPromptPrefix.Text = 'PS '
             $GitPromptSettings.DefaultPromptPrefix.BackgroundColor = [ConsoleColor]::White
             $res = &$prompt
-            $res | Should BeExactly "${csi}107mPS ${csi}0m$(GetHomePath)> "
+            $res | Should BeExactly "${csi}107mPS ${csi}49m$(GetHomePath)> "
         }
         It 'Returns the expected prompt string with expanded DefaultPromptPrefix' {
             Set-Location $Home -ErrorAction Stop
             $GitPromptSettings.DefaultPromptPrefix.Text = '[$(hostname)] '
             $GitPromptSettings.DefaultPromptPrefix.BackgroundColor = 0xF5F5F5
             $res = &$prompt
-            $res | Should BeExactly "${csi}48;2;245;245;245m[$(hostname)] ${csi}0m$(GetHomePath)> "
+            $res | Should BeExactly "${csi}48;2;245;245;245m[$(hostname)] ${csi}49m$(GetHomePath)> "
         }
         It 'Returns the expected prompt path colors' {
             Set-Location $Home -ErrorAction Stop
@@ -192,7 +192,7 @@ Describe 'Default Prompt Tests - ANSI' {
             $GitPromptSettings.DefaultPromptPath.ForegroundColor = [ConsoleColor]::DarkCyan
             $GitPromptSettings.DefaultPromptPath.BackgroundColor = [ConsoleColor]::DarkRed
             $res = &$prompt
-            $res | Should BeExactly "$(Get-PromptConnectionInfo)${csi}36m${csi}41m$(GetHomePath)${csi}0m> "
+            $res | Should BeExactly "$(Get-PromptConnectionInfo)${csi}36m${csi}41m$(GetHomePath)${csi}39;49m> "
         }
         It 'Returns the expected prompt string with prefix, suffix and abbrev home set' {
             Set-Location $Home -ErrorAction Stop
@@ -202,7 +202,7 @@ Describe 'Default Prompt Tests - ANSI' {
             $GitPromptSettings.DefaultPromptSuffix.ForegroundColor = [ConsoleColor]::DarkBlue
             $GitPromptSettings.DefaultPromptAbbreviateHomeDirectory = $true
             $res = &$prompt
-            $res | Should BeExactly "${csi}38;2;245;245;245m[$(hostname)] ${csi}0m$(GetHomePath)${csi}34m - 42> ${csi}0m"
+            $res | Should BeExactly "${csi}38;2;245;245;245m[$(hostname)] ${csi}39m$(GetHomePath)${csi}34m - 42> ${csi}39m"
         }
         It 'Returns the expected prompt string with prompt timing enabled' {
             Set-Location $Home -ErrorAction Stop
@@ -211,7 +211,7 @@ Describe 'Default Prompt Tests - ANSI' {
             $res = &$prompt
             $escapedHome = [regex]::Escape((GetHomePath))
             $rexcsi = [regex]::Escape($csi)
-            $res | Should Match "$escapedHome${rexcsi}95m \d+ms${rexcsi}0m> "
+            $res | Should Match "$escapedHome${rexcsi}95m \d+ms${rexcsi}39m> "
         }
     }
 
@@ -238,7 +238,7 @@ A  test/Foo.Tests.ps1
             $res = &$prompt
             Assert-MockCalled git -ModuleName posh-git
             $path = GetHomeRelPath $PSScriptRoot
-            $res | Should BeExactly "$(Get-PromptConnectionInfo)$path ${csi}93m[${csi}0m${csi}96mmaster${csi}0m${csi}32m${csi}49m +1${csi}0m${csi}32m${csi}49m ~0${csi}0m${csi}32m${csi}49m -0${csi}0m${csi}93m |${csi}0m${csi}31m${csi}49m +0${csi}0m${csi}31m${csi}49m ~1${csi}0m${csi}31m${csi}49m -1${csi}0m${csi}31m !${csi}0m${csi}93m]${csi}0m> "
+            $res | Should BeExactly "$(Get-PromptConnectionInfo)$path ${csi}93m[${csi}39m${csi}96mmaster${csi}39m${csi}32m +1${csi}39m${csi}32m ~0${csi}39m${csi}32m -0${csi}39m${csi}93m |${csi}39m${csi}31m +0${csi}39m${csi}31m ~1${csi}39m${csi}31m -1${csi}39m${csi}31m !${csi}39m${csi}93m]${csi}39m> "
         }
 
         It 'Returns the expected prompt string with changed PathStatusSeparator' {
@@ -258,7 +258,7 @@ A  test/Foo.Tests.ps1
             $res = [string](&$prompt *>&1)
             Assert-MockCalled git -ModuleName posh-git -Scope It
             $path = GetHomeRelPath $PSScriptRoot
-            $res | Should BeExactly "$(Get-PromptConnectionInfo)$path${csi}107m !! ${csi}0m${csi}93m[${csi}0m${csi}96mmaster${csi}0m${csi}93m]${csi}0m> "
+            $res | Should BeExactly "$(Get-PromptConnectionInfo)$path${csi}107m !! ${csi}49m${csi}93m[${csi}39m${csi}96mmaster${csi}39m${csi}93m]${csi}39m> "
         }
         It 'Returns the expected prompt string with expanded PathStatusSeparator' {
             Mock -ModuleName posh-git -CommandName git {
@@ -277,7 +277,7 @@ A  test/Foo.Tests.ps1
             $res = [string](&$prompt *>&1)
             Assert-MockCalled git -ModuleName posh-git -Scope It
             $path = GetHomeRelPath $PSScriptRoot
-            $res | Should BeExactly "$(Get-PromptConnectionInfo)$path${csi}107m [$(hostname)] ${csi}0m${csi}93m[${csi}0m${csi}96mmaster${csi}0m${csi}93m]${csi}0m> "
+            $res | Should BeExactly "$(Get-PromptConnectionInfo)$path${csi}107m [$(hostname)] ${csi}49m${csi}93m[${csi}39m${csi}96mmaster${csi}39m${csi}93m]${csi}39m> "
         }
     }
 }

--- a/test/GitPrompt.Tests.ps1
+++ b/test/GitPrompt.Tests.ps1
@@ -44,7 +44,7 @@ M test/Baz.Tests.ps1
 
         It 'Returns status output from Write-VcsStatus as string' {
             $res = Write-VcsStatus
-            $res | Should BeExactly " ${csi}93m[${csi}0m${csi}96mmaster${csi}0m${csi}32m${csi}49m +1${csi}0m${csi}32m${csi}49m ~0${csi}0m${csi}32m${csi}49m -0${csi}0m${csi}96m ~${csi}0m${csi}93m]${csi}0m"
+            $res | Should BeExactly " ${csi}93m[${csi}39m${csi}96mmaster${csi}39m${csi}32m +1${csi}39m${csi}32m ~0${csi}39m${csi}32m -0${csi}39m${csi}96m ~${csi}39m${csi}93m]${csi}39m"
         }
     }
 }


### PR DESCRIPTION
This fixes a bug with using **posh‑git** inside a [**PowerLine** block](https://github.com/Jaykul/PowerLine/blob/master/README.md), which would result in the background colour being reset to the PowerShell window’s background colour, breaking the **PowerLine** block.

review?(@dahlbyk): I’ve been using this for the last 15 days, and it works fine for me.