### PR TITLE
Incorrect git root abbreviation

### DIFF
--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -305,8 +305,7 @@ function Get-PromptPath {
     # Abbreviate path under a git repository as "<repo-name>:<relative-path>"
     if ($abbrevGitDir -and $gitPath -and $currentPath.StartsWith($gitPath, $stringComparison)) {
         $gitName = Split-Path $gitPath -Leaf
-        $relPath = $currentPath.SubString($gitPath.Length)
-        if ($relPath -eq "") { $relPath = [System.IO.Path]::DirectorySeparatorChar }
+        $relPath = if ($currentPath -eq $gitPath) { "" } else { $currentPath.SubString($gitPath.Length + 1) }
         $currentPath = "$gitName`:$relPath"
     }
     # Abbreviate path under the user's home dir as "~<relative-path>"

--- a/test/Shared.ps1
+++ b/test/Shared.ps1
@@ -75,8 +75,7 @@ function GetGitRelPath([string]$Path) {
 
     if ($GitPromptSettings.DefaultPromptAbbreviateGitDirectory) {
         $gitName = Split-Path $gitPath -Leaf
-        $relPath = $Path.Substring($gitPath.Length)
-        if ($relPath -eq "") { $relPath = [System.IO.Path]::DirectorySeparatorChar }
+        $relPath = if ($Path -eq $gitPath) { "" } else { $Path.Substring($gitPath.Length + 1) }
         "$gitName`:$relPath"
     }
     else {


### PR DESCRIPTION
Found a subtle problem in the git path abbreviation:
```
# this is correct
git show :README.md
git show :src/GitUtils.ps1

# this is wrong
git show :/README.md 
git show :/src/GitUtils.ps1
```

So it seems to me that the abbreviation should be adjusted - PR changes abbreviation to:
<img width="219" alt="image" src="https://user-images.githubusercontent.com/297963/70996605-10c4bc00-20cb-11ea-8b14-f1698ff14ea6.png">