### PR TITLE
Use `--list` for `branch` and `tag` tab expansion

### DIFF
--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -136,8 +136,8 @@ function script:gitBranches($filter, $includeHEAD = $false, $prefix = '') {
         $filter = $matches['to']
     }
 
-    $branches = @(git branch --no-color | ForEach-Object { if (($_ -notmatch "^\* \(HEAD detached .+\)$") -and ($_ -match "^[\*\+]?\s*(?<ref>\S+)(?: -> .+)?")) { $matches['ref'] } }) +
-                @(git branch --no-color -r | ForEach-Object { if ($_ -match "^  (?<ref>\S+)(?: -> .+)?") { $matches['ref'] } }) +
+    $branches = @(git branch --no-color --list "$filter*" | ForEach-Object { if (($_ -notmatch "^\* \(HEAD detached .+\)$") -and ($_ -match "^[\*\+]?\s*(?<ref>.*)")) { $matches['ref'] } }) +
+                @(git branch --no-color --remotes --list "$filter*" | ForEach-Object { if ($_ -match "^  (?<ref>\S+)(?: -> .+)?") { $matches['ref'] } }) +
                 @(if ($includeHEAD) { 'HEAD','FETCH_HEAD','ORIG_HEAD','MERGE_HEAD' })
 
     $branches |
