### PR TITLE
Fixed non-ascii git branch name garbled.

### DIFF
--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -32,16 +32,16 @@ function Invoke-Utf8ConsoleCommand([ScriptBlock]$cmd) {
         # A native executable that writes to stderr AND has its stderr redirected will generate non-terminating
         # error records if the user has set $ErrorActionPreference to Stop. Override that value in this scope.
         $ErrorActionPreference = 'Continue'
-        if ($currentEncoding.IsSingleByte) {
-            try { [Console]::OutputEncoding = [Text.Encoding]::UTF8 } catch [System.IO.IOException] {}
+        if (!$currentEncoding.IsSingleByte) {
+            [Console]::OutputEncoding = [Text.Encoding]::UTF8
+            & $cmd
+            [Console]::OutputEncoding = $currentEncoding
         }
-        & $cmd
+        else {
+            & $cmd
+        }
     }
     finally {
-        if ($currentEncoding.IsSingleByte) {
-            try { [Console]::OutputEncoding = $currentEncoding } catch [System.IO.IOException] {}
-        }
-
         # Clear out stderr output that was added to the $Error collection, putting those errors in a module variable
         if ($global:Error.Count -gt $errorCount) {
             $numNewErrors = $global:Error.Count - $errorCount

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -32,19 +32,13 @@ function Invoke-Utf8ConsoleCommand([ScriptBlock]$cmd) {
         # A native executable that writes to stderr AND has its stderr redirected will generate non-terminating
         # error records if the user has set $ErrorActionPreference to Stop. Override that value in this scope.
         $ErrorActionPreference = 'Continue'
-        try { 
-            [Console]::OutputEncoding = [Text.Encoding]::UTF8
-            & $cmd
-            try { 
-                [Console]::OutputEncoding = $currentEncoding
-            }
-            catch [System.IO.IOException] {}
-        }
-        catch [System.IO.IOException] {
-            & $cmd
-        }
+        
+        try { [Console]::OutputEncoding = [Text.Encoding]::UTF8 } catch [System.IO.IOException] {}
+        & $cmd
     }
     finally {
+        try { [Console]::OutputEncoding = $currentEncoding } catch [System.IO.IOException] {}
+        
         # Clear out stderr output that was added to the $Error collection, putting those errors in a module variable
         if ($global:Error.Count -gt $errorCount) {
             $numNewErrors = $global:Error.Count - $errorCount

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -35,7 +35,10 @@ function Invoke-Utf8ConsoleCommand([ScriptBlock]$cmd) {
         try { 
             [Console]::OutputEncoding = [Text.Encoding]::UTF8
             & $cmd
-            [Console]::OutputEncoding = $currentEncoding
+            try { 
+                [Console]::OutputEncoding = $currentEncoding
+            }
+            catch [System.IO.IOException] {}
         }
         catch [System.IO.IOException] {
             & $cmd

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -32,12 +32,12 @@ function Invoke-Utf8ConsoleCommand([ScriptBlock]$cmd) {
         # A native executable that writes to stderr AND has its stderr redirected will generate non-terminating
         # error records if the user has set $ErrorActionPreference to Stop. Override that value in this scope.
         $ErrorActionPreference = 'Continue'
-        if (!$currentEncoding.IsSingleByte) {
+        try { 
             [Console]::OutputEncoding = [Text.Encoding]::UTF8
             & $cmd
             [Console]::OutputEncoding = $currentEncoding
         }
-        else {
+        catch [System.IO.IOException] {
             & $cmd
         }
     }


### PR DESCRIPTION
By 2020, The utf-8 encoding beats the market for any other specified non-single byte encodings for internationalization. In fact, most of Asian developer would prefer utf-8 as the first-class citizens while remaining specified old encoding like gbk, big5, jis as default page code only for windows system compatibly.

#397 @dahlbyk you introduced a bug that it wont't change to utf-8 for non-single byte while you actually want to do it!

After fixed, It will avoid changing output encoding which causing error for single-byte charset users. (but it will return get non utf8 encoding string which make no problem in fact )  #708 