### PR TITLE
v0: Add build script for creating module with scripts being merged into it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 VERSION
 *.nupkg
 obj
+# ignore release dirs
+/*.*.*

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,30 @@
+$outputFolder = (Join-Path $PSScriptRoot 'out')
+
+# Clean
+if (Test-Path $outputFolder) {
+    Remove-Item $outputFolder -Recurse
+}
+
+# Copy files to output folder
+Copy-Item -Path (Join-Path $PSScriptRoot 'src') -Destination $outputFolder -Recurse
+
+$mainModulePath = (Join-Path $outputFolder 'posh-git.psm1')
+$contentOfMainModule = Get-Content -Path $mainModulePath
+
+$PowerShellScriptsToBeMerged = Get-ChildItem -Path $outputFolder -Filter '*.ps1'
+foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {
+    $NameOfScriptToBeMerged = $powerShellScriptToBeMerged.Name
+    $scriptContentToBeMerged = Get-Content -Path $powerShellScriptToBeMerged
+    $replaceSearchText = ". `$PSScriptRoot\$NameOfScriptToBeMerged"
+    if ($contentOfMainModule.Contains($replaceSearchText)) {
+        $contentOfMainModule = $contentOfMainModule.Replace(". `$PSScriptRoot\$NameOfScriptToBeMerged",
+            @"
+#region
+$scriptContentToBeMerged
+#endregion
+"@)
+        Remove-Item $powerShellScriptToBeMerged
+    }
+}
+
+Set-Content -Path $mainModulePath -Value $contentOfMainModule

--- a/build.ps1
+++ b/build.ps1
@@ -14,7 +14,7 @@ $contentOfMainModule = Get-Content -Path $mainModulePath
 $PowerShellScriptsToBeMerged = Get-ChildItem -Path $outputFolder -Filter '*.ps1'
 foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {
     $NameOfScriptToBeMerged = $powerShellScriptToBeMerged.Name
-    $scriptContentToBeMerged = Get-Content -Path $powerShellScriptToBeMerged
+    $scriptContentToBeMerged = Get-Content -Path $powerShellScriptToBeMerged -Raw
     $replaceSearchText = ". `$PSScriptRoot\$NameOfScriptToBeMerged"
     if ($contentOfMainModule.Contains($replaceSearchText)) {
         $contentOfMainModule = $contentOfMainModule.Replace(". `$PSScriptRoot\$NameOfScriptToBeMerged",
@@ -28,3 +28,5 @@ $scriptContentToBeMerged
 }
 
 Set-Content -Path $mainModulePath -Value $contentOfMainModule
+
+Write-Verbose "Module created at '$outputFolder'" -Verbose

--- a/build.ps1
+++ b/build.ps1
@@ -15,7 +15,7 @@ $contentOfMainModule = Get-Content -Path $mainModulePath
 $PowerShellScriptsToBeMerged = Get-ChildItem -Path $outputFolder -Filter '*.ps1'
 foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {
     $NameOfScriptToBeMerged = $powerShellScriptToBeMerged.Name
-    $scriptContentToBeMerged = Get-Content -Path $powerShellScriptToBeMerged -Raw
+    $scriptContentToBeMerged = Get-Content -Path $powerShellScriptToBeMerged.FullName -Raw
     $replaceSearchText = ". `$PSScriptRoot\$NameOfScriptToBeMerged"
     if ($contentOfMainModule.Contains($replaceSearchText)) {
         $contentOfMainModule = $contentOfMainModule.Replace(". `$PSScriptRoot\$NameOfScriptToBeMerged",
@@ -25,7 +25,7 @@ $scriptContentToBeMerged
 #endregion
 
 "@)
-        Remove-Item $powerShellScriptToBeMerged
+        Remove-Item $powerShellScriptToBeMerged.FullName
     }
 }
 


### PR DESCRIPTION
Related: #692
This targets the `v0` branch.
The AppVeyor build has a problem is a known issue where AppVeyor does not see that the target branch is not master and cannot deal with that....