### PR TITLE
Fix bug w/multiple completions of name parameter on remove-gitbranch

### DIFF
--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -278,12 +278,6 @@ function GitTabExpansionInternal($lastBlock, $GitStatus = $null) {
         return gitBranches $matches['ref'] $true
     }
 
-    # Handles Remove-GitBranch
-    if (($lastBlock -match "^Remove-GitBranch\s+(?!-)(?<ref>\S*)") -or
-        ($lastBlock -match "^Remove-GitBranch.* -Name\s+(?<ref>\S*)")) {
-        return gitBranches $matches['ref'] $true
-    }
-
     switch -regex ($lastBlock -replace "^$(Get-AliasPattern git) ","") {
 
         # Handles git <cmd> <op>
@@ -474,7 +468,6 @@ function TabExpansion($line, $lastWord) {
         "^$(Get-AliasPattern git) (.*)" { Expand-GitCommand $lastBlock }
         "^$(Get-AliasPattern tgit) (.*)" { Expand-GitCommand $lastBlock }
         "^$(Get-AliasPattern gitk) (.*)" { Expand-GitCommand $lastBlock }
-        "^$(Get-AliasPattern Remove-GitBranch) (.*)" { Expand-GitCommand $lastBlock }
 
         # Fall back on existing tab expansion
         default {
@@ -483,4 +476,10 @@ function TabExpansion($line, $lastWord) {
             }
         }
     }
+}
+
+# Handles Remove-GitBranch -Name parameter auto-completion using the built-in mechanism for cmdlet parameters
+Register-ArgumentCompleter -CommandName Remove-GitBranch -ParameterName Name -ScriptBlock {
+    param($Command, $Parameter, $WordToComplete, $CommandAst, $FakeBoundParams)
+    gitBranches $WordToComplete $true
 }

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -452,7 +452,7 @@ function Get-AliasPattern($cmd) {
 
         Where-Object { $_ -match $Pattern }
 
-    ## Recovering Deleted Branches
+    Recovering Deleted Branches
 
     If you wind up deleting a branch you didn't intend to, you can easily recover it with the info provided by Git during the delete. For instance, let's say you realized you didn't want to delete the branch 'feature/exp1'. In the output of this command, you should see a deletion entry for this branch that looks like:
 

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -178,17 +178,6 @@ Describe 'TabExpansion Tests' {
         }
     }
 
-    Context 'Remove-GitBranch TabExpansion Tests' {
-        It 'Tab completes branches by positional parameter' {
-            $result = & $module GitTabExpansionInternal 'Remove-GitBranch mas'
-            $result | Should BeExactly 'master'
-        }
-        It 'Tab completes branches by named parameter' {
-            $result = & $module GitTabExpansionInternal 'Remove-GitBranch -IncludeUnmerged -WhatIf -Name mas'
-            $result | Should BeExactly 'master'
-        }
-    }
-
     Context 'Vsts' {
         BeforeEach {
             [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]


### PR DESCRIPTION
This is better because it uses the more direct mechanism for parameter
argument completion for cmdlets.

Fix help markdown warning in this cmdlet.