### PR TITLE
Add note about setting Git alias before importing module

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ Save the profile script, then close PowerShell and open a new PowerShell session
 Type `git fe` and then press <kbd>tab</kbd>. If posh-git has been imported, that command should tab complete to
 `git fetch`.
 
+If you want posh-git to detect your own aliases for git, then you *must* have set the alias *before* importing posh-git.
+So if you have `Set-Alias g git` then ensure it is executed before `Import-Module posh-git`, and `g checkout` will
+complete as if you'd typed `git`.
+
 ## Git status summary information
 
 The Git status summary information provides a wealth of "Git status" information at a glance, all the time in your


### PR DESCRIPTION
I expected this to work, and [indeed it does](https://github.com/dahlbyk/posh-git/blob/fa3b1f52404854dcab90e2730a24ad090a274931/src/GitTabExpansion.ps1#L543), but there's an ordering problem that is helpful to have called out.