### PR TITLE
Make SSH_AGENT_PID mapping to Windows PID

### DIFF
--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -433,7 +433,7 @@ function Get-NativeSshAgent {
         # The ssh.exe binary version must include "OpenSSH"
         # The windows ssh-agent service must exist
         $service = Get-Service ssh-agent -ErrorAction Ignore
-        $executableMatches = Get-Command ssh.exe | ForEach-Object FileVersionInfo | Where-Object ProductVersion -match OpenSSH
+        $executableMatches = Get-Command ssh.exe -ErrorAction Ignore | ForEach-Object FileVersionInfo | Where-Object ProductVersion -match OpenSSH
         $valid = $service -and $executableMatches
         if ($valid) {
             return $service;

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -401,14 +401,26 @@ function Get-SshAgent() {
     else {
         $agentPid = $Env:SSH_AGENT_PID
         if ($agentPid) {
-            $sshAgentProcess = Get-Process | Where-Object { ($_.Id -eq $agentPid) -and ($_.Name -eq 'ssh-agent') }
-            if ($null -ne $sshAgentProcess) {
-                return $agentPid
+            # Convert cygwin PID to Windows PID
+            $ps = Find-Ssh('ps')
+            if (!$ps) {
+                Write-Warning 'Could not find ps'
+                return 0
             }
-            else {
-                setenv 'SSH_AGENT_PID' $null
-                setenv 'SSH_AUTH_SOCK' $null
+            $pidMap = @{ }
+            (& $ps) | Select-Object -skip 1 | ForEach-Object {
+                $line = ($_ -split "\s+" -match "\S")
+                $pidMap[$line[0]] = $line[3]
             }
+            $winPid = $pidMap[$agentPid]
+            if ($winPid) {
+                $sshAgentProcess = Get-Process | Where-Object { ($_.Id -eq $winPid) -and ($_.Name -eq 'ssh-agent') }
+                if ($null -ne $sshAgentProcess) {
+                    return $winPid
+                }    
+            }
+            setenv 'SSH_AGENT_PID' $null
+            setenv 'SSH_AUTH_SOCK' $null
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/dahlbyk/posh-sshell/issues/21
PID and WINPID mismatch was introduced in the recent cygwin release,
see https://github.com/git-for-windows/git/issues/2274