### PR TITLE
VS Code tasks improvments

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -41,6 +41,18 @@
             "problemMatcher": [
                 "$pester"
             ]
+        },
+        {
+            "label": "TestCurrentFile",
+            "type": "shell",
+            "command": "Clear-Host; Import-Module Pester -MinimumVersion 5.0.0; $c = [PesterConfiguration]::Default; $c.Run.Path = '${file}'; $c.Output.Verbosity = 'Detailed'; Invoke-Pester -Configuration $c",
+            "group": {
+                "kind": "test",
+                "isDefault": false
+            },
+            "problemMatcher": [
+                "$pester"
+            ]
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -33,7 +33,7 @@
         {
             "label": "Test",
             "type": "shell",
-            "command": "Import-Module Pester -MinimumVersion 5.0.0; $c = [PesterConfiguration]::Default; $c.Run.Path = 'test'; $c.Output.Verbosity = 'Detailed'; $c.Debug.WriteVSCodeMarker = $true; Invoke-Pester -Configuration $c",
+            "command": "Import-Module Pester -MinimumVersion 5.0.0; $c = [PesterConfiguration]::Default; $c.Run.Path = 'test'; $c.Output.Verbosity = 'Detailed'; Invoke-Pester -Configuration $c",
             "group": {
                 "kind": "test",
                 "isDefault": true


### PR DESCRIPTION
Fixed error with Pester tests launch.  
```
The property 'WriteVSCodeMarker' cannot be found on this object. Verify that the property exists and can be set.
```

Added new task for running tests only in current file. 