### PR TITLE
Fix for failing tests when GPG Signing is enabled globally

### DIFF
--- a/test/Shared.ps1
+++ b/test/Shared.ps1
@@ -137,6 +137,8 @@ function NewGitTempRepo([switch]$MakeInitialCommit) {
     if ($MakeInitialCommit) {
         &$gitbin config user.email "spaceman.spiff@appveyor.com"
         &$gitbin config user.name "Spaceman Spiff"
+        &$gitbin config commit.gpgSign "false"
+
         'readme' | Out-File ./README.md -Encoding ascii
         &$gitbin add ./README.md *>$null
         &$gitbin commit -m "initial commit." *>$null

--- a/test/TabExpansion.Tests.ps1
+++ b/test/TabExpansion.Tests.ps1
@@ -232,16 +232,16 @@ Describe 'TabExpansion Tests' {
             [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssigments', '')]
             $repoPath = NewGitTempRepo -MakeInitialCommit
 
-            $addedAliases = @()
+            $addedAliases = @{}
             function Add-GlobalTestAlias($Name, $Value) {
                 if (!(&$gitbin config --global "alias.$Name")) {
                     &$gitbin config --global "alias.$Name" $Value
-                    $addedAliases += $Name
+                    $addedAliases[$Name] = $Value
                 }
             }
         }
         AfterAll {
-            $addedAliases | Where-Object { $_ } | ForEach-Object {
+            $addedAliases.Keys | ForEach-Object {
                 &$gitbin config --global --unset "alias.$_" 2>$null
             }
 


### PR DESCRIPTION
Have a global `.gitconfig` with:
```
[commit]
    gpgSign = true
```

Which makes `Invoke-Pester` to fail tests with:
* One in `Get-GitDirectory.Tests.ps1`: `Returns the correct dir when under a worktree`
* Three of `Get-GitStatus.Tests.ps1` - all under: `Context Branch progress suffix`
* A few from `TabExpansion.Tests.ps1` - in contexts as:
  * `Git Config Alias TabExpansion Tests`
  * `PowerShell Alias TabExpansion Tests`
  * `PowerShell Special Chars Tests`

Those tests will fail, as they could not make commits. Moreover, some tests were being _"polluting"_ global configuration with some test aliases, which were not removed after theirs execution.

Thus, your `.gitconfig` file became something like:
```
[commit]
    gpgSign = true
[alias]
	test-944577f4-7f84-4473-931d-93b95d9a65fd = config
	co = checkout
```

This PR should fix that, and tests should not be broken due to GPG configuration, and no foreign aliases should stay.