### PR TITLE
Pass -PesterResults to Coveralls

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ test_script:
       $configuration.TestResult.OutputFormat = "NUnit2.5"
       $configuration.TestResult.OutputPath = $testResultsFile
       $configuration.CodeCoverage.Enabled = $true
-      $configuration.CodeCoverage.Path = (gci ..\src\* -include *.ps1,*.psm1)
+      $configuration.CodeCoverage.Path = (gci .\src\* -include *.ps1,*.psm1)
 
       $res = Invoke-Pester -Configuration $configuration -ErrorAction SilentlyContinue
       if (Test-Path $testResultsFile) {
@@ -58,5 +58,5 @@ test_script:
           Write-Host 'CA_KEY not set! (Expected on PR builds.)'
           return;
       }
-      $coverageResult = Format-Coverage -PesterResults $res -CoverallsApiToken $ENV:CA_KEY -RootFolder ../ -BranchName $ENV:APPVEYOR_REPO_BRANCH
+      $coverageResult = Format-Coverage -PesterResults $res -CoverallsApiToken $ENV:CA_KEY -BranchName $ENV:APPVEYOR_REPO_BRANCH
       Publish-Coverage -Coverage $coverageResult

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,8 @@ test_script:
       $configuration.TestResult.Enabled = $true
       $configuration.TestResult.OutputFormat = "NUnit2.5"
       $configuration.TestResult.OutputPath = $testResultsFile
+      $configuration.CodeCoverage.Enabled = $true
+      $configuration.CodeCoverage.Path = (gci ..\src\* -include *.ps1,*.psm1)
 
       $res = Invoke-Pester -Configuration $configuration -ErrorAction SilentlyContinue
       if (Test-Path $testResultsFile) {
@@ -56,5 +58,5 @@ test_script:
           Write-Host 'CA_KEY not set! (Expected on PR builds.)'
           return;
       }
-      $coverageResult = Format-Coverage -Include (gci ..\src\* -include *.ps1,*.psm1) -CoverallsApiToken $ENV:CA_KEY -RootFolder ../ -BranchName $ENV:APPVEYOR_REPO_BRANCH
+      $coverageResult = Format-Coverage -PesterResults $res -CoverallsApiToken $ENV:CA_KEY -RootFolder ../ -BranchName $ENV:APPVEYOR_REPO_BRANCH
       Publish-Coverage -Coverage $coverageResult


### PR DESCRIPTION
Hoping to fix #808 

[Coveralls calls `Invoke-Pester -CodeCoverage $Include -Quiet -PassThru`](https://github.com/JanDeDobbeleer/coveralls/blob/fb6a95a954431277375d5479d13645f9c1a0fad7/Coveralls.ps1#L158-L160), which maps to [`$Configuration.CodeCoverage` in Pester 5](https://github.com/pester/Pester/blob/f90f42614b574d96c095e5e3d4c6ae815702c561/src/Pester.ps1#L810-L819).