@@ -147,7 +147,7 @@ function script:gitBranches($filter, $includeHEAD = $false, $prefix = '') {
 }
 
 function script:gitRemoteUniqueBranches($filter) {
-    git branch --no-color -r |
+    git branch --no-color --remotes --list "$filter*" |
         ForEach-Object { if ($_ -match "^  (?<remote>[^/]+)/(?<branch>\S+)(?! -> .+)?$") { $matches['branch'] } } |
         Group-Object -NoElement |
         Where-Object { $_.Count -eq 1 } |
@@ -169,7 +169,7 @@ function script:gitConfigKeys($section, $filter, $defaultOptions = '') {
 }
 
 function script:gitTags($filter, $prefix = '') {
-    git tag |
+    git tag --list "$filter*" |
         Where-Object { $_ -like "$filter*" } |
         ForEach-Object { $prefix + $_ } |
         quoteStringWithSpecialChars
@@ -177,7 +177,7 @@ function script:gitTags($filter, $prefix = '') {
 
 function script:gitFeatures($filter, $command) {
     $featurePrefix = git config --local --get "gitflow.prefix.$command"
-    $branches = @(git branch --no-color | ForEach-Object { if ($_ -match "^\*?\s*$featurePrefix(?<ref>.*)") { $matches['ref'] } })
+    $branches = @(git branch --no-color --list "$filter*" | ForEach-Object { if ($_ -match "^\*?\s*$featurePrefix(?<ref>.*)") { $matches['ref'] } })
     $branches |
         Where-Object { $_ -ne '(no branch)' -and $_ -like "$filter*" } |
         ForEach-Object { $featurePrefix + $_ } |
@@ -185,7 +185,7 @@ function script:gitFeatures($filter, $command) {
 }
 
 function script:gitRemoteBranches($remote, $ref, $filter, $prefix = '') {
-    git branch --no-color -r |
+    git branch --no-color --remotes --list "$remote/$filter*" |
         Where-Object { $_ -like "  $remote/$filter*" } |
         ForEach-Object { $prefix + $ref + ($_ -replace "  $remote/","") } |
         quoteStringWithSpecialChars

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -136,7 +136,7 @@ function script:gitBranches($filter, $includeHEAD = $false, $prefix = '') {
         $filter = $matches['to']
     }
 
-    $branches = @(git branch --no-color --list "$filter*" | ForEach-Object { if (($_ -notmatch "^\* \(HEAD detached .+\)$") -and ($_ -match "^[\*\+]?\s*(?<ref>.*)")) { $matches['ref'] } }) +
+    $branches = @(git branch --no-color --list "$filter*" | ForEach-Object { if (($_ -notmatch "^\* \(HEAD detached .+\)$") -and ($_ -match "^[\*\+]?\s*(?<ref>\S+)(?! -> .+)?")) { $matches['ref'] } }) +
                 @(git branch --no-color --remotes --list "$filter*" | ForEach-Object { if ($_ -match "^  (?<ref>\S+)(?: -> .+)?") { $matches['ref'] } }) +
                 @(if ($includeHEAD) { 'HEAD','FETCH_HEAD','ORIG_HEAD','MERGE_HEAD' })
 

--- a/test/GitParamTabExpansion.Tests.ps1
+++ b/test/GitParamTabExpansion.Tests.ps1
@@ -6,85 +6,85 @@ Describe 'ParamsTabExpansion Tests' {
     Context 'Push Parameters TabExpansion Tests' {
         It 'Tab completes all long push parameters' {
             $result = & $module GitTabExpansionInternal 'git push --'
-            $result -contains '--all' | Should -Be $true
-            $result -contains '--delete' | Should -Be $true
-            $result -contains '--dry-run' | Should -Be $true
-            $result -contains '--exec=' | Should -Be $true
-            $result -contains '--follow-tags' | Should -Be $true
-            $result -contains '--force' | Should -Be $true
-            $result -contains '--force-with-lease' | Should -Be $true
-            $result -contains '--mirror' | Should -Be $true
-            $result -contains '--no-force-with-lease' | Should -Be $true
-            $result -contains '--no-thin' | Should -Be $true
-            $result -contains '--no-verify' | Should -Be $true
-            $result -contains '--porcelain' | Should -Be $true
-            $result -contains '--progress' | Should -Be $true
-            $result -contains '--prune' | Should -Be $true
-            $result -contains '--quiet' | Should -Be $true
-            $result -contains '--receive-pack=' | Should -Be $true
-            $result -contains '--recurse-submodules=' | Should -Be $true
-            $result -contains '--repo=' | Should -Be $true
-            $result -contains '--set-upstream' | Should -Be $true
-            $result -contains '--tags' | Should -Be $true
-            $result -contains '--thin' | Should -Be $true
-            $result -contains '--verbose' | Should -Be $true
-            $result -contains '--verify' | Should -Be $true
+            $result | Should -Contain '--all'
+            $result | Should -Contain '--delete'
+            $result | Should -Contain '--dry-run'
+            $result | Should -Contain '--exec='
+            $result | Should -Contain '--follow-tags'
+            $result | Should -Contain '--force'
+            $result | Should -Contain '--force-with-lease'
+            $result | Should -Contain '--mirror'
+            $result | Should -Contain '--no-force-with-lease'
+            $result | Should -Contain '--no-thin'
+            $result | Should -Contain '--no-verify'
+            $result | Should -Contain '--porcelain'
+            $result | Should -Contain '--progress'
+            $result | Should -Contain '--prune'
+            $result | Should -Contain '--quiet'
+            $result | Should -Contain '--receive-pack='
+            $result | Should -Contain '--recurse-submodules='
+            $result | Should -Contain '--repo='
+            $result | Should -Contain '--set-upstream'
+            $result | Should -Contain '--tags'
+            $result | Should -Contain '--thin'
+            $result | Should -Contain '--verbose'
+            $result | Should -Contain '--verify'
         }
         It 'Tab completes all short push parameters' {
             $result = & $module GitTabExpansionInternal 'git push -'
-            $result -contains '-f' | Should -Be $true
-            $result -contains '-n' | Should -Be $true
-            $result -contains '-q' | Should -Be $true
-            $result -contains '-u' | Should -Be $true
-            $result -contains '-v' | Should -Be $true
+            $result | Should -Contain '-f'
+            $result | Should -Contain '-n'
+            $result | Should -Contain '-q'
+            $result | Should -Contain '-u'
+            $result | Should -Contain '-v'
         }
         It 'Tab completes push parameters values' {
             $result = & $module GitTabExpansionInternal 'git push --recurse-submodules='
-            $result -contains '--recurse-submodules=check' | Should -Be $true
-            $result -contains '--recurse-submodules=on-demand' | Should -Be $true
+            $result | Should -Contain '--recurse-submodules=check'
+            $result | Should -Contain '--recurse-submodules=on-demand'
         }
     }
 
     Context 'Pretty/Format TabCompletion Tests - No Custom Formats' {
         It 'Tab completes default formats for log --pretty' {
             $result = & $module GitTabExpansionInternal 'git log --pretty='
-            $result -contains '--pretty=oneline' | Should -Be $true
-            $result -contains '--pretty=short' | Should -Be $true
-            $result -contains '--pretty=medium' | Should -Be $true
-            $result -contains '--pretty=full' | Should -Be $true
-            $result -contains '--pretty=fuller' | Should -Be $true
-            $result -contains '--pretty=email' | Should -Be $true
-            $result -contains '--pretty=raw' | Should -Be $true
+            $result | Should -Contain '--pretty=oneline'
+            $result | Should -Contain '--pretty=short'
+            $result | Should -Contain '--pretty=medium'
+            $result | Should -Contain '--pretty=full'
+            $result | Should -Contain '--pretty=fuller'
+            $result | Should -Contain '--pretty=email'
+            $result | Should -Contain '--pretty=raw'
         }
         It 'Tab completes default formats for log --format' {
             $result = & $module GitTabExpansionInternal 'git log --format='
-            $result -contains '--format=oneline' | Should -Be $true
-            $result -contains '--format=short' | Should -Be $true
-            $result -contains '--format=medium' | Should -Be $true
-            $result -contains '--format=full' | Should -Be $true
-            $result -contains '--format=fuller' | Should -Be $true
-            $result -contains '--format=email' | Should -Be $true
-            $result -contains '--format=raw' | Should -Be $true
+            $result | Should -Contain '--format=oneline'
+            $result | Should -Contain '--format=short'
+            $result | Should -Contain '--format=medium'
+            $result | Should -Contain '--format=full'
+            $result | Should -Contain '--format=fuller'
+            $result | Should -Contain '--format=email'
+            $result | Should -Contain '--format=raw'
         }
         It 'Tab completes default formats for show --pretty' {
             $result = & $module GitTabExpansionInternal 'git show --pretty='
-            $result -contains '--pretty=oneline' | Should -Be $true
-            $result -contains '--pretty=short' | Should -Be $true
-            $result -contains '--pretty=medium' | Should -Be $true
-            $result -contains '--pretty=full' | Should -Be $true
-            $result -contains '--pretty=fuller' | Should -Be $true
-            $result -contains '--pretty=email' | Should -Be $true
-            $result -contains '--pretty=raw' | Should -Be $true
+            $result | Should -Contain '--pretty=oneline'
+            $result | Should -Contain '--pretty=short'
+            $result | Should -Contain '--pretty=medium'
+            $result | Should -Contain '--pretty=full'
+            $result | Should -Contain '--pretty=fuller'
+            $result | Should -Contain '--pretty=email'
+            $result | Should -Contain '--pretty=raw'
         }
         It 'Tab completes default formats for show --format' {
             $result = & $module GitTabExpansionInternal 'git show --format='
-            $result -contains '--format=oneline' | Should -Be $true
-            $result -contains '--format=short' | Should -Be $true
-            $result -contains '--format=medium' | Should -Be $true
-            $result -contains '--format=full' | Should -Be $true
-            $result -contains '--format=fuller' | Should -Be $true
-            $result -contains '--format=email' | Should -Be $true
-            $result -contains '--format=raw' | Should -Be $true
+            $result | Should -Contain '--format=oneline'
+            $result | Should -Contain '--format=short'
+            $result | Should -Contain '--format=medium'
+            $result | Should -Contain '--format=full'
+            $result | Should -Contain '--format=fuller'
+            $result | Should -Contain '--format=email'
+            $result | Should -Contain '--format=raw'
         }
     }
 
@@ -103,51 +103,51 @@ Describe 'ParamsTabExpansion Tests' {
 
         It 'Tab completes default and custom formats for log --pretty' {
             $result = & $module GitTabExpansionInternal 'git log --pretty='
-            $result -contains '--pretty=oneline' | Should -Be $true
-            $result -contains '--pretty=short' | Should -Be $true
-            $result -contains '--pretty=medium' | Should -Be $true
-            $result -contains '--pretty=full' | Should -Be $true
-            $result -contains '--pretty=fuller' | Should -Be $true
-            $result -contains '--pretty=email' | Should -Be $true
-            $result -contains '--pretty=raw' | Should -Be $true
-            $result -contains '--pretty=birdseye' | Should -Be $true
-            $result -contains '--pretty=test2' | Should -Be $true
+            $result | Should -Contain '--pretty=oneline'
+            $result | Should -Contain '--pretty=short'
+            $result | Should -Contain '--pretty=medium'
+            $result | Should -Contain '--pretty=full'
+            $result | Should -Contain '--pretty=fuller'
+            $result | Should -Contain '--pretty=email'
+            $result | Should -Contain '--pretty=raw'
+            $result | Should -Contain '--pretty=birdseye'
+            $result | Should -Contain '--pretty=test2'
         }
         It 'Tab completes default and custom formats for log --format' {
             $result = & $module GitTabExpansionInternal 'git log --format='
-            $result -contains '--format=oneline' | Should -Be $true
-            $result -contains '--format=short' | Should -Be $true
-            $result -contains '--format=medium' | Should -Be $true
-            $result -contains '--format=full' | Should -Be $true
-            $result -contains '--format=fuller' | Should -Be $true
-            $result -contains '--format=email' | Should -Be $true
-            $result -contains '--format=raw' | Should -Be $true
-            $result -contains '--format=birdseye' | Should -Be $true
-            $result -contains '--format=test2' | Should -Be $true
+            $result | Should -Contain '--format=oneline'
+            $result | Should -Contain '--format=short'
+            $result | Should -Contain '--format=medium'
+            $result | Should -Contain '--format=full'
+            $result | Should -Contain '--format=fuller'
+            $result | Should -Contain '--format=email'
+            $result | Should -Contain '--format=raw'
+            $result | Should -Contain '--format=birdseye'
+            $result | Should -Contain '--format=test2'
         }
         It 'Tab completes default and custom formats for show --pretty' {
             $result = & $module GitTabExpansionInternal 'git show --pretty='
-            $result -contains '--pretty=oneline' | Should -Be $true
-            $result -contains '--pretty=short' | Should -Be $true
-            $result -contains '--pretty=medium' | Should -Be $true
-            $result -contains '--pretty=full' | Should -Be $true
-            $result -contains '--pretty=fuller' | Should -Be $true
-            $result -contains '--pretty=email' | Should -Be $true
-            $result -contains '--pretty=raw' | Should -Be $true
-            $result -contains '--pretty=birdseye' | Should -Be $true
-            $result -contains '--pretty=test2' | Should -Be $true
+            $result | Should -Contain '--pretty=oneline'
+            $result | Should -Contain '--pretty=short'
+            $result | Should -Contain '--pretty=medium'
+            $result | Should -Contain '--pretty=full'
+            $result | Should -Contain '--pretty=fuller'
+            $result | Should -Contain '--pretty=email'
+            $result | Should -Contain '--pretty=raw'
+            $result | Should -Contain '--pretty=birdseye'
+            $result | Should -Contain '--pretty=test2'
         }
         It 'Tab completes default and custom formats for show --format' {
             $result = & $module GitTabExpansionInternal 'git show --format='
-            $result -contains '--format=oneline' | Should -Be $true
-            $result -contains '--format=short' | Should -Be $true
-            $result -contains '--format=medium' | Should -Be $true
-            $result -contains '--format=full' | Should -Be $true
-            $result -contains '--format=fuller' | Should -Be $true
-            $result -contains '--format=email' | Should -Be $true
-            $result -contains '--format=raw' | Should -Be $true
-            $result -contains '--format=birdseye' | Should -Be $true
-            $result -contains '--format=test2' | Should -Be $true
+            $result | Should -Contain '--format=oneline'
+            $result | Should -Contain '--format=short'
+            $result | Should -Contain '--format=medium'
+            $result | Should -Contain '--format=full'
+            $result | Should -Contain '--format=fuller'
+            $result | Should -Contain '--format=email'
+            $result | Should -Contain '--format=raw'
+            $result | Should -Contain '--format=birdseye'
+            $result | Should -Contain '--format=test2'
         }
     }
 }

--- a/test/GitParamTabExpansionVsts.Tests.ps1
+++ b/test/GitParamTabExpansionVsts.Tests.ps1
@@ -28,32 +28,32 @@ Describe 'ParamsTabExpansion VSTS Tests' {
 
         It 'Tab completes git pr create parameters values' {
             $result = & $module GitTabExpansionInternal 'git test-vsts-pr create --'
-            $result -contains '--auto-complete' | Should -Be $true
+            $result | Should -Contain '--auto-complete'
         }
         It 'Tab completes git pr create auto-complete parameters values' {
             $result = & $module GitTabExpansionInternal 'git test-vsts-pr create --auto-complete --'
-            $result -contains '--delete-source-branch' | Should -Be $true
+            $result | Should -Contain '--delete-source-branch'
         }
 
         It 'Tab completes git pr show all parameters values' {
             $result = & $module GitTabExpansionInternal 'git test-vsts-pr show --'
-            $result -contains '--' | Should -Be $false
-            $result -contains '--debug' | Should -Be $true
-            $result -contains '--help' | Should -Be $true
-            $result -contains '--output' | Should -Be $true
-            $result -contains '--query' | Should -Be $true
-            $result -contains '--verbose' | Should -Be $true
+            $result | Should -Not -Contain '--'
+            $result | Should -Contain '--debug'
+            $result | Should -Contain '--help'
+            $result | Should -Contain '--output'
+            $result | Should -Contain '--query'
+            $result | Should -Contain '--verbose'
         }
 
         It 'Tab completes git pr create all short push parameters' {
             $result = & $module GitTabExpansionInternal 'git test-vsts-pr create -'
-            $result -contains '-d' | Should -Be $true
-            $result -contains '-i' | Should -Be $true
-            $result -contains '-p' | Should -Be $true
-            $result -contains '-r' | Should -Be $true
-            $result -contains '-s' | Should -Be $true
-            $result -contains '-h' | Should -Be $true
-            $result -contains '-o' | Should -Be $true
+            $result | Should -Contain '-d'
+            $result | Should -Contain '-i'
+            $result | Should -Contain '-p'
+            $result | Should -Contain '-r'
+            $result | Should -Contain '-s'
+            $result | Should -Contain '-h'
+            $result | Should -Contain '-o'
         }
     }
 }

--- a/test/GitProxyFunctionExpansion.Tests.ps1
+++ b/test/GitProxyFunctionExpansion.Tests.ps1
@@ -331,33 +331,33 @@ Describe 'Proxy Function Expansion Tests' {
             $functionText = & $module Expand-GitProxyFunction 'Invoke-GitFunction '
             $result = & $module GitTabExpansionInternal $functionText
 
-            $result -contains '' | Should -Be $false
-            $result -contains 'start' | Should -Be $true
-            $result -contains 'run' | Should -Be $true
+            $result | Should -Not -Contain ''
+            $result | Should -Contain 'start'
+            $result | Should -Contain 'run'
 
             $functionText = & $module Expand-GitProxyFunction 'Invoke-GitFunction s'
             $result2 = & $module GitTabExpansionInternal $functionText
 
-            $result2 -contains 'start' | Should -Be $true
-            $result2 -contains 'skip' | Should -Be $true
+            $result2 | Should -Contain 'start'
+            $result2 | Should -Contain 'skip'
         }
         It 'Tab completes remote subcommands' {
             function global:Invoke-GitFunction { git remote $args }
             $functionText = & $module Expand-GitProxyFunction 'Invoke-GitFunction '
             $result = & $module GitTabExpansionInternal $functionText
 
-            $result -contains '' | Should -Be $false
-            $result -contains 'add' | Should -Be $true
-            $result -contains 'set-branches' | Should -Be $true
-            $result -contains 'get-url' | Should -Be $true
-            $result -contains 'update' | Should -Be $true
+            $result | Should -Not -Contain ''
+            $result | Should -Contain 'add'
+            $result | Should -Contain 'set-branches'
+            $result | Should -Contain 'get-url'
+            $result | Should -Contain 'update'
 
             $functionText = & $module Expand-GitProxyFunction 'Invoke-GitFunction s'
             $result2 = & $module GitTabExpansionInternal $functionText
 
-            $result2 -contains 'set-branches' | Should -Be $true
-            $result2 -contains 'set-head' | Should -Be $true
-            $result2 -contains 'set-url' | Should -Be $true
+            $result2 | Should -Contain 'set-branches'
+            $result2 | Should -Contain 'set-head'
+            $result2 | Should -Contain 'set-url'
         }
     }
 }

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -4,7 +4,7 @@ BeforeAll {
 
 Describe 'TabExpansion function test' -Skip:($PSVersionTable.PSVersion.Major -gt 5) {
     It 'Windows PowerShell v5 exports a TabExpansion function' {
-        $module.ExportedFunctions.Keys -contains 'TabExpansion' | Should -Be $true
+        $module.ExportedFunctions.Keys | Should -Contain 'TabExpansion'
     }
 }
 
@@ -18,36 +18,36 @@ Describe 'TabExpansion Tests' {
         It 'Tab completes bisect subcommands' {
             $result = & $module GitTabExpansionInternal 'git bisect '
 
-            $result -contains '' | Should -Be $false
-            $result -contains 'start' | Should -Be $true
-            $result -contains 'run' | Should -Be $true
+            $result | Should -Not -Contain ''
+            $result | Should -Contain 'start'
+            $result | Should -Contain 'run'
 
             $result2 = & $module GitTabExpansionInternal 'git bisect s'
 
-            $result2 -contains 'start' | Should -Be $true
-            $result2 -contains 'skip' | Should -Be $true
+            $result2 | Should -Contain 'start'
+            $result2 | Should -Contain 'skip'
         }
         It 'Tab completes remote subcommands' {
             $result = & $module GitTabExpansionInternal 'git remote '
 
-            $result -contains '' | Should -Be $false
-            $result -contains 'add' | Should -Be $true
-            $result -contains 'set-branches' | Should -Be $true
-            $result -contains 'get-url' | Should -Be $true
-            $result -contains 'update' | Should -Be $true
+            $result | Should -Not -Contain ''
+            $result | Should -Contain 'add'
+            $result | Should -Contain 'set-branches'
+            $result | Should -Contain 'get-url'
+            $result | Should -Contain 'update'
 
             $result2 = & $module GitTabExpansionInternal 'git remote s'
 
-            $result2 -contains 'set-branches' | Should -Be $true
-            $result2 -contains 'set-head' | Should -Be $true
-            $result2 -contains 'set-url' | Should -Be $true
+            $result2 | Should -Contain 'set-branches'
+            $result2 | Should -Contain 'set-head'
+            $result2 | Should -Contain 'set-url'
         }
         It 'Tab completes update-git-for-windows only on Windows' {
             $result = & $module GitTabExpansionInternal 'git update-'
 
             if ((($PSVersionTable.PSVersion.Major -eq 5) -or $IsWindows)) {
-                $result -contains '' | Should -Be $false
-                $result -contains 'update-git-for-windows' | Should -Be $true
+                $result | Should -Not -Contain ''
+                $result | Should -Contain 'update-git-for-windows'
             }
             else {
                 $result | Should -BeNullOrEmpty
@@ -66,20 +66,20 @@ Describe 'TabExpansion Tests' {
             &$gitbin symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master 2>$null
         }
         It 'Tab completes all remotes' {
-            (&$gitbin remote) -contains 'origin' | Should -Be $true
+            (&$gitbin remote) | Should -Contain 'origin'
 
             $result = & $module GitTabExpansionInternal 'git push '
-            $result -contains 'origin' | Should -Be $true
+            $result | Should -Contain 'origin'
         }
         It 'Tab completes all branches' {
             $result = & $module GitTabExpansionInternal 'git push origin '
-            $result -contains 'master' | Should -Be $true
-            $result -contains 'origin/master' | Should -Be $true
-            $result -contains 'origin/HEAD' | Should -Be $true
+            $result | Should -Contain 'master'
+            $result | Should -Contain 'origin/master'
+            $result | Should -Contain 'origin/HEAD'
         }
         It 'Tab completes all :branches' {
             $result = & $module GitTabExpansionInternal 'git push origin :'
-            $result -contains ':master' | Should -Be $true
+            $result | Should -Contain ':master'
         }
         It 'Tab completes matching remotes' {
             $result = & $module GitTabExpansionInternal 'git push or'
@@ -111,9 +111,9 @@ Describe 'TabExpansion Tests' {
         }
         It 'Tab completes all branches with preceding parameters' {
             $result = & $module GitTabExpansionInternal 'git push  --follow-tags  -u   origin '
-            $result -contains 'master' | Should -Be $true
-            $result -contains 'origin/master' | Should -Be $true
-            $result -contains 'origin/HEAD' | Should -Be $true
+            $result | Should -Contain 'master'
+            $result | Should -Contain 'origin/master'
+            $result | Should -Contain 'origin/HEAD'
         }
         It 'Tab completes matching branch with preceding parameters' {
             $result = & $module GitTabExpansionInternal 'git push  --follow-tags  -u   origin ma'
@@ -223,7 +223,7 @@ Describe 'TabExpansion Tests' {
         }
         It 'Tab completes pr options' {
             $result = & $module GitTabExpansionInternal 'git test-vsts-pr '
-            $result -contains 'abandon' | Should -Be $true
+            $result | Should -Contain 'abandon'
         }
     }
 

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -175,7 +175,7 @@ Describe 'TabExpansion Tests' {
                 $result | Should -BeExactly $branchName
 
                 $result = & $module GitTabExpansionInternal 'git push  --follow-tags  -u   origin '
-                $result -contains $branchName | Should -Be $true
+                $result | Should -Contain $branchName
             }
             finally {
                 &$gitbin branch -D $branchName


### PR DESCRIPTION
To improve performance of those tab expansions, which are currently sub-optimal in git repos with a lot of branches.

* for `branch`, `--list` has been available since 1.7.8
  * https://github.com/git/git/blob/ecbdaf0899161c067986e9d9d564586d4b045d62/Documentation/RelNotes/1.7.8.txt#L25
* for `tag`, `--list` has been available since 1.7.10
  * https://github.com/git/git/blob/142430338477d9d1bb25be66267225fb58498d92/Documentation/RelNotes/1.7.10.txt#L128

This is a major performance improvement I've been using locally. Seeing that posh-git has moved to require git v2 or higher, this feature will be in all git versions using posh-git and I thought to share it.

Often times in monolithic repositories at work I used to wait for multiple seconds for branch and tag name completion to succeed, this offloads most of the work to the git engine.