### PR TITLE
updated the 'Installing posh-git via Scoop' instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Another popular package manager for Windows is [Scoop](https://scoop.sh/), which
  it into your profile:
 
 ```powershell
+scoop bucket add extras
 scoop install posh-git
 Add-PoshGitToProfile
 ```


### PR DESCRIPTION
# Problem

After freshly installing scoop, you can't following the post-git instructions to install post-git via scoop without adding the scoop `extras` bucket. 

```
~ cody > scoop install posh-git                                                                               
Couldn't find manifest for 'posh-git'.
```

# Solution

Update the readme to include the `scoop bucket add extras` command. @cortexcompiler mentioned this as a comment here: https://github.com/dahlbyk/posh-git/pull/763#discussion_r603735339

```
~ cody > scoop bucket add extras
Checking repo... ok
The extras bucket was added successfully.

~ cody > scoop install posh-git
Installing 'posh-git' (1.0.0) [64bit]
Downloading https://github.com/dahlbyk/posh-git/archive/v1.0.0.zip (-1 B)...

Checking hash of v1.0.0.zip ... ok.
Extracting v1.0.0.zip ... done.
Linking ~\scoop\apps\posh-git\current => ~\scoop\apps\posh-git\1.0.0
Adding ~\scoop\modules to your PowerShell module path.
Installing PowerShell module 'posh-git'
Linking ~\scoop\modules\posh-git => ~\scoop\apps\posh-git\current
'posh-git' (1.0.0) was installed successfully!
Notes
-----
See usage: https://github.com/dahlbyk/posh-git#using-posh-git
```
