### PR TITLE
Fix #854 - PowerShell aliases against app with .exe ext doesn't work

### DIFF
--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -302,6 +302,7 @@ function script:expandParamValues($cmd, $param, $filter) {
 }
 
 function Expand-GitCommand($Command) {
+    # Parse all Git output as UTF8, including tab completion output - https://github.com/dahlbyk/posh-git/pull/359
     $res = Invoke-Utf8ConsoleCommand { GitTabExpansionInternal $Command $Global:GitStatus }
     $res
 }
@@ -540,7 +541,7 @@ if (!$UseLegacyTabExpansion -and ($PSVersionTable.PSVersion.Major -ge 6)) {
     $cmdNames = "git","tgit","gitk"
 
     # Create regex pattern from $cmdNames: ^(git|git\.exe|tgit|tgit\.exe|gitk|gitk\.exe)$
-    $cmdNamesPattern = "^($(($cmdNames | ForEach-Object { "${_}|${_}\.exe" }) -join '|'))$"
+    $cmdNamesPattern = "^($($cmdNames -join '|'))(\.exe)?$"
     $cmdNames += Get-Alias | Where-Object { $_.Definition -match $cmdNamesPattern } | Foreach-Object Name
 
     if ($EnableProxyFunctionExpansion) {

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -442,7 +442,7 @@ function InDotGitOrBareRepoDir([string][ValidateNotNullOrEmpty()]$GitDir) {
 }
 
 function Get-AliasPattern($cmd) {
-    $aliases = @($cmd) + @(Get-Alias | Where-Object { $_.Definition -eq $cmd } | Select-Object -Exp Name)
+    $aliases = @($cmd) + @(Get-Alias | Where-Object { $_.Definition -match "^($cmd|$cmd\.exe)$" } | Foreach-Object Name)
    "($($aliases -join '|'))"
 }
 

--- a/src/GitUtils.ps1
+++ b/src/GitUtils.ps1
@@ -442,7 +442,7 @@ function InDotGitOrBareRepoDir([string][ValidateNotNullOrEmpty()]$GitDir) {
 }
 
 function Get-AliasPattern($cmd) {
-    $aliases = @($cmd) + @(Get-Alias | Where-Object { $_.Definition -match "^($cmd|$cmd\.exe)$" } | Foreach-Object Name)
+    $aliases = @($cmd) + @(Get-Alias | Where-Object { $_.Definition -match "^$cmd(\.exe)?$" } | Foreach-Object Name)
    "($($aliases -join '|'))"
 }
 

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -308,6 +308,10 @@ Describe 'TabExpansion Tests' {
             $result = & $module GitTabExpansionInternal "ge checkout ma"
             $result | Should -BeExactly 'master'
         }
+        It 'Get-AliasPattern finds the aliases for the given command' {
+            $result = & $module Get-AliasPattern git
+            $result | Should -BeExactly '(git|g|ge)'
+        }
     }
 
     Context 'PowerShell Special Chars Tests' {

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -232,7 +232,7 @@ Describe 'TabExpansion Tests' {
         }
     }
 
-    Context 'Alias TabExpansion Tests' {
+    Context 'Git Config Alias TabExpansion Tests' {
         BeforeAll {
             [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
             $repoPath = NewGitTempRepo -MakeInitialCommit
@@ -279,6 +279,33 @@ Describe 'TabExpansion Tests' {
             (&$gitbin config --get-all alias.co).Count | Should -BeGreaterThan 1
 
             $result = & $module GitTabExpansionInternal 'git co ma'
+            $result | Should -BeExactly 'master'
+        }
+    }
+
+    Context 'PowerShell Alias TabExpansion Tests' {
+        BeforeAll {
+            [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
+            $repoPath = NewGitTempRepo -MakeInitialCommit
+            New-Alias g  git     -Scope Global
+            New-Alias ge git.exe -Scope Global
+        }
+        AfterAll {
+            Remove-Alias g, ge
+            RemoveGitTempRepo $repoPath
+        }
+        It 'Tab completes PowerShell alias specifying git (with no extension)' {
+            $result = & $module GitTabExpansionInternal "g check"
+            $result | Should -BeExactly 'checkout'
+
+            $result = & $module GitTabExpansionInternal "g checkout ma"
+            $result | Should -BeExactly 'master'
+        }
+        It 'Tab completes PowerShell alias specifying git.exe' {
+            $result = & $module GitTabExpansionInternal "ge check"
+            $result | Should -BeExactly 'checkout'
+
+            $result = & $module GitTabExpansionInternal "ge checkout ma"
             $result | Should -BeExactly 'master'
         }
     }


### PR DESCRIPTION
Add RegisteredCommands field to GitTabSettings for debug purposes.