### PR TITLE
Enable custom completers for complex user aliases

### DIFF
--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -95,15 +95,6 @@ catch {
     Write-Debug "Search for 'flow' in 'git help' output failed with error: $_"
 }
 
-filter quoteStringWithSpecialChars {
-    if ($_ -and ($_ -match '\s+|#|@|\$|;|,|''|\{|\}|\(|\)')) {
-        $str = $_ -replace "'", "''"
-        "'$str'"
-    }
-    else {
-        $_
-    }
-}
 
 function script:gitCommands($filter, $includeAliases) {
     $cmdList = @()

--- a/src/GitTabExpansion.ps1
+++ b/src/GitTabExpansion.ps1
@@ -298,10 +298,12 @@ function Expand-GitCommand($Command) {
     $res
 }
 
-function GitTabExpansionInternal($lastBlock, $GitStatus = $null) {
+function GitTabExpansionInternal($Command, $GitStatus = $null) {
     $ignoreGitParams = '(?<params>\s+-(?:[aA-zZ0-9]+|-[aA-zZ0-9][aA-zZ0-9-]*)(?:=\S+)?)*'
 
-    if ($lastBlock -match "^$(Get-AliasPattern git) (?<cmd>\S+)(?<args> .*)$") {
+    $lastBlock = $Command
+    if ($Command -match "^$(Get-AliasPattern git) (?<cmd>\S+)(?<args> .*)$") {
+        $Command = $Matches['cmd'] + " " + $Matches['args']
         $lastBlock = expandGitAlias $Matches['cmd'] $Matches['args']
     }
 
@@ -489,6 +491,13 @@ function GitTabExpansionInternal($lastBlock, $GitStatus = $null) {
         "vsts\.pr\s+(?<cmd>$vstsCommandsWithShortParams).*-(?<shortparam>\S*)$"
         {
             expandShortParams $shortVstsParams $matches['cmd'] $matches['shortparam']
+        }
+
+        # Handles any other command
+        default {
+            $extraGitTabExpansions | ForEach-Object {
+                & $_ $Command
+            }
         }
     }
 }

--- a/src/Utils.ps1
+++ b/src/Utils.ps1
@@ -497,3 +497,13 @@ function dbg($Message, [Diagnostics.Stopwatch]$Stopwatch) {
         Write-Verbose ('{0:00000}:{1}' -f $Stopwatch.ElapsedMilliseconds,$Message) -Verbose # -ForegroundColor Yellow
     }
 }
+
+filter global:quoteStringWithSpecialChars {
+    if ($_ -and ($_ -match '\s+|#|@|\$|;|,|''|\{|\}|\(|\)')) {
+        $str = $_ -replace "'", "''"
+        "'$str'"
+    }
+    else {
+        $_
+    }
+}

--- a/src/posh-git.psm1
+++ b/src/posh-git.psm1
@@ -7,6 +7,19 @@ if (Test-Path Env:\POSHGIT_ENABLE_STRICTMODE) {
 
 . $PSScriptRoot\CheckRequirements.ps1 > $null
 
+# Load extra modules with user customized configuration
+$extraGitTabExpansions = @()
+Get-Module -ListAvailable posh-git-extras-* | ForEach-Object {
+    Import-Module -Force $_
+    $local:expandGitCommand = Get-Command -Module $_ -Name "GitTabCustomExpansion" -All
+    $local:params = $expandGitCommand.Parameters
+
+    if ($params.Count -eq 1 -and
+            $params["gitCommandBlock"].ParameterType -eq [string]) {
+        $extraGitTabExpansions += ($expandGitCommand)
+    }
+}
+
 . $PSScriptRoot\ConsoleMode.ps1
 . $PSScriptRoot\Utils.ps1
 . $PSScriptRoot\AnsiUtils.ps1


### PR DESCRIPTION
## Creating custom completers for complex aliases

`posh-git` will search the `$env:PSModulePath` for modules whose name match `posh-git-extras-*` and use any
function in the found modules that has the name `GitTabCustomExpansion` and expects a single parameter of type
`[string]`.

These functions receive the command as written on the console, stripped by the `git` binary command
and should return/write custom suggestions.

Here's how you can do it:

```
# Configure an alias:
> git config --global alias.wttr '!f() { curl https://wttr.in/$1; }; f'

# Find your PS-Module-Paths:
> $env:PSModulePath
C:\Users\me\Documents\WindowsPowerShell\Modules;C:\Program Files\WindowsPowerShell\Modules;C:\Windows\system32\WindowsPowerShell\v1.0\Modules
```

You probably want to select a folder in your user space. In the `Modules` folder, create another folder,
e.g. `posh-git-extras-aliases` and in that folder a file named `posh-git-extras-aliases.psm1`.

In this module file, you must declare and export the function `GitTabCustomExpansion`:

```
# C:\Users\me\Documents\WindowsPowerShell\Modules\posh-git-extras-aliases\posh-git-extras-aliases.psm1

function GitTabCustomExpansion()
{
    param(
        [string]$gitCommandBlock
    )

    switch -regex ($gitCommandBlock) {
        "^wttr\s+(?<loc>[\S]*)$" {
            @('London', 'Berlin', 'Amsterdam') |
            Where-Object { $_ -like "$($Matches['loc'])*" }
        }
    }
}

Export-ModuleMember -Function GitTabCustomExpansion
```