### PR TITLE
Add GitPromptValues global to allow error status display in prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # posh-git Release History
 
+## 1.0.0-beta4 - TBD
+
+### Added
+
+- `$global:GitPromptValues` with the following properties to enable users to have access to the information necessary
+  to display error status in their prompt as well as debug their prompt customizations:
+  - DollarQuestion
+  - IsAdmin
+  - LastExitCode
+  - LastPrompt
+
 ## 1.0.0-beta3 - March 10, 2019
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -358,6 +358,8 @@ This will change the prompt to:
 
 ![[master ≡] ~\GitHub\posh-git&#10;02-18 14:04:35 38> ][prompt-custom]
 
+### Prompt Layouts
+
 For reference, the following layouts show the relative position of the various parts of the posh-git prompt.
 Note that `<>` denotes parts of the prompt that may not appear depending on the status of settings and whether or not
 the current dir is in a Git repository.
@@ -375,12 +377,51 @@ Prompt layout when DefaultPromptWriteStatusFirst is set to $true:
 {DPPrefix}<{BeforeStatus}{Status}{AfterStatus}>{PathStatusSeparator}{DPPath}{DPBeforeSuffix}<{DPDebug}><{DPTimingFormat}>{DPSuffix}
 ```
 
+### Displaying Error Information
+
+If you want to display the error status of the last command, you can use the values stored in the `$global:GitPromptValues`
+object which includes the value of `$LastExitCode` and `$?` (represented by the property `DollarQuestion`). Here is
+a prompt customization that displays a Red exit code value when `$LastExitCode` is non-zero or a Red `!` if `$?`
+is `$false`:
+
+```powershell
+function global:PromptWriteErrorInfo() {
+    if ($global:GitPromptValues.DollarQuestion) { return }
+
+    if ($global:GitPromptValues.LastExitCode) {
+        "`e[31m(" + $global:GitPromptValues.LastExitCode + ") `e[0m"
+    }
+    else {
+        "`e[31m! `e[0m"
+    }
+}
+
+$global:GitPromptSettings.DefaultPromptBeforeSuffix.Text = '`n$(PromptWriteErrorInfo)$([DateTime]::now.ToString("MM-dd HH:mm:ss"))'
+```
+
+When a PowerShell command fails, this is the prompt you will see:
+
+![~\GitHub\posh-git [master ≡]&#10;! 07-01 22:36:31> ][prompt-error1]
+
+When an external application returns a non-zero exit code, 1 in this case, you will see the exit code in the prompt:
+
+![~\GitHub\posh-git [master ≡]&#10;(1) 07-01 22:32:28> ][prompt-error2]
+
+Note that until you run an external application that sets `$LASTEXITCODE` to zero or you manually set the variable to
+0, you will see the exit code for any error.  In addition to `LastExitCode` and `DollarQuestion`,
+`$global:GitPromtpValues` also has `IsAdmin` and `LastPrompt` properties.  The `LastPrompt` property contains the ANSI
+escaped string that was used for the last prompt. This can be useful for debugging your prompt display particularly
+when using ANSI/VT sequences.
+
+### $GitPromptScriptBlock
+
 If you require even more customization than `$GitPromptSettings` provides, you can create your own prompt
 function to show whatever information you want.
 See the [Customizing Your PowerShell Prompt][wiki-custom-prompt] wiki page for details.
 
-However, if you need a custom prompt to perform some non-prompt logic, you can still use posh-git's prompt function to
-write out a prompt string.  This can be done with the `$GitPromptScriptBlock` variable as shown below e.g.:
+However, if you need a custom prompt just to perform some non-prompt logic, you can still use posh-git's
+prompt function to write out the prompt string.  This can be done with the `$GitPromptScriptBlock` variable as shown
+below e.g.:
 
 ```powershell
 # my profile.ps1
@@ -448,6 +489,8 @@ function prompt {
 [prompt-swap]:     https://github.com/dahlbyk/posh-git/wiki/images/PromptStatusFirst.png   "[master ≡] ~\GitHub\posh-git> "
 [prompt-two-line]: https://github.com/dahlbyk/posh-git/wiki/images/PromptTwoLine.png       "~\GitHub\posh-git [master ≡]&#10;> "
 [prompt-custom]:   https://github.com/dahlbyk/posh-git/wiki/images/PromptCustom.png        "[master ≡] ~\GitHub\posh-git&#10;02-18 14:04:35 38> "
+[prompt-error1]:   https://github.com/dahlbyk/posh-git/wiki/images/PromptError1.png        "~\GitHub\posh-git [master ≡]&#10;! 07-01 22:36:31> "
+[prompt-error2]:   https://github.com/dahlbyk/posh-git/wiki/images/PromptError2.png        "~\GitHub\posh-git [master ≡]&#10;(1) 07-01 22:32:28> "
 
 [v0-change]:       https://github.com/dahlbyk/posh-git/blob/v0/CHANGELOG.md
 [v0-readme]:       https://github.com/dahlbyk/posh-git/blob/v0/README.md

--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -2,6 +2,7 @@
 # http://www.markembling.info/view/my-ideal-powershell-prompt-with-git-integration
 
 $global:GitPromptSettings = [PoshGitPromptSettings]::new()
+$global:GitPromptValues = [PoshGitPromptValues]::new()
 
 # Override some of the normal colors if the background color is set to the default DarkMagenta.
 $s = $global:GitPromptSettings

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -292,3 +292,10 @@ class PoshGitPromptSettings {
 
     [bool]$Debug = $false
 }
+
+class PoshGitPromptValues {
+    [int]$LastExitCode
+    [bool]$DollarQuestion
+    [bool]$IsAdmin
+    [string]$LastPrompt
+}

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -29,6 +29,17 @@ else {
 
 # The built-in posh-git prompt function in ScriptBlock form.
 $GitPromptScriptBlock = {
+    $origDollarQuestion = $global:?
+    $origLastExitCode = $global:LASTEXITCODE
+
+    if (!$global:GitPromptValues) {
+        $global:GitPromptValues = [PoshGitPromptValues]::new()
+    }
+
+    $global:GitPromptValues.DollarQuestion = $origDollarQuestion
+    $global:GitPromptValues.LastExitCode = $origLastExitCode
+    $global:GitPromptValues.IsAdmin = $IsAdmin
+
     $settings = $global:GitPromptSettings
     if (!$settings) {
         return "<`$GitPromptSettings not found> "
@@ -37,8 +48,6 @@ $GitPromptScriptBlock = {
     if ($settings.DefaultPromptEnableTiming) {
         $sw = [System.Diagnostics.Stopwatch]::StartNew()
     }
-
-    $origLastExitCode = $global:LASTEXITCODE
 
     if ($settings.SetEnvColumns) {
         # Set COLUMNS so git knows how wide the terminal is
@@ -100,8 +109,7 @@ $GitPromptScriptBlock = {
     }
     else {
         # If using ANSI, set this global to help debug ANSI issues
-        [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-        $global:PoshGitLastPrompt = EscapeAnsiString $prompt
+        $global:GitPromptValues.LastPrompt = EscapeAnsiString $prompt
     }
 
     $global:LASTEXITCODE = $origLastExitCode


### PR DESCRIPTION
It is useful to display the error status of the last command.  But in
order to do that we must preserve the value of $? and make the
original $LASTEXITCODE available to string expansion in the prompt.