### PR TITLE
Add build module

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -19,9 +19,10 @@ foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {
     if ($contentOfMainModule.Contains($replaceSearchText)) {
         $contentOfMainModule = $contentOfMainModule.Replace(". `$PSScriptRoot\$NameOfScriptToBeMerged",
             @"
-#region
+#region $($powerShellScriptToBeMerged.BaseName)
 $scriptContentToBeMerged
 #endregion
+
 "@)
         Remove-Item $powerShellScriptToBeMerged
     }

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,32 @@
+$outputFolder = (Join-Path $PSScriptRoot 'out')
+
+# Clean
+if (Test-Path $outputFolder) {
+    Remove-Item $outputFolder -Recurse
+}
+
+# Copy files to output folder
+Copy-Item -Path (Join-Path $PSScriptRoot 'src') -Destination $outputFolder -Recurse
+
+$mainModulePath = (Join-Path $outputFolder 'posh-git.psm1')
+$contentOfMainModule = Get-Content -Path $mainModulePath
+
+$PowerShellScriptsToBeMerged = Get-ChildItem -Path $outputFolder -Filter '*.ps1'
+foreach ($powerShellScriptToBeMerged in $PowerShellScriptsToBeMerged) {
+    $NameOfScriptToBeMerged = $powerShellScriptToBeMerged.Name
+    $scriptContentToBeMerged = Get-Content -Path $powerShellScriptToBeMerged -Raw
+    $replaceSearchText = ". `$PSScriptRoot\$NameOfScriptToBeMerged"
+    if ($contentOfMainModule.Contains($replaceSearchText)) {
+        $contentOfMainModule = $contentOfMainModule.Replace(". `$PSScriptRoot\$NameOfScriptToBeMerged",
+            @"
+#region
+$scriptContentToBeMerged
+#endregion
+"@)
+        Remove-Item $powerShellScriptToBeMerged
+    }
+}
+
+Set-Content -Path $mainModulePath -Value $contentOfMainModule
+
+Write-Verbose "Module created at '$outputFolder'" -Verbose


### PR DESCRIPTION
Related: #692
This targets the `master` branch.

It creates the module in an `out` folder by copying the content of the `src` folder into it first and then merging the `.ps1` files into the main `.psm1` files that are dot sourced by looking for the pattern `$PSScriptRoot\ScriptName.ps1` and replacing it with the content and wrapping it into a `#region` block.