### PR TITLE
Reset to default fg/bg after display vt seqs in Text field of settings

### DIFF
--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -202,7 +202,7 @@ class PoshGitTextSpan {
             $txt = $this.ToAnsiString()
             if (Test-VirtualTerminalSequece $txt) {
                 $escAnsi = "ANSI: `"$(EscapeAnsiString $txt)`""
-                $str = "Text: `"$txt`",${sep}${escAnsi}"
+                $str = "Text: `"$txt`e[39;49m`",${sep}${escAnsi}"
             }
             else {
                 $str = "Text: `"$txt`""


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/5177512/70380727-e1f55b80-18fc-11ea-9971-18656d809a98.png)

Resulting in this (same exact settings):

![image](https://user-images.githubusercontent.com/5177512/70380762-444e5c00-18fd-11ea-8903-b4fc40dd614e.png)
