### PR TITLE
Add show remote name

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,16 @@ This will change the prompt to:
 
 ![~\GitHub\posh-git [main ≡]&#10;> ][prompt-two-line]
 
+If you prefer to show the remote repository name for the branch, use this setting:
+
+```text
+$GitPromptSettings.ShowRemoteName = $true
+```
+
+This will change the prompt to:
+
+![~\GitHub\posh-git [origin/master ≡]> ][prompt-show-remote-name]
+
 You can swap the order of the path and the Git status summary with the following setting:
 
 ```text
@@ -522,6 +532,7 @@ function prompt {
 [prompt-no-abbr]:  https://github.com/dahlbyk/posh-git/wiki/images/PromptNoAbbrevHome.png  "C:\Users\Keith\GitHub\posh-git [main ≡]> "
 [prompt-path]:     https://github.com/dahlbyk/posh-git/wiki/images/PromptOrangePath.png    "~\GitHub\posh-git [main ≡]> "
 [prompt-swap]:     https://github.com/dahlbyk/posh-git/wiki/images/PromptStatusFirst.png   "[main ≡] ~\GitHub\posh-git> "
+[prompt-show-remote-name]:    https://github.com/dahlbyk/posh-git/wiki/images/PromptShowRemoteName.png     "~\GitHub\posh-git> [origin/main ≡] "
 [prompt-two-line]: https://github.com/dahlbyk/posh-git/wiki/images/PromptTwoLine.png       "~\GitHub\posh-git [main ≡]&#10;> "
 [prompt-custom]:   https://github.com/dahlbyk/posh-git/wiki/images/PromptCustom.png        "[main ≡] ~\GitHub\posh-git&#10;02-18 14:04:35 38> "
 [prompt-custom-wpathdelim]:   https://github.com/dahlbyk/posh-git/wiki/images/PromptCustomDelim.png        "[main ≡] {~\GitHub\posh-git}&#10;02-18 14:04:35 38> "

--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -391,11 +391,10 @@ function Write-GitRemoteName {
 
     $str = ""
 
-    # Expecting same format as 'origin/master'. See regex here: https://regex101.com/library/TMX8aJ
-    if($Status.Upstream -match '(?<remotename>\w*)(?<seperator>\/)(?<branchname>\w*)') {
-
+    # Expecting similar format as 'origin/master' or 'origin/development/master'
+    if($Status.Upstream -match '(?<remotename>\w+)(?<seperator>\/).*' ) {
         $remoteNameTextSpan = [PoshGitTextSpan]::new($s.DefaultColor)
-        $remoteNameTextSpan.Text = $Matches.remotename + $Matches.seperator
+        $remoteNameTextSpan.Text = $Matches.remotename + '/'
 
         if ($StringBuilder) {
             $StringBuilder | Write-Prompt $remoteNameTextSpan > $null

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -266,6 +266,7 @@ class PoshGitPromptSettings {
 
     [bool]$EnableStashStatus     = $false
     [bool]$ShowStatusWhenZero    = $true
+    [bool]$ShowRemoteName        = $false
     [bool]$AutoRefreshIndex      = $true
 
     [UntrackedFilesMode]$UntrackedFilesMode = [UntrackedFilesMode]::Default

--- a/src/posh-git.psd1
+++ b/src/posh-git.psd1
@@ -39,6 +39,7 @@ FunctionsToExport = @(
     'Write-GitBranchName',
     'Write-GitBranchStatus',
     'Write-GitIndexStatus',
+    'Write-GitRemoteName',
     'Write-GitStashCount',
     'Write-GitWorkingDirStatus',
     'Write-GitWorkingDirStatusSummary',

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -177,6 +177,7 @@ $exportModuleMemberParams = @{
         'Write-GitBranchName',
         'Write-GitBranchStatus',
         'Write-GitIndexStatus',
+        'Write-GitRemoteName',
         'Write-GitStashCount',
         'Write-GitWorkingDirStatus',
         'Write-GitWorkingDirStatusSummary',

--- a/test/Get-GitStatus.Tests.ps1
+++ b/test/Get-GitStatus.Tests.ps1
@@ -36,8 +36,34 @@ Describe 'Get-GitStatus Tests' {
             $status.Index.Modified.Count | Should -Be 0
             $status.Index.Unmerged.Count | Should -Be 0
         }
+        It 'Returns the correct remote repository name' {
+            Mock -ModuleName posh-git git {
+                $OFS = " "
+                if ($args -contains 'rev-parse') {
+                    $res = Invoke-Expression "&$gitbin $args"
+                    return $res
+                }
+                Convert-NativeLineEnding @'
+## rkeithill/more-status-tests...origin/rkeithill/more-status-tests
+'@
+            }
 
-
+            $status = Get-GitStatus
+            Should -Invoke -ModuleName posh-git -CommandName git -Exactly 1
+            $status.Branch | Should -Be "rkeithill/more-status-tests"
+            $status.Upstream | Should -Be "origin/rkeithill/more-status-tests"
+            $status.HasIndex | Should -Be $false
+            $status.HasUntracked | Should -Be $false
+            $status.HasWorking | Should -Be $false
+            $status.Working.Added.Count | Should -Be 0
+            $status.Working.Deleted.Count | Should -Be 0
+            $status.Working.Modified.Count | Should -Be 0
+            $status.Working.Unmerged.Count | Should -Be 0
+            $status.Index.Added.Count | Should -Be 0
+            $status.Index.Deleted.Count | Should -Be 0
+            $status.Index.Modified.Count | Should -Be 0
+            $status.Index.Unmerged.Count | Should -Be 0
+        }
         It 'Returns the correct number of added untracked working files' {
             Mock -ModuleName posh-git git {
                 $OFS = " "


### PR DESCRIPTION
This PR resolves feature request #781.

The updated README.md needs to have the following image added with the name of 'PromptShowRemoteName.png' to GitHub:
![PromptShowRemoteName](https://user-images.githubusercontent.com/459665/174494362-931b9efc-1836-43b2-a411-123e647691e5.png)
 