### PR TITLE
Add option to abbreviate based path based on the git root

### DIFF
--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -283,6 +283,7 @@ class PoshGitPromptSettings {
     [PoshGitTextSpan]$DefaultPromptSuffix       = '$(">" * ($nestedPromptLevel + 1)) '
 
     [bool]$DefaultPromptAbbreviateHomeDirectory = $true
+    [bool]$DefaultPromptAbbreviateGitDirectory  = $false
     [bool]$DefaultPromptWriteStatusFirst        = $false
     [bool]$DefaultPromptEnableTiming            = $false
     [PoshGitTextSpan]$DefaultPromptTimingFormat = ' {0}ms'

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -301,15 +301,14 @@ function Get-PromptPath {
         if ($gitPath) { $gitPath = Split-Path $gitPath -Parent }
     }
 
-    # Abbreviate path under a git repository
+    # Abbreviate path under a git repository as "<repo-name>:<relative-path>"
     if ($abbrevGitDir -and $gitPath -and $currentPath.StartsWith($gitPath, $stringComparison)) {
-        # Up another level to keep repo name in the abbreviated path
-        # $removePath = Split-Path $gitPath -Parent
         $gitName = Split-Path $gitPath -Leaf
-        $relPath = if ($currentPath -eq $gitPath) { "/" } else { $currentPath.SubString($gitPath.Length) }
+        $relPath = $currentPath.SubString($gitPath.Length)
+        if ($relPath -eq "") { $relPath = [System.IO.Path]::DirectorySeparatorChar }
         $currentPath = "$gitName`:$relPath"
     }
-    # Abbreviate path under the user's home dir
+    # Abbreviate path under the user's home dir as "~<relative-path>"
     elseif ($abbrevHomeDir -and $currentPath.StartsWith($Home, $stringComparison)) {
         $currentPath = "~" + $currentPath.SubString($Home.Length)
     }

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -293,6 +293,7 @@ function Get-PromptPath {
     # Look up the git root
     if ($abbrevGitDir) {
         $gitPath = $(Get-GitDirectory)
+        # Up one level from `.git`
         if ($gitPath) { $gitPath = $(Split-Path $gitPath -Parent) }
     }
 
@@ -301,6 +302,7 @@ function Get-PromptPath {
     # Abbreviate path by replacing beginning of path with - *iff* the path is under a git repository
     if ($abbrevGitDir -and $currentPath -and $gitPath -and
         $currentPath.StartsWith($gitPath, $stringComparison)) {
+        # Up another level to keep repo name in path
         $removePath = $(Split-Path $gitPath -Parent)
         $currentPath = "-" + $currentPath.SubString($removePath.Length)
     }

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -291,6 +291,7 @@ function Get-PromptPath {
     if (!$settings -or !$currentPath -or $currentPath.Equals($Home, $stringComparison)) {
         return $currentPath
     }
+
     $abbrevHomeDir = $settings.DefaultPromptAbbreviateHomeDirectory
     $abbrevGitDir = $settings.DefaultPromptAbbreviateGitDirectory
 

--- a/test/DefaultPrompt.Tests.ps1
+++ b/test/DefaultPrompt.Tests.ps1
@@ -135,6 +135,48 @@ A  test/Foo.Tests.ps1
             $path = GetHomeRelPath $PSScriptRoot
             $res | Should BeExactly "$(Get-PromptConnectionInfo)$path - 42 [master]> "
         }
+
+        It 'Returns the expected prompt string with DefaultPromptAbbreviateGitDirectory disabled' {
+            Mock -ModuleName posh-git -CommandName git {
+                $OFS = " "
+                if ($args -contains 'rev-parse') {
+                    $res = Invoke-Expression "&$gitbin $args"
+                    return $res
+                }
+                Convert-NativeLineEnding -SplitLines @'
+## master
+
+'@
+            }
+            $GitPromptSettings.DefaultPromptAbbreviateGitDirectory = $false
+            $res = [string](&$prompt *>&1)
+            Assert-MockCalled git -ModuleName posh-git -Scope It
+            $path = GetGitRelPath $PSScriptRoot
+            # Restore default
+            $GitPromptSettings.DefaultPromptAbbreviateGitDirectory = $false
+            $res | Should BeExactly "$(Get-PromptConnectionInfo)$path [master]> "
+        }
+
+        It 'Returns the expected prompt string with DefaultPromptAbbreviateGitDirectory enabled' {
+            Mock -ModuleName posh-git -CommandName git {
+                $OFS = " "
+                if ($args -contains 'rev-parse') {
+                    $res = Invoke-Expression "&$gitbin $args"
+                    return $res
+                }
+                Convert-NativeLineEnding -SplitLines @'
+## master
+
+'@
+            }
+            $GitPromptSettings.DefaultPromptAbbreviateGitDirectory = $true
+            $res = [string](&$prompt *>&1)
+            Assert-MockCalled git -ModuleName posh-git -Scope It
+            $path = GetGitRelPath $PSScriptRoot
+            # Restore default
+            $GitPromptSettings.DefaultPromptAbbreviateGitDirectory = $false
+            $res | Should BeExactly "$(Get-PromptConnectionInfo)$path [master]> "
+        }
     }
 }
 

--- a/test/DefaultPrompt.Tests.ps1
+++ b/test/DefaultPrompt.Tests.ps1
@@ -157,7 +157,31 @@ A  test/Foo.Tests.ps1
             $res | Should BeExactly "$(Get-PromptConnectionInfo)$path [master]> "
         }
 
