### PR TITLE
GitPrompt.ps1: fix doc typo "VscPromptStatuses" -> "VcsPromptStatuses"

### DIFF
--- a/src/GitPrompt.ps1
+++ b/src/GitPrompt.ps1
@@ -886,15 +886,15 @@ if (!(Test-Path Variable:Global:VcsPromptStatuses)) {
 
 <#
 .SYNOPSIS
-    Writes all version control prompt statuses configured in $global:VscPromptStatuses.
+    Writes all version control prompt statuses configured in $global:VcsPromptStatuses.
 .DESCRIPTION
-    Writes all version control prompt statuses configured in $global:VscPromptStatuses.
+    Writes all version control prompt statuses configured in $global:VcsPromptStatuses.
     By default, this includes the PoshGit prompt status.
 .EXAMPLE
     PS C:\> Write-VcsStatus
 
     Writes all version control prompt statuses that have been configured
-    with the global variable $VscPromptStatuses
+    with the global variable $VcsPromptStatuses
 #>
 function Global:Write-VcsStatus {
     Set-ConsoleMode -ANSI


### PR DESCRIPTION
Fixes a typo in the documentation for "Write-VcsStatus", which mentions the wrong variable.