### PR TITLE
Only default home dir abbreviation to $true on Linux/macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
   ([PR #779](https://github.com/dahlbyk/posh-git/pull/779))
   Thanks @csc027
 
+### Changed
+
+- `$GitPromptSettings.DefaultPromptAbbreviateHomeDirectory` defaults to `$false` on Windows. When enabled, `~` is
+   always substituted for the user's home path. Before this change, when directly in your home dir, this setting would
+   result in the full path displayed in the prompt e.g. `C:\Users\Keith`.  After this change, `~` will be displayed.
+   The new behavior is consistent with how the home path is displayed in prompts in other shells on Linux.
+
 ### Fixed
 
 - Register-ArgumentCompleter based tab-expansion in beta4 doesn't work with PowerShell aliases to git,tgit,gitk.

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -274,7 +274,7 @@ class PoshGitPromptSettings {
     [string[]]$RepositoriesInWhichToDisableFileStatus = @()
 
     [string]$DescribeStyle = ''
-    [psobject]$WindowTitle = {param($GitStatus, [bool]$IsAdmin) "$(if ($IsAdmin) {'Admin: '})$(if ($GitStatus) {"$($GitStatus.RepoName) [$($GitStatus.Branch)]"} else {Get-PromptPath}) ~ PowerShell $($PSVersionTable.PSVersion.Major).$($PSVersionTable.PSVersion.Minor) $(if ([IntPtr]::Size -eq 4) {'32-bit '})($PID)"}
+    [psobject]$WindowTitle = {param($GitStatus, [bool]$IsAdmin) "$(if ($IsAdmin) {'Admin: '})$(if ($GitStatus) {"$($GitStatus.RepoName) [$($GitStatus.Branch)]"} else {Get-PromptPath}) - PowerShell $($PSVersionTable.PSVersion.Major).$($PSVersionTable.PSVersion.Minor) $(if ([IntPtr]::Size -eq 4) {'32-bit '})($PID)"}
 
     [PoshGitTextSpan]$DefaultPromptPrefix       = '$(Get-PromptConnectionInfo -Format "[{1}@{0}]: ")'
     [PoshGitTextSpan]$DefaultPromptPath         = '$(Get-PromptPath)'
@@ -282,7 +282,7 @@ class PoshGitPromptSettings {
     [PoshGitTextSpan]$DefaultPromptDebug        = [PoshGitTextSpan]::new(' [DBG]:', [ConsoleColor]::Magenta)
     [PoshGitTextSpan]$DefaultPromptSuffix       = '$(">" * ($nestedPromptLevel + 1)) '
 
-    [bool]$DefaultPromptAbbreviateHomeDirectory = $true
+    [bool]$DefaultPromptAbbreviateHomeDirectory = ($PSVersionTable.PSVersion.Major -gt 5) -and !$IsWindows
     [bool]$DefaultPromptAbbreviateGitDirectory  = $false
     [bool]$DefaultPromptWriteStatusFirst        = $false
     [bool]$DefaultPromptEnableTiming            = $false

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -32,13 +32,13 @@ function Invoke-Utf8ConsoleCommand([ScriptBlock]$cmd) {
         # A native executable that writes to stderr AND has its stderr redirected will generate non-terminating
         # error records if the user has set $ErrorActionPreference to Stop. Override that value in this scope.
         $ErrorActionPreference = 'Continue'
-        
+
         try { [Console]::OutputEncoding = [Text.Encoding]::UTF8 } catch [System.IO.IOException] {}
         & $cmd
     }
     finally {
         try { [Console]::OutputEncoding = $currentEncoding } catch [System.IO.IOException] {}
-        
+
         # Clear out stderr output that was added to the $Error collection, putting those errors in a module variable
         if ($global:Error.Count -gt $errorCount) {
             $numNewErrors = $global:Error.Count - $errorCount
@@ -285,7 +285,7 @@ function Get-PromptPath {
     # The latter is more desirable.
     $pathInfo = $ExecutionContext.SessionState.Path.CurrentLocation
     $currentPath = if ($pathInfo.Drive) { $pathInfo.Path } else { $pathInfo.ProviderPath }
-    if (!$settings -or !$currentPath -or $currentPath.Equals($Home, $stringComparison)) {
+    if (!$settings -or !$currentPath) {
         return $currentPath
     }
 

--- a/test/DefaultPrompt.Tests.ps1
+++ b/test/DefaultPrompt.Tests.ps1
@@ -356,13 +356,13 @@ Describe 'Default Prompt WindowTitle Tests' -Skip:($Host.Name -eq 'RemoteHostImp
         [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
         $homePath = [regex]::Escape((GetHomePath))
         [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-        $repoAdminRegex = '^Admin: posh-git \[master\] \~ PowerShell \d+\.\d+ (\d\d-bit )?\(\d+\)$'
+        $repoAdminRegex = '^Admin: posh-git \[master\] - PowerShell \d+\.\d+ (\d\d-bit )?\(\d+\)$'
         [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-        $repoRegex = '^posh-git \[master\] \~ PowerShell \d+\.\d+ (\d\d-bit )?\(\d+\)$'
+        $repoRegex = '^posh-git \[master\] - PowerShell \d+\.\d+ (\d\d-bit )?\(\d+\)$'
         [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-        $nonRepoAdminRegex = '^Admin: ' + $homePath + ' \~ PowerShell \d+\.\d+ (\d\d-bit )?\(\d+\)$'
+        $nonRepoAdminRegex = '^Admin: ' + $homePath + ' - PowerShell \d+\.\d+ (\d\d-bit )?\(\d+\)$'
         [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
-        $nonRepoRegex = '^' + $homePath + ' \~ PowerShell \d+\.\d+ (\d\d-bit )?\(\d+\)$'
+        $nonRepoRegex = '^' + $homePath + ' - PowerShell \d+\.\d+ (\d\d-bit )?\(\d+\)$'
     }
     BeforeEach {
         # Ensure these settings start out set to the default values as the module only grabs

--- a/test/Shared.ps1
+++ b/test/Shared.ps1
@@ -60,7 +60,12 @@ function global:Convert-NativeLineEnding([string]$content, [switch]$SplitLines) 
 }
 
 function GetHomePath() {
-    $Home
+    if ($GitPromptSettings.DefaultPromptAbbreviateHomeDirectory) {
+        "~"
+    }
+    else {
+        $Home
+    }
 }
 
 function GetHomeRelPath([string]$Path) {


### PR DESCRIPTION
If enabled, always substitute ~ for the home dir path on all OSs.

Address issue brought up in #746 