### PR TITLE
Autocomplete user-defined pretty formats

### DIFF
--- a/src/GitParamTabExpansion.ps1
+++ b/src/GitParamTabExpansion.ps1
@@ -150,8 +150,24 @@ $gitParamValues = @{
     log = @{
         decorate = 'short full no'
         'no-walk' = 'sorted unsorted'
-        pretty = 'oneline short medium full fuller email raw'
-        format = 'oneline short medium full fuller email raw'
+        pretty = {
+            param($ref)
+            $completions = @()
+            gitConfigKeys $ref 'pretty' | ForEach-Object { $completions += $_ }
+            'oneline short medium full fuller email raw' -split ' ' |
+                Where-Object { $_ -like "$filter*" } |
+                ForEach-Object { $completions += $_ }
+            return $completions | Sort-Object
+        }
+        format = {
+            param($ref)
+            $completions = @()
+            gitConfigKeys $ref 'pretty' | ForEach-Object { $completions += $_ }
+            'oneline short medium full fuller email raw' -split ' ' |
+                Where-Object { $_ -like "$filter*" } |
+                ForEach-Object { $completions += $_ }
+            return $completions | Sort-Object
+        }
         encoding = 'UTF-8'
         date = 'relative local default iso rfc short raw'
     }
@@ -189,8 +205,24 @@ $gitParamValues = @{
         strategy = 'resolve recursive octopus ours subtree'
     }
     show = @{
-        pretty = 'oneline short medium full fuller email raw'
-        format = 'oneline short medium full fuller email raw'
+        pretty = {
+            param($ref)
+            $completions = @()
+            gitConfigKeys $ref 'pretty' | ForEach-Object { $completions += $_ }
+            'oneline short medium full fuller email raw' -split ' ' |
+                Where-Object { $_ -like "$filter*" } |
+                ForEach-Object { $completions += $_ }
+            return $completions | Sort-Object
+        }
+        format = {
+            param($ref)
+            $completions = @()
+            gitConfigKeys $ref 'pretty' | ForEach-Object { $completions += $_ }
+            'oneline short medium full fuller email raw' -split ' ' |
+                Where-Object { $_ -like "$filter*" } |
+                ForEach-Object { $completions += $_ }
+            return $completions | Sort-Object
+        }
         encoding = 'utf-8'
     }
     status = @{

--- a/src/GitParamTabExpansion.ps1
+++ b/src/GitParamTabExpansion.ps1
@@ -151,22 +151,12 @@ $gitParamValues = @{
         decorate = 'short full no'
         'no-walk' = 'sorted unsorted'
         pretty = {
-            param($ref)
-            $completions = @()
-            gitConfigKeys $ref 'pretty' | ForEach-Object { $completions += $_ }
-            'oneline short medium full fuller email raw' -split ' ' |
-                Where-Object { $_ -like "$filter*" } |
-                ForEach-Object { $completions += $_ }
-            return $completions | Sort-Object
+            param($format)
+            gitConfigKeys 'pretty' $format 'oneline short medium full fuller email raw'
         }
         format = {
-            param($ref)
-            $completions = @()
-            gitConfigKeys $ref 'pretty' | ForEach-Object { $completions += $_ }
-            'oneline short medium full fuller email raw' -split ' ' |
-                Where-Object { $_ -like "$filter*" } |
-                ForEach-Object { $completions += $_ }
-            return $completions | Sort-Object
+            param($format)
+            gitConfigKeys 'pretty' $format 'oneline short medium full fuller email raw'
         }
         encoding = 'UTF-8'
         date = 'relative local default iso rfc short raw'
@@ -206,22 +196,12 @@ $gitParamValues = @{
     }
     show = @{
         pretty = {
-            param($ref)
-            $completions = @()
-            gitConfigKeys $ref 'pretty' | ForEach-Object { $completions += $_ }
-            'oneline short medium full fuller email raw' -split ' ' |
-                Where-Object { $_ -like "$filter*" } |
-                ForEach-Object { $completions += $_ }
-            return $completions | Sort-Object
+            param($format)
+            gitConfigKeys 'pretty' $format 'oneline short medium full fuller email raw'
         }
         format = {
-            param($ref)
-            $completions = @()
-            gitConfigKeys $ref 'pretty' | ForEach-Object { $completions += $_ }
-            'oneline short medium full fuller email raw' -split ' ' |
-                Where-Object { $_ -like "$filter*" } |
-                ForEach-Object { $completions += $_ }
-            return $completions | Sort-Object
+            param($format)
+            gitConfigKeys 'pretty' $format 'oneline short medium full fuller email raw'
         }
         encoding = 'utf-8'
     }

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -155,10 +155,15 @@ function script:gitRemoteUniqueBranches($filter) {
         quoteStringWithSpecialChars
 }
 
-function script:gitConfigKeys($filter, $section) {
+function script:gitConfigKeys($section, $filter, $defaultOptions = '') {
+    $completions = @($defaultOptions -split ' ')
+
     git config --name-only --get-regexp ^$section\..* |
-        ForEach-Object { $_ -replace "$section\.","" } |
+        ForEach-Object { $completions += ($_ -replace "$section\.","") }
+
+    return $completions |
         Where-Object { $_ -like "$filter*" } |
+        Sort-Object |
         quoteStringWithSpecialChars
 }
 

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -155,6 +155,13 @@ function script:gitRemoteUniqueBranches($filter) {
         quoteStringWithSpecialChars
 }
 
+function script:gitConfigKeys($filter, $section) {
+    git config --name-only --get-regexp ^$section\..* |
+        ForEach-Object { $_ -replace "$section\.","" } |
+        Where-Object { $_ -like "$filter*" } |
+        quoteStringWithSpecialChars
+}
+
 function script:gitTags($filter, $prefix = '') {
     git tag |
         Where-Object { $_ -like "$filter*" } |

--- a/test/GitParamTabExpansion.Tests.ps1
+++ b/test/GitParamTabExpansion.Tests.ps1
@@ -44,5 +44,111 @@ Describe 'ParamsTabExpansion Tests' {
             $result -contains '--recurse-submodules=on-demand' | Should -Be $true
         }
     }
+
+    Context 'Pretty/Format TabCompletion Tests - No Custom Formats' {
+        It 'Tab completes default formats for log --pretty' {
+            $result = & $module GitTabExpansionInternal 'git log --pretty='
+            $result -contains '--pretty=oneline' | Should -Be $true
+            $result -contains '--pretty=short' | Should -Be $true
+            $result -contains '--pretty=medium' | Should -Be $true
+            $result -contains '--pretty=full' | Should -Be $true
+            $result -contains '--pretty=fuller' | Should -Be $true
+            $result -contains '--pretty=email' | Should -Be $true
+            $result -contains '--pretty=raw' | Should -Be $true
+        }
+        It 'Tab completes default formats for log --format' {
+            $result = & $module GitTabExpansionInternal 'git log --format='
+            $result -contains '--format=oneline' | Should -Be $true
+            $result -contains '--format=short' | Should -Be $true
+            $result -contains '--format=medium' | Should -Be $true
+            $result -contains '--format=full' | Should -Be $true
+            $result -contains '--format=fuller' | Should -Be $true
+            $result -contains '--format=email' | Should -Be $true
+            $result -contains '--format=raw' | Should -Be $true
+        }
+        It 'Tab completes default formats for show --pretty' {
+            $result = & $module GitTabExpansionInternal 'git show --pretty='
+            $result -contains '--pretty=oneline' | Should -Be $true
+            $result -contains '--pretty=short' | Should -Be $true
+            $result -contains '--pretty=medium' | Should -Be $true
+            $result -contains '--pretty=full' | Should -Be $true
+            $result -contains '--pretty=fuller' | Should -Be $true
+            $result -contains '--pretty=email' | Should -Be $true
+            $result -contains '--pretty=raw' | Should -Be $true
+        }
+        It 'Tab completes default formats for show --format' {
+            $result = & $module GitTabExpansionInternal 'git show --format='
+            $result -contains '--format=oneline' | Should -Be $true
+            $result -contains '--format=short' | Should -Be $true
+            $result -contains '--format=medium' | Should -Be $true
+            $result -contains '--format=full' | Should -Be $true
+            $result -contains '--format=fuller' | Should -Be $true
+            $result -contains '--format=email' | Should -Be $true
+            $result -contains '--format=raw' | Should -Be $true
+        }
+    }
+
+    Context 'Pretty/Format TabCompletion Tests - With Custom Formats' {
+        BeforeEach {
+            [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
+            $repoPath = NewGitTempRepo
+
+            # Test with custom formats
+            &$gitbin config pretty.birdseye "%C(auto)%h%d %s %C(bold blue)<%aN> %C(green)(%cr)%Creset"
+            &$gitbin config pretty.test2 "%h%d %s <%aN> (%cr)"
+        }
+        AfterEach {
+            RemoveGitTempRepo $repoPath
+        }
+
+        It 'Tab completes default and custom formats for log --pretty' {
+            $result = & $module GitTabExpansionInternal 'git log --pretty='
+            $result -contains '--pretty=oneline' | Should -Be $true
+            $result -contains '--pretty=short' | Should -Be $true
+            $result -contains '--pretty=medium' | Should -Be $true
+            $result -contains '--pretty=full' | Should -Be $true
+            $result -contains '--pretty=fuller' | Should -Be $true
+            $result -contains '--pretty=email' | Should -Be $true
+            $result -contains '--pretty=raw' | Should -Be $true
+            $result -contains '--pretty=birdseye' | Should -Be $true
+            $result -contains '--pretty=test2' | Should -Be $true
+        }
+        It 'Tab completes default and custom formats for log --format' {
+            $result = & $module GitTabExpansionInternal 'git log --format='
+            $result -contains '--format=oneline' | Should -Be $true
+            $result -contains '--format=short' | Should -Be $true
+            $result -contains '--format=medium' | Should -Be $true
+            $result -contains '--format=full' | Should -Be $true
+            $result -contains '--format=fuller' | Should -Be $true
+            $result -contains '--format=email' | Should -Be $true
+            $result -contains '--format=raw' | Should -Be $true
+            $result -contains '--format=birdseye' | Should -Be $true
+            $result -contains '--format=test2' | Should -Be $true
+        }
+        It 'Tab completes default and custom formats for show --pretty' {
+            $result = & $module GitTabExpansionInternal 'git show --pretty='
+            $result -contains '--pretty=oneline' | Should -Be $true
+            $result -contains '--pretty=short' | Should -Be $true
+            $result -contains '--pretty=medium' | Should -Be $true
+            $result -contains '--pretty=full' | Should -Be $true
+            $result -contains '--pretty=fuller' | Should -Be $true
+            $result -contains '--pretty=email' | Should -Be $true
+            $result -contains '--pretty=raw' | Should -Be $true
+            $result -contains '--pretty=birdseye' | Should -Be $true
+            $result -contains '--pretty=test2' | Should -Be $true
+        }
+        It 'Tab completes default and custom formats for show --format' {
+            $result = & $module GitTabExpansionInternal 'git show --format='
+            $result -contains '--format=oneline' | Should -Be $true
+            $result -contains '--format=short' | Should -Be $true
+            $result -contains '--format=medium' | Should -Be $true
+            $result -contains '--format=full' | Should -Be $true
+            $result -contains '--format=fuller' | Should -Be $true
+            $result -contains '--format=email' | Should -Be $true
+            $result -contains '--format=raw' | Should -Be $true
+            $result -contains '--format=birdseye' | Should -Be $true
+            $result -contains '--format=test2' | Should -Be $true
+        }
+    }
 }
 


### PR DESCRIPTION
Enumerates any `pretty.*` keys in the user's Git config and includes
them alongside built-in options like `oneline`, `short`, `full`, etc.
for the `--pretty=` and `--format=` parameters of `git log` and
`git show`.

The key enumeration is done generically via function `gitConfigKeys`,
which in theory could be used for enumerating other config values with a
similar structure.

Fixes #786.