### PR TITLE
refactor: exclude PSUseSingluarNouns

### DIFF
--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -17,7 +17,7 @@
     # Use ExcludeRules when you want to run most of the default set of rules except
     # for a few rules you wish to "exclude".  Note: if a rule is in both IncludeRules
     # and ExcludeRules, the rule will be excluded.
-    ExcludeRules = @('PSAvoidUsingWriteHost', 'PSAvoidGlobalVars', 'PSAvoidUsingInvokeExpression', 'PSReviewUnusedParameter')
+    ExcludeRules = @('PSUseSingularNouns', 'PSAvoidUsingWriteHost', 'PSAvoidGlobalVars', 'PSAvoidUsingInvokeExpression', 'PSReviewUnusedParameter')
 
     # You can use the following entry to supply parameters to rules that take parameters.
     # For instance, the PSAvoidUsingCmdletAliases rule takes a whitelist for aliases you


### PR DESCRIPTION
I became irritated by this rule showing up for functions like New-GitPromptSettings. Instead of refactoring all similar methods when the noun seems just fine or refactoring so that each function implements ShouldProcess, I think it best just to suppress the rule.