### PR TITLE
Fix tests: Modifying git init initial branch to always be master.

### DIFF
--- a/test/Shared.ps1
+++ b/test/Shared.ps1
@@ -126,7 +126,12 @@ function NewGitTempRepo([switch]$MakeInitialCommit) {
     Push-Location
     $temp = [System.IO.Path]::GetTempPath()
     $repoPath = Join-Path $temp ([IO.Path]::GetRandomFileName())
-    &$gitbin init $repoPath *>$null
+    $initArgs = @()
+    if (&$gitbin config init.defaultBranch) {
+        $initArgs += '--initial-branch', 'master'
+    }
+
+    &$gitbin init $initArgs $repoPath *>$null
     Set-Location $repoPath
 
     if ($MakeInitialCommit) {


### PR DESCRIPTION
If `init.defaultBranch` is set (2.28.0 or later), then test setup explicitly initializes the repo with "master" as the default branch.
This argument will not be added to the command unless `init.defaultBranch` is set.

This ensures the tests always use "master" and so aren't affected by that setting.