-        It 'Returns the expected prompt string with DefaultPromptAbbreviateGitDirectory enabled' {
+        It 'Returns the expected prompt string with DefaultPromptAbbreviateGitDirectory enabled (root)' {
+            Mock -ModuleName posh-git -CommandName git {
+                $OFS = " "
+                if ($args -contains 'rev-parse') {
+                    $res = Invoke-Expression "&$gitbin $args"
+                    return $res
+                }
+                Convert-NativeLineEnding -SplitLines @'
+## master
+
+'@
+            }
+            $GitPromptSettings.DefaultPromptAbbreviateGitDirectory = $true
+            $gitRootPath = Split-Path $PSScriptRoot -Parent
+            Set-Location $gitRootPath
+            $res = [string](&$prompt *>&1)
+            Assert-MockCalled git -ModuleName posh-git -Scope It
+            $path = GetGitRelPath $gitRootPath
+            # Restore default
+            Set-Location $PSScriptRoot
+            $GitPromptSettings.DefaultPromptAbbreviateGitDirectory = $false
+            $res | Should BeExactly "$(Get-PromptConnectionInfo)$path [master]> "
+        }
+
+        It 'Returns the expected prompt string with DefaultPromptAbbreviateGitDirectory enabled (subfolder)' {
             Mock -ModuleName posh-git -CommandName git {
                 $OFS = " "
                 if ($args -contains 'rev-parse') {

--- a/test/Shared.ps1
+++ b/test/Shared.ps1
@@ -75,7 +75,9 @@ function GetGitRelPath([string]$Path) {
 
     if ($GitPromptSettings.DefaultPromptAbbreviateGitDirectory) {
         $gitName = Split-Path $gitPath -Leaf
-        "$gitName`:$($Path.Substring($gitPath.Length))"
+        $relPath = $Path.Substring($gitPath.Length)
+        if ($relPath -eq "") { $relPath = [System.IO.Path]::DirectorySeparatorChar }
+        "$gitName`:$relPath"
     }
     else {
         # Otherwise, honor Home path abbreviation

--- a/test/Shared.ps1
+++ b/test/Shared.ps1
@@ -74,7 +74,6 @@ function GetGitRelPath([string]$Path) {
     }
 
     if ($GitPromptSettings.DefaultPromptAbbreviateGitDirectory) {
-        # Up another level to keep repo name in path
         $gitName = Split-Path $gitPath -Leaf
         "$gitName`:$($Path.Substring($gitPath.Length))"
     }

--- a/test/Shared.ps1
+++ b/test/Shared.ps1
@@ -61,12 +61,12 @@ function GetHomeRelPath([string]$Path) {
 }
 
 function GetGitRelPath([string]$Path) {
-    $gitPath = $(Get-GitDirectory)
+    $gitPath = Get-GitDirectory
     if (!$gitPath) {
         throw "GetGitRelPath should be called inside a git repository"
     }
     # Up one level from `.git`
-    $gitPath = $(Split-Path $gitPath -Parent)
+    $gitPath = Split-Path $gitPath -Parent
 
     if (!$Path.StartsWith($gitPath)) {
         # Path not under $gitPath
@@ -75,8 +75,8 @@ function GetGitRelPath([string]$Path) {
 
     if ($GitPromptSettings.DefaultPromptAbbreviateGitDirectory) {
         # Up another level to keep repo name in path
-        $removePath = $(Split-Path $gitPath -Parent)
-        "-$($Path.Substring($removePath.Length))"
+        $gitName = Split-Path $gitPath -Leaf
+        "$gitName`:$($Path.Substring($gitPath.Length))"
     }
     else {
         # Otherwise, honor Home path abbreviation

--- a/test/Shared.ps1
+++ b/test/Shared.ps1
@@ -60,6 +60,30 @@ function GetHomeRelPath([string]$Path) {
     }
 }
 
+function GetGitRelPath([string]$Path) {
+    $gitPath = $(Get-GitDirectory)
+    if (!$gitPath) {
+        throw "GetGitRelPath should be called inside a git repository"
+    }
+    # Up one level from `.git`
+    $gitPath = $(Split-Path $gitPath -Parent)
+
+    if (!$Path.StartsWith($gitPath)) {
+        # Path not under $gitPath
+        return $Path
+    }
+
+    if ($GitPromptSettings.DefaultPromptAbbreviateGitDirectory) {
+        # Up another level to keep repo name in path
+        $removePath = $(Split-Path $gitPath -Parent)
+        "-$($Path.Substring($removePath.Length))"
+    }
+    else {
+        # Otherwise, honor Home path abbreviation
+        GetHomeRelPath $Path
+    }
+}
+
 function MakeNativePath([string]$Path) {
     $Path -replace '\\|/', [System.IO.Path]::DirectorySeparatorChar
 }


### PR DESCRIPTION
Implement #719. Added an option to abbreviate the prompt path based on the git root.

When enabled
```
$GitPromptSettings.DefaultPromptAbbreviateGitDirectory = $true
```
When the currentpath is under a git repository, e.g.
```
~/company/work/projects/client/project-name/src [master] >
```
Prompt shows a path shortened to:
```
# using an arbitrary token to indicate the shortening
-/project-name/src [master] >
# or maybe using git `:/` root convention
project-name:/src [master] >
```