### PR TITLE
Fix git restore scriptblock used by expandParamValues

### DIFF
--- a/src/GitParamTabExpansion.ps1
+++ b/src/GitParamTabExpansion.ps1
@@ -181,8 +181,8 @@ $gitParamValues = @{
         conflict = 'merge diff3'
         source = {
             param($ref)
-            gitBranches $matches['ref'] $true
-            gitTags $matches['ref']
+            gitBranches $ref $true
+            gitTags $ref
         }
     }
     revert = @{

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -263,7 +263,7 @@ function script:expandParamValues($cmd, $param, $filter) {
     $paramValues = $gitParamValues[$cmd][$param]
 
     $completions = if ($paramValues -is [scriptblock]) {
-        & $paramValues $filter | Where-Object { $_ -like "$filter*" }
+        & $paramValues $filter
     }
     else {
         $paramValues.Trim() -split ' ' | Where-Object { $_ -like "$filter*" } | Sort-Object


### PR DESCRIPTION
We don't need to filter the values returned by the scriptblock.
That is why we provide the filter to the scriptblock. We could also
enforce a sort but then that takes away the scriptblock ability to sort 
how it likes.