### PR TITLE
Avoid try/catch for 'DarkYellow'

### DIFF
--- a/src/AnsiUtils.ps1
+++ b/src/AnsiUtils.ps1
@@ -64,6 +64,11 @@ function Get-VirtualTerminalSequence ($color, [int]$offset = 0) {
         return "${AnsiEscape}$(38 + $offset);2;${r};${g};${b}m"
     }
 
+    # Force 'DarkYellow' to ConsoleColor, since it is not an HTML color
+    if ($color -eq [System.ConsoleColor]::DarkYellow) {
+        $color = [System.ConsoleColor]::DarkYellow
+    }
+
     if ($color -is [String]) {
         try {
             if ($ColorTranslatorType) {
@@ -72,11 +77,6 @@ function Get-VirtualTerminalSequence ($color, [int]$offset = 0) {
         }
         catch {
             Write-Debug $_
-        }
-
-        # Hard to get here but DarkYellow is not an HTML color but it is a ConsoleColor
-        if (($color -isnot $ColorType) -and ($null -ne ($consoleColor = $color -as [System.ConsoleColor]))) {
-            $color = $consoleColor
         }
     }
 

--- a/src/AnsiUtils.ps1
+++ b/src/AnsiUtils.ps1
@@ -68,8 +68,7 @@ function Get-VirtualTerminalSequence ($color, [int]$offset = 0) {
     if ($color -eq [System.ConsoleColor]::DarkYellow) {
         $color = [System.ConsoleColor]::DarkYellow
     }
-
-    if ($color -is [String]) {
+    elseif ($color -is [String]) {
         try {
             if ($ColorTranslatorType) {
                 $color = $ColorTranslatorType::FromHtml($color)


### PR DESCRIPTION
Error log in https://github.com/dahlbyk/posh-git/issues/771#issuecomment-716622281 pointed out using `'DarkYellow'` ends up polluting `$Errors` with:

```text
Exception calling "FromHtml" with "1" argument(s): "DarkYellow is not a valid value for Int32."
At C:\Dev\OSS\posh-git\src\AnsiUtils.ps1:70 char:17
+                 $color = $ColorTranslatorType::FromHtml($color)
```

Since `DarkYellow` is the only `[ConsoleColor]` that's not also represented in HTML, a hard-coded exception seems appropriate.

cc #536