### PR TITLE
Always display BeforeIndex text for  PowerLine style prompts

### DIFF
--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -223,8 +223,9 @@ function Write-GitStatus {
     $sb | Write-GitBranchName $Status -NoLeadingSpace > $null
     $sb | Write-GitBranchStatus $Status > $null
 
+    $sb | Write-Prompt $s.BeforeIndex > $null
+
     if ($s.EnableFileStatus -and $Status.HasIndex) {
-        $sb | Write-Prompt $s.BeforeIndex > $null
         $sb | Write-GitIndexStatus $Status > $null
 
         if ($Status.HasWorking) {


### PR DESCRIPTION
This allows the user to always an appropriate colored space after the branch name/branch status and before working dir changes (when there are no staged changes) e.g.:

![image](https://user-images.githubusercontent.com/5177512/69896244-465f5c00-12fa-11ea-9881-0d496e2d0847.png)
