### PR TITLE
Added an option to get a more concise git status

### DIFF
--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -570,7 +570,20 @@ function Write-GitIndexStatus {
                 $NoLeadingSpace = $false
             }
 
-            $indexStatusText += "$($s.FileAddedText)$($Status.Index.Added.Count)"
+            if ($settings.EnableFileConciseStatusFromCache) {
+                $added = $status.Index.Added
+                $modified = $status.Index.Modified
+                $deleted = $status.Index.Deleted
+                $unmerged = $status.Index.Unmerged
+            }
+            else {
+                $added = $status.Index.Added.Count
+                $modified = $status.Index.Modified.Count
+                $deleted = $status.Index.Deleted.Count
+                $unmerged = $status.Index.Unmerged.Count
+            }
+
+            $indexStatusText += "$($s.FileAddedText)$($added)"
 
             if ($StringBuilder) {
                 $StringBuilder | Write-Prompt $indexStatusText -Color $s.IndexColor > $null
@@ -587,7 +600,7 @@ function Write-GitIndexStatus {
                 $NoLeadingSpace = $false
             }
 
-            $indexStatusText += "$($s.FileModifiedText)$($status.Index.Modified.Count)"
+            $indexStatusText += "$($s.FileModifiedText)$($modified)"
 
             if ($StringBuilder) {
                 $StringBuilder | Write-Prompt $indexStatusText -Color $s.IndexColor > $null
@@ -604,7 +617,7 @@ function Write-GitIndexStatus {
                 $NoLeadingSpace = $false
             }
 
-            $indexStatusText += "$($s.FileRemovedText)$($Status.Index.Deleted.Count)"
+            $indexStatusText += "$($s.FileRemovedText)$($deleted)"
 
             if ($StringBuilder) {
                 $StringBuilder | Write-Prompt $indexStatusText -Color $s.IndexColor > $null
@@ -621,7 +634,7 @@ function Write-GitIndexStatus {
                 $NoLeadingSpace = $false
             }
 
-            $indexStatusText += "$($s.FileConflictedText)$($Status.Index.Unmerged.Count)"
+            $indexStatusText += "$($s.FileConflictedText)$($unmerged)"
 
             if ($StringBuilder) {
                 $StringBuilder | Write-Prompt $indexStatusText -Color $s.IndexColor > $null
@@ -685,7 +698,20 @@ function Write-GitWorkingDirStatus {
                 $NoLeadingSpace = $false
             }
 
-            $workingStatusText += "$($s.FileAddedText)$($Status.Working.Added.Count)"
+            if ($settings.EnableFileConciseStatusFromCache) {
+                $added = $status.Working.Added
+                $modified = $status.Working.Modified
+                $deleted = $status.Working.Deleted
+                $unmerged = $status.Working.Unmerged
+            }
+            else {
+                $added = $status.Working.Added.Count
+                $modified = $status.Working.Modified.Count
+                $deleted = $status.Working.Deleted.Count
+                $unmerged = $status.Working.Unmerged.Count
+            }
+
+            $workingStatusText += "$($s.FileAddedText)$($added)"
 
             if ($StringBuilder) {
                 $StringBuilder | Write-Prompt $workingStatusText -Color $s.WorkingColor > $null
@@ -702,7 +728,7 @@ function Write-GitWorkingDirStatus {
                 $NoLeadingSpace = $false
             }
 
-            $workingStatusText += "$($s.FileModifiedText)$($Status.Working.Modified.Count)"
+            $workingStatusText += "$($s.FileModifiedText)$($modified)"
 
             if ($StringBuilder) {
                 $StringBuilder | Write-Prompt $workingStatusText -Color $s.WorkingColor > $null
@@ -719,7 +745,7 @@ function Write-GitWorkingDirStatus {
                 $NoLeadingSpace = $false
             }
 
-            $workingStatusText += "$($s.FileRemovedText)$($Status.Working.Deleted.Count)"
+            $workingStatusText += "$($s.FileRemovedText)$($deleted)"
 
             if ($StringBuilder) {
                 $StringBuilder | Write-Prompt $workingStatusText -Color $s.WorkingColor > $null
@@ -736,7 +762,7 @@ function Write-GitWorkingDirStatus {
                 $NoLeadingSpace = $false
             }
 
-            $workingStatusText += "$($s.FileConflictedText)$($Status.Working.Unmerged.Count)"
+            $workingStatusText += "$($s.FileConflictedText)$($unmerged)"
 
             if ($StringBuilder) {
                 $StringBuilder | Write-Prompt $workingStatusText -Color $s.WorkingColor > $null

--- a/src/PoshGitTypes.ps1
+++ b/src/PoshGitTypes.ps1
@@ -274,6 +274,7 @@ class PoshGitPromptSettings {
     [bool]$EnableFileStatus      = $true
 
     [Nullable[bool]]$EnableFileStatusFromCache        = $null
+    [Nullable[bool]]$EnableFileConciseStatusFromCache = $null
     [string[]]$RepositoriesInWhichToDisableFileStatus = @()
 
     [string]$DescribeStyle = ''


### PR DESCRIPTION
Get-GitConciseStatusFromCache returns the number of files instead of the file path to avoid taking too long for IO under a large number of file changes.


![image](https://user-images.githubusercontent.com/31889177/188446312-4ba6322d-9e9f-40e7-b1ea-316e9ee00c2d.png)

[git-status-cache](https://github.com/cmarcusreid/git-status-cache-posh-client)'s pull request is still pending, maybe you can try my repository
see also:
https://github.com/cmarcusreid/git-status-cache/pull/29
https://github.com/cmarcusreid/git-status-cache-posh-client/pull/14