### PR TITLE
chore(travis): Use Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ jobs:
   include:
     - stage: linux
       os: linux
-      dist: trusty
+      dist: xenial
       sudo: false
       addons:
         apt:
           sources:
-            - sourceline: deb [arch=amd64] https://packages.microsoft.com/ubuntu/14.04/prod trusty main
+            - sourceline: deb [arch=amd64] https://packages.microsoft.com/ubuntu/16.04/prod xenial main
               key_url: https://packages.microsoft.com/keys/microsoft.asc
           packages:
             - powershell


### PR DESCRIPTION
This migrates the Travis build to run on **Ubuntu 16.04 Xenial**.

review?(@dahlbyk, @rkeithhill): This fixes the build to pass again.