### PR TITLE
Add warning for non-G4W on Windows

### DIFF
--- a/src/CheckRequirements.ps1
+++ b/src/CheckRequirements.ps1
@@ -2,6 +2,7 @@ $global:GitMissing = $false
 
 $requiredVersion = [Version]'1.7.2'
 $script:GitVersion = $requiredVersion
+$script:GitCygwin = $false
 
 if (!(Get-Command git -TotalCount 1 -ErrorAction SilentlyContinue)) {
     Write-Warning "git command could not be found. Please create an alias or add it to your PATH."
@@ -9,8 +10,18 @@ if (!(Get-Command git -TotalCount 1 -ErrorAction SilentlyContinue)) {
     return
 }
 
-if ([string](git --version 2> $null) -match '(?<ver>\d+(?:\.\d+)+)') {
+if ([string](git --version 2> $null) -match '(?<ver>\d+(?:\.\d+)+)(?<g4w>\.windows)?') {
     $script:GitVersion = [System.Version]$Matches['ver']
+
+    if (($PSVersionTable.PSVersion.Major -le 5) -or $IsWindows) {
+        if (!$Matches['g4w']) {
+            $script:GitCygwin = $true
+
+            if (!$Env:POSHGIT_CYGWIN_WARNING) {
+                Write-Warning "posh-git recommends Git for Windows. You appear to have a different distribution."
+            }
+        }
+    }
 }
 
 if ($GitVersion -lt $requiredVersion) {

--- a/src/CheckRequirements.ps1
+++ b/src/CheckRequirements.ps1
@@ -18,7 +18,7 @@ if ([string](git --version 2> $null) -match '(?<ver>\d+(?:\.\d+)+)(?<g4w>\.windo
             $script:GitCygwin = $true
 
             if (!$Env:POSHGIT_CYGWIN_WARNING) {
-                Write-Warning "posh-git recommends Git for Windows. You appear to have a different distribution."
+                Write-Warning 'You appear to have an unsupported Git distribution; setting $GitPromptSettings.AnsiConsole = $false. posh-git recommends Git for Windows.'
             }
         }
     }

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -223,7 +223,7 @@ class PoshGitTextSpan {
 }
 
 class PoshGitPromptSettings {
-    [bool]$AnsiConsole = $Host.UI.SupportsVirtualTerminal -or ($Env:ConEmuANSI -eq "ON")
+    [bool]$AnsiConsole = ($Host.UI.SupportsVirtualTerminal -or ($Env:ConEmuANSI -eq "ON")) -and !$script:GitCygwin
     [bool]$SetEnvColumns = $true
 
     [PoshGitCellColor]$DefaultColor = [PoshGitCellColor]::new()


### PR DESCRIPTION
#771 suggests we don't want folks using `git` from Cygwin. I think we can just check for `.windows` in `git --version`?

Set `$Env:POSHGIT_CYGWIN_WARNING = 'false'` to hide the warning.

![image](https://user-images.githubusercontent.com/133987/97383356-677a5500-189b-11eb-824e-07141c3fc2c1.png)
