### PR TITLE
Fix #718 do not create HOME env var

### DIFF
--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -291,11 +291,14 @@ function Get-PromptPath {
 
     $stringComparison = Get-PathStringComparison
 
-    # Abbreviate path by replacing beginning of path with ~ *iff* the path is under the user's home dir
-    if ($abbrevHomeDir -and $currentPath -and !$currentPath.Equals($Home, $stringComparison) -and
-        $currentPath.StartsWith($Home, $stringComparison)) {
+    # $HOME is defined by PowerShell on all platforms. If for some reason it isn't defined, use a fallback.
+    $homePath = if ($HOME) {$HOME} else {[System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile)}
 
-        $currentPath = "~" + $currentPath.SubString($Home.Length)
+    # Abbreviate path by replacing beginning of path with ~ *iff* the path is under the user's home dir
+    if ($abbrevHomeDir -and $currentPath -and !$currentPath.Equals($homePath, $stringComparison) -and
+        $currentPath.StartsWith($homePath, $stringComparison)) {
+
+        $currentPath = "~" + $currentPath.SubString($homePath.Length)
     }
 
     return $currentPath

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -291,14 +291,11 @@ function Get-PromptPath {
 
     $stringComparison = Get-PathStringComparison
 
-    # $HOME is defined by PowerShell on all platforms. If for some reason it isn't defined, use a fallback.
-    $homePath = if ($HOME) {$HOME} else {[System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile)}
-
     # Abbreviate path by replacing beginning of path with ~ *iff* the path is under the user's home dir
-    if ($abbrevHomeDir -and $currentPath -and !$currentPath.Equals($homePath, $stringComparison) -and
-        $currentPath.StartsWith($homePath, $stringComparison)) {
+    if ($abbrevHomeDir -and $currentPath -and !$currentPath.Equals($Home, $stringComparison) -and
+        $currentPath.StartsWith($Home, $stringComparison)) {
 
-        $currentPath = "~" + $currentPath.SubString($homePath.Length)
+        $currentPath = "~" + $currentPath.SubString($Home.Length)
     }
 
     return $currentPath

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -1,4 +1,4 @@
-param([bool]$ForcePoshGitPrompt, [bool]$SkipHomeEnvVar)
+param([bool]$ForcePoshGitPrompt)
 
 . $PSScriptRoot\CheckRequirements.ps1 > $null
 
@@ -12,18 +12,6 @@ param([bool]$ForcePoshGitPrompt, [bool]$SkipHomeEnvVar)
 . $PSScriptRoot\GitParamTabExpansion.ps1
 . $PSScriptRoot\GitTabExpansion.ps1
 . $PSScriptRoot\TortoiseGit.ps1
-
-# At the point we drop v5 support, we can rely on using the built-in $IsWindows
-if ($PSVersionTable.PSVersion.Major -eq 5) {
-    $IsWindows = $true
-}
-
-# Only create HOME env var on Windows when not defined and using older Git
-if ($IsWindows -and !$Env:HOME -and !$SkipHomeEnvVar -and !(Get-Command git).Source.EndsWith('cmd\git.exe')) {
-    $Env:HOME = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile)
-    Write-Warning "posh-git set `$Env:HOME for this version of Git. To disable creation of `$Env:HOME"
-    Write-Warning "and this warning, consider upgrading Git or use: Import-Module posh-git -Args 0,1"
-}
 
 $IsAdmin = Test-Administrator
 

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -13,9 +13,6 @@ param([switch]$ForcePoshGitPrompt)
 . $PSScriptRoot\GitTabExpansion.ps1
 . $PSScriptRoot\TortoiseGit.ps1
 
-if (!$Env:HOME) { $Env:HOME = "$Env:HOMEDRIVE$Env:HOMEPATH" }
-if (!$Env:HOME) { $Env:HOME = "$Env:USERPROFILE" }
-
 $IsAdmin = Test-Administrator
 
 # Get the default prompt definition.

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -1,4 +1,4 @@
-param([switch]$ForcePoshGitPrompt)
+param([bool]$ForcePoshGitPrompt, [bool]$SkipHomeEnvVar)
 
 . $PSScriptRoot\CheckRequirements.ps1 > $null
 
@@ -12,6 +12,18 @@ param([switch]$ForcePoshGitPrompt)
 . $PSScriptRoot\GitParamTabExpansion.ps1
 . $PSScriptRoot\GitTabExpansion.ps1
 . $PSScriptRoot\TortoiseGit.ps1
+
+# At the point we drop v5 support, we can rely on using the built-in $IsWindows
+if ($PSVersionTable.PSVersion.Major -eq 5) {
+    $IsWindows = $true
+}
+
+# Only create HOME env var on Windows when not defined and using older Git
+if ($IsWindows -and !$Env:HOME -and !$SkipHomeEnvVar -and !(Get-Command git).Source.EndsWith('cmd\git.exe')) {
+    $Env:HOME = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile)
+    Write-Warning "posh-git set `$Env:HOME for this version of Git. To disable creation of `$Env:HOME"
+    Write-Warning "and this warning, consider upgrading Git or use: Import-Module posh-git -Args 0,1"
+}
 
 $IsAdmin = Test-Administrator
 

--- a/test/DefaultPrompt.Tests.ps1
+++ b/test/DefaultPrompt.Tests.ps1
@@ -14,7 +14,7 @@ Describe 'Default Prompt Tests - NO ANSI' {
 
     Context 'Prompt with no Git summary' {
         It 'Returns the expected prompt string' {
-            Set-Location $env:HOME -ErrorAction Stop
+            Set-Location $HOME -ErrorAction Stop
             $res = [string](&$prompt *>&1)
             $res | Should BeExactly "$(Get-PromptConnectionInfo)$(GetHomePath)> "
         }
@@ -152,7 +152,7 @@ Describe 'Default Prompt Tests - ANSI' {
 
     Context 'Prompt with no Git summary' {
         It 'Returns the expected prompt string' {
-            Set-Location $env:HOME -ErrorAction Stop
+            Set-Location $HOME -ErrorAction Stop
             $res = &$prompt
             $res | Should BeExactly "$(Get-PromptConnectionInfo)$(GetHomePath)> "
         }


### PR DESCRIPTION
Windows does not normally define a `HOME` env var so we are always defining that env var.  We should be using PowerShell's built-in variable `$HOME` instead.

Fixes #